### PR TITLE
feat: support static file hosting for BioEngine app deployments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,184 @@
+# BioEngine Worker — CLAUDE.md
+
+## Project Overview
+
+BioEngine Worker is a **Kubernetes-based compute engine and AI application deployment platform** for life sciences. It enables users to manage and deploy AI models (e.g., image analysis, segmentation) and build full-stack applications on top of those models. The platform runs on [Ray](https://www.ray.io/) and [Ray Serve](https://docs.ray.io/en/latest/serve/index.html) for distributed inference and integrates with [Hypha](https://hypha.aicell.io/) for RPC service discovery, artifact management, and authentication.
+
+**Top-level goals:**
+- Deploy and serve AI models and applications at scale (single-machine, SLURM HPC, Kubernetes/external Ray clusters)
+- Provide a unified API for remote management of model deployments via Hypha RPC
+- Stream large scientific datasets with privacy-preserving access control
+- Support both compute backends (Ray Serve deployments) and static frontends (artifact-hosted web UIs)
+
+---
+
+## Architecture
+
+```
+┌────────────────────────────────────────┐
+│            Hypha Server                │
+│   (RPC, service discovery, artifacts)  │
+└────────────┬───────────────────────────┘
+             │ WebSocket / RPC
+┌────────────▼───────────────────────────┐
+│         BioEngineWorker                │  ← bioengine/worker/worker.py
+│  ┌─────────────────────────────────┐   │
+│  │  RayCluster                     │   │  ← bioengine/ray/ray_cluster.py
+│  │  (SLURM / single / external)    │   │
+│  └─────────────────────────────────┘   │
+│  ┌─────────────────────────────────┐   │
+│  │  AppsManager                    │   │  ← bioengine/applications/apps_manager.py
+│  │  (Ray Serve lifecycle +         │   │
+│  │   artifact management)          │   │
+│  └─────────────────────────────────┘   │
+│  ┌─────────────────────────────────┐   │
+│  │  BioEngineDatasets              │   │  ← bioengine/datasets/
+│  │  (Zarr HTTP streaming)          │   │
+│  └─────────────────────────────────┘   │
+└────────────────────────────────────────┘
+```
+
+### Key Components
+
+| Component | File | Responsibility |
+|-----------|------|----------------|
+| `BioEngineWorker` | `bioengine/worker/worker.py` | Main orchestrator; Hypha service registration |
+| `AppsManager` | `bioengine/applications/apps_manager.py` | Application lifecycle (deploy/stop/status) |
+| `AppBuilder` | `bioengine/applications/app_builder.py` | Build Ray Serve apps from artifacts |
+| `RayCluster` | `bioengine/ray/ray_cluster.py` | Ray cluster lifecycle (SLURM/local/external) |
+| `BioEngineDatasets` | `bioengine/datasets/datasets.py` | Zarr dataset streaming |
+| Artifact utilities | `bioengine/utils/artifact_utils.py` | Hypha artifact CRUD helpers |
+
+---
+
+## Application Manifest
+
+Every BioEngine application is described by a `manifest.yaml` file. This file is stored in the Hypha artifact manager alongside Python deployment code.
+
+### Required Fields
+
+```yaml
+name: My Application        # Human-readable name
+id: my-application          # Unique lowercase ID (hyphens only)
+id_emoji: "🔬"              # Visual emoji identifier
+description: "..."          # Short description
+type: ray-serve             # Must be "ray-serve"
+deployments:                # List of Python class entry points
+  - module_file:ClassName
+authorized_users:
+  - "*"                     # Or specific user IDs
+```
+
+### Optional Fields
+
+```yaml
+# Static frontend hosting
+static_hosting: true        # Enable Hypha artifact static site hosting
+frontend_entry: "frontend/index.html"  # Entry HTML file (relative to artifact root)
+
+# Metadata
+format_version: "0.5.0"
+version: "1.0.0"
+authors:
+  - {name: "...", affiliation: "...", github_user: "..."}
+license: MIT
+documentation: README.md
+tutorial: tutorial.ipynb
+tags: [bioengine, image-analysis]
+```
+
+When `static_hosting: true`, BioEngine enables Hypha's static site hosting on the artifact at deployment time. The `frontend_entry` determines the `website_root` directory served (e.g., `frontend/index.html` → `website_root: "frontend"`). The resulting URL is:
+```
+https://hypha.aicell.io/{workspace}/artifacts/{artifact-id}/
+```
+
+---
+
+## Deployment Modes
+
+| Mode | Description |
+|------|-------------|
+| `single-machine` | Local Ray cluster (dev, small-scale) |
+| `external-cluster` | Connect to existing Ray cluster (Kubernetes) |
+| `slurm` | Auto-scaling via SLURM job scheduler (HPC) |
+
+---
+
+## Worker Service API
+
+The BioEngine worker registers as a Hypha service. Key methods:
+
+| Method | Admin | Description |
+|--------|:-----:|-------------|
+| `get_status` | | Overall worker status |
+| `check_access` | | Check caller permissions |
+| `list_applications` | ✓ | List deployed applications |
+| `run_application` | ✓ | Deploy an application from artifact |
+| `stop_application` | ✓ | Stop a running application |
+| `get_application_status` | | Status of specific application |
+| `save_application` | ✓ | Create/update application artifact |
+| `get_application_manifest` | ✓ | Get manifest for an application |
+| `delete_application` | ✓ | Delete an application artifact |
+| `execute_python_code` | ✓ | Run Python code in Ray task |
+| `list_datasets` | | Available datasets |
+
+---
+
+## Development Setup
+
+Use the existing `bioengine-worker` conda environment:
+
+```bash
+conda activate bioengine-worker
+pip install -e ".[worker,dev]"
+source .env   # loads HYPHA_TOKEN
+```
+
+### Run Locally
+
+```bash
+python -m bioengine.worker \
+    --mode single-machine \
+    --head-num-gpus 1 \
+    --head-num-cpus 4 \
+    --workspace-dir ~/.bioengine \
+    --debug
+```
+
+For local artifact development, set:
+```bash
+export BIOENGINE_LOCAL_ARTIFACT_PATH=/path/to/bioengine-worker/tests
+```
+
+### Run Tests
+
+```bash
+pytest tests/end_to_end/ -v
+```
+
+---
+
+## Code Conventions
+
+- **Permissions**: Use `check_permissions(context, authorized_users, resource_name)` from `bioengine.utils`
+- **Schema methods**: Decorate public API methods with `@schema_method` and use `pydantic.Field` for parameter descriptions
+- **Logging**: Use `create_logger("ComponentName", ...)` from `bioengine.utils`
+- **Artifact IDs**: Always fully qualified as `workspace/alias`
+- **Artifact config**: Use `{"permissions": {"*": "r"}}` for public read; `{"website_root": "<dir>"}` for static hosting
+
+## Key File Locations
+
+- `bioengine/utils/artifact_utils.py` — All Hypha artifact CRUD helpers
+- `bioengine/applications/apps_manager.py` — `run_application`, `save_application`, lifecycle
+- `bioengine/applications/app_builder.py` — `build()` constructs Ray Serve app from artifact
+- `tests/demo_app/` — Minimal example BioEngine app
+- `bioengine_apps/model-runner/` — Production model-runner app
+- `pyproject.toml` — Package version and dependencies
+
+## Agent Workflow Guidelines
+
+- **Simplicity First**: Make every change as minimal as possible.
+- **No Regressions**: Only change what's necessary; read before modifying.
+- **Prove It Works**: Test and verify before marking done.
+- Planning lives in model context — do NOT create planning files in the repo.
+- Lessons go in `.github/copilot-instructions.md` (durable repo-level knowledge).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,8 +72,7 @@ authorized_users:
 ### Optional Fields
 
 ```yaml
-# Static frontend hosting
-static_hosting: true        # Enable Hypha artifact static site hosting
+# Static frontend hosting — set frontend_entry to enable automatically
 frontend_entry: "frontend/index.html"  # Entry HTML file (relative to artifact root)
 
 # Metadata
@@ -87,9 +86,9 @@ tutorial: tutorial.ipynb
 tags: [bioengine, image-analysis]
 ```
 
-When `static_hosting: true`, BioEngine enables Hypha's static site hosting on the artifact at deployment time. The `frontend_entry` determines the `website_root` directory served (e.g., `frontend/index.html` → `website_root: "frontend"`). The resulting URL is:
+When `frontend_entry` is set, BioEngine configures a `view_config` on the Hypha artifact during `save_application` (while the artifact is staged). The `frontend_entry` determines `root_directory` and `index` (e.g., `frontend/index.html` → `root_directory: "frontend"`, `index: "index.html"`). The resulting URL is:
 ```
-https://hypha.aicell.io/{workspace}/artifacts/{artifact-id}/
+https://hypha.aicell.io/{workspace}/view/{artifact-id}/
 ```
 
 ---

--- a/bioengine/applications/app_builder.py
+++ b/bioengine/applications/app_builder.py
@@ -23,7 +23,7 @@ from bioengine.datasets import BioEngineDatasets
 from bioengine.utils import create_logger, update_requirements, validate_manifest
 
 
-class AppManifest(TypedDict):
+class AppManifest(TypedDict, total=False):
     """
     Schema definition for BioEngine application manifest files.
 
@@ -40,6 +40,10 @@ class AppManifest(TypedDict):
     • deployments: List of Python files to deploy (format: "file:ClassName")
     • authorized_users: Who can access this app (user IDs or ["*"] for public)
 
+    Optional Fields:
+    • static_hosting: Enable Hypha artifact static site hosting for a frontend UI
+    • frontend_entry: Entry HTML file for the static frontend (e.g. "frontend/index.html")
+
     Example YAML:
     ```yaml
     name: "Image Classifier"
@@ -49,6 +53,8 @@ class AppManifest(TypedDict):
     type: "ray-serve"
     deployments: ["classifier:ImageClassifier"]
     authorized_users: ["user123", "*"]
+    static_hosting: true
+    frontend_entry: "frontend/index.html"
     ```
     """
 
@@ -59,6 +65,8 @@ class AppManifest(TypedDict):
     type: str
     deployments: List[str]
     authorized_users: List[str]
+    static_hosting: bool
+    frontend_entry: str
 
 
 class AppBuilder:
@@ -1454,6 +1462,8 @@ class AppBuilder:
                 ],
                 "application_kwargs": application_kwargs,
                 "application_env_vars": application_env_vars,
+                "static_hosting": manifest.get("static_hosting", False),
+                "frontend_entry": manifest.get("frontend_entry"),
             }
 
             self.logger.info(

--- a/bioengine/applications/app_builder.py
+++ b/bioengine/applications/app_builder.py
@@ -41,8 +41,8 @@ class AppManifest(TypedDict, total=False):
     • authorized_users: Who can access this app (user IDs or ["*"] for public)
 
     Optional Fields:
-    • static_hosting: Enable Hypha artifact static site hosting for a frontend UI
-    • frontend_entry: Entry HTML file for the static frontend (e.g. "frontend/index.html")
+    • frontend_entry: Entry HTML file for the static frontend (e.g. "frontend/index.html").
+                      When set, static site hosting is configured automatically.
 
     Example YAML:
     ```yaml
@@ -53,7 +53,6 @@ class AppManifest(TypedDict, total=False):
     type: "ray-serve"
     deployments: ["classifier:ImageClassifier"]
     authorized_users: ["user123", "*"]
-    static_hosting: true
     frontend_entry: "frontend/index.html"
     ```
     """
@@ -65,7 +64,6 @@ class AppManifest(TypedDict, total=False):
     type: str
     deployments: List[str]
     authorized_users: List[str]
-    static_hosting: bool
     frontend_entry: str
 
 
@@ -1462,7 +1460,6 @@ class AppBuilder:
                 ],
                 "application_kwargs": application_kwargs,
                 "application_env_vars": application_env_vars,
-                "static_hosting": manifest.get("static_hosting", False),
                 "frontend_entry": manifest.get("frontend_entry"),
             }
 

--- a/bioengine/applications/apps_manager.py
+++ b/bioengine/applications/apps_manager.py
@@ -1533,13 +1533,19 @@ class AppsManager:
                 required_resources=app.metadata["resources"],
             )
 
-            # Derive static site URL from the manifest (hosting was set up in save_application)
+            # Derive static site URL only if the Hypha artifact has website_root configured
+            # (set during save_application). Reading the artifact config is the ground truth —
+            # the manifest's static_hosting field alone is not sufficient.
             static_site_url = None
-            if app.metadata.get("static_hosting"):
-                static_site_url = get_static_site_url(
-                    artifact_id=artifact_id,
-                    server_url=self.server.config.public_base_url,
-                )
+            try:
+                artifact_info = await self.artifact_manager.read(artifact_id)
+                if "website_root" in (artifact_info.config or {}):
+                    static_site_url = get_static_site_url(
+                        artifact_id=artifact_id,
+                        server_url=self.server.config.public_base_url,
+                    )
+            except Exception:
+                pass  # local artifact or read failed — static URL not available
 
             # Store deployment state with proper timestamps
             self._deployed_applications[application_id] = {

--- a/bioengine/applications/apps_manager.py
+++ b/bioengine/applications/apps_manager.py
@@ -20,6 +20,7 @@ from bioengine.utils import (
     create_application_from_files,
     create_context,
     create_logger,
+    enable_static_hosting_on_artifact,
     ensure_applications_collection,
 )
 
@@ -720,6 +721,7 @@ class AppsManager:
             "authorized_users": application_info["authorized_users"],
             "available_methods": application_info["available_methods"],
             "max_ongoing_requests": application_info["max_ongoing_requests"],
+            "static_site_url": application_info.get("static_site_url"),
             "service_ids": await self._get_application_service_ids(application_id),
             "start_time": application_info["started_at"],
             "last_updated_at": application_info["last_updated_at"],
@@ -1513,6 +1515,27 @@ class AppsManager:
                 required_resources=app.metadata["resources"],
             )
 
+            # Enable static hosting on the artifact if requested in the manifest
+            static_site_url = None
+            if app.metadata.get("static_hosting"):
+                frontend_entry = app.metadata.get("frontend_entry") or "index.html"
+                try:
+                    static_site_url = await enable_static_hosting_on_artifact(
+                        artifact_manager=self.artifact_manager,
+                        artifact_id=artifact_id,
+                        frontend_entry=frontend_entry,
+                        server_url=self.server.config.public_base_url,
+                        logger=self.logger,
+                    )
+                    self.logger.info(
+                        f"Static hosting configured for application '{application_id}': {static_site_url}"
+                    )
+                except Exception as e:
+                    self.logger.warning(
+                        f"Failed to enable static hosting for application '{application_id}': {e}. "
+                        "Deployment will continue without static hosting."
+                    )
+
             # Store deployment state with proper timestamps
             self._deployed_applications[application_id] = {
                 "display_name": app.metadata["name"],
@@ -1527,6 +1550,7 @@ class AppsManager:
                 "application_resources": app.metadata["resources"],
                 "authorized_users": app.metadata["authorized_users"],
                 "available_methods": app.metadata["available_methods"],
+                "static_site_url": static_site_url,
                 "started_at": started_at,  # Preserved from original deployment or set for new application
                 "last_updated_at": last_updated_at,  # Same as started_at for new, current time for updates
                 "last_updated_by": user_id,

--- a/bioengine/applications/apps_manager.py
+++ b/bioengine/applications/apps_manager.py
@@ -1533,19 +1533,15 @@ class AppsManager:
                 required_resources=app.metadata["resources"],
             )
 
-            # Derive static site URL only if the Hypha artifact has website_root configured
-            # (set during save_application). Reading the artifact config is the ground truth —
-            # the manifest's static_hosting field alone is not sufficient.
+            # Derive static site URL from the manifest's static_hosting field.
+            # The manifest is public and always readable; the Hypha artifact config
+            # (website_root) is not readable across workspaces.
             static_site_url = None
-            try:
-                artifact_info = await self.artifact_manager.read(artifact_id)
-                if "website_root" in (artifact_info.config or {}):
-                    static_site_url = get_static_site_url(
-                        artifact_id=artifact_id,
-                        server_url=self.server.config.public_base_url,
-                    )
-            except Exception:
-                pass  # local artifact or read failed — static URL not available
+            if app.metadata.get("static_hosting"):
+                static_site_url = get_static_site_url(
+                    artifact_id=artifact_id,
+                    server_url=self.server.config.public_base_url,
+                )
 
             # Store deployment state with proper timestamps
             self._deployed_applications[application_id] = {

--- a/bioengine/applications/apps_manager.py
+++ b/bioengine/applications/apps_manager.py
@@ -1533,9 +1533,7 @@ class AppsManager:
                 required_resources=app.metadata["resources"],
             )
 
-            # Derive static site URL from the manifest's static_hosting field.
-            # The manifest is public and always readable; the Hypha artifact config
-            # (website_root) is not readable across workspaces.
+            # Derive static site base URL from the current hypha server and application ID
             static_site_url = None
             if app.metadata.get("static_hosting"):
                 static_site_url = get_static_site_url(

--- a/bioengine/applications/apps_manager.py
+++ b/bioengine/applications/apps_manager.py
@@ -1533,9 +1533,10 @@ class AppsManager:
                 required_resources=app.metadata["resources"],
             )
 
-            # Derive static site base URL from the current hypha server and application ID
+            # Derive static site URL from the manifest's frontend_entry field.
+            # If frontend_entry is set, view_config was configured during save_application.
             static_site_url = None
-            if app.metadata.get("static_hosting"):
+            if app.metadata.get("frontend_entry"):
                 static_site_url = get_static_site_url(
                     artifact_id=artifact_id,
                     server_url=self.server.config.public_base_url,

--- a/bioengine/applications/apps_manager.py
+++ b/bioengine/applications/apps_manager.py
@@ -20,8 +20,8 @@ from bioengine.utils import (
     create_application_from_files,
     create_context,
     create_logger,
-    enable_static_hosting_on_artifact,
     ensure_applications_collection,
+    get_static_site_url,
 )
 
 
@@ -703,6 +703,24 @@ class AppsManager:
                 message = f"Application '{application_id}' has not been deployed yet."
             deployments = {}
 
+        service_ids = await self._get_application_service_ids(application_id)
+
+        # Build static site URL with runtime config params so the frontend
+        # knows which Hypha server and service replica to connect to.
+        base_static_url = application_info.get("static_site_url")
+        static_site_url = None
+        if base_static_url and service_ids:
+            first = service_ids[0]
+            ws_id = first.get("websocket_service_id") or ""
+            rtc_id = first.get("webrtc_service_id") or ""
+            server_url = self.server.config.public_base_url
+            params = (
+                f"server={server_url}"
+                f"&ws_service_id={ws_id}"
+                f"&webrtc_service_id={rtc_id}"
+            )
+            static_site_url = f"{base_static_url}?{params}"
+
         return {
             "display_name": application_info["display_name"],
             "description": application_info["description"],
@@ -721,8 +739,8 @@ class AppsManager:
             "authorized_users": application_info["authorized_users"],
             "available_methods": application_info["available_methods"],
             "max_ongoing_requests": application_info["max_ongoing_requests"],
-            "static_site_url": application_info.get("static_site_url"),
-            "service_ids": await self._get_application_service_ids(application_id),
+            "static_site_url": static_site_url,
+            "service_ids": service_ids,
             "start_time": application_info["started_at"],
             "last_updated_at": application_info["last_updated_at"],
             "last_updated_by": application_info["last_updated_by"],
@@ -1515,26 +1533,13 @@ class AppsManager:
                 required_resources=app.metadata["resources"],
             )
 
-            # Enable static hosting on the artifact if requested in the manifest
+            # Derive static site URL from the manifest (hosting was set up in save_application)
             static_site_url = None
             if app.metadata.get("static_hosting"):
-                frontend_entry = app.metadata.get("frontend_entry") or "index.html"
-                try:
-                    static_site_url = await enable_static_hosting_on_artifact(
-                        artifact_manager=self.artifact_manager,
-                        artifact_id=artifact_id,
-                        frontend_entry=frontend_entry,
-                        server_url=self.server.config.public_base_url,
-                        logger=self.logger,
-                    )
-                    self.logger.info(
-                        f"Static hosting configured for application '{application_id}': {static_site_url}"
-                    )
-                except Exception as e:
-                    self.logger.warning(
-                        f"Failed to enable static hosting for application '{application_id}': {e}. "
-                        "Deployment will continue without static hosting."
-                    )
+                static_site_url = get_static_site_url(
+                    artifact_id=artifact_id,
+                    server_url=self.server.config.public_base_url,
+                )
 
             # Store deployment state with proper timestamps
             self._deployed_applications[application_id] = {

--- a/bioengine/utils/__init__.py
+++ b/bioengine/utils/__init__.py
@@ -1,6 +1,7 @@
 from .artifact_utils import (
     create_application_from_files,
     create_file_list_from_directory,
+    enable_static_hosting_on_artifact,
     ensure_applications_collection,
     validate_manifest,
 )

--- a/bioengine/utils/__init__.py
+++ b/bioengine/utils/__init__.py
@@ -3,6 +3,7 @@ from .artifact_utils import (
     create_file_list_from_directory,
     enable_static_hosting_on_artifact,
     ensure_applications_collection,
+    get_static_site_url,
     validate_manifest,
 )
 from .geo_location import fetch_centroid_coordinates, fetch_geolocation

--- a/bioengine/utils/__init__.py
+++ b/bioengine/utils/__init__.py
@@ -1,7 +1,7 @@
 from .artifact_utils import (
+    configure_view_config_on_artifact,
     create_application_from_files,
     create_file_list_from_directory,
-    enable_static_hosting_on_artifact,
     ensure_applications_collection,
     get_static_site_url,
     validate_manifest,

--- a/bioengine/utils/__init__.py
+++ b/bioengine/utils/__init__.py
@@ -1,5 +1,4 @@
 from .artifact_utils import (
-    configure_view_config_on_artifact,
     create_application_from_files,
     create_file_list_from_directory,
     ensure_applications_collection,

--- a/bioengine/utils/artifact_utils.py
+++ b/bioengine/utils/artifact_utils.py
@@ -1,6 +1,6 @@
 import base64
 import logging
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Dict, List, Optional, Union
 
 import httpx
@@ -543,6 +543,74 @@ async def commit_artifact(
         raise RuntimeError(f"Failed to commit artifact '{artifact_id}': {e}")
 
     logger.info(f"Successfully committed artifact '{artifact_id}'")
+
+
+async def enable_static_hosting_on_artifact(
+    artifact_manager: ObjectProxy,
+    artifact_id: str,
+    frontend_entry: str,
+    server_url: str,
+    logger: Optional[logging.Logger] = None,
+) -> str:
+    """
+    Enable static site hosting on a Hypha artifact and return the site URL.
+
+    Configures the artifact's ``website_root`` config field so that the Hypha
+    server serves the frontend files as a static website.  The ``frontend_entry``
+    path determines which subdirectory becomes the website root.
+
+    For example, if ``frontend_entry`` is ``"frontend/index.html"``, the
+    ``website_root`` is set to ``"frontend"`` and the resulting site URL is::
+
+        {server_url}/{workspace}/artifacts/{alias}/
+
+    If ``frontend_entry`` is at the artifact root (e.g. ``"index.html"``), the
+    ``website_root`` is set to ``""`` (empty string, i.e. the artifact root).
+
+    Args:
+        artifact_manager: Hypha artifact manager service instance.
+        artifact_id: Fully-qualified artifact ID (``workspace/alias``).
+        frontend_entry: Path to the entry HTML file relative to the artifact
+            root (e.g. ``"frontend/index.html"`` or ``"index.html"``).
+        server_url: Public base URL of the Hypha server
+            (e.g. ``"https://hypha.aicell.io"``).
+        logger: Optional logger instance.
+
+    Returns:
+        The public static site URL for the artifact.
+
+    Raises:
+        RuntimeError: If reading or editing the artifact fails.
+    """
+    if logger is None:
+        logger = create_logger("ArtifactUtils")
+
+    # Derive website_root from the directory portion of frontend_entry
+    parent = str(PurePosixPath(frontend_entry).parent)
+    website_root = "" if parent == "." else parent
+
+    try:
+        # Read existing config to avoid overwriting other settings
+        existing_artifact = await artifact_manager.read(artifact_id)
+        config = dict(existing_artifact.config or {})
+        config["website_root"] = website_root
+
+        await artifact_manager.edit(
+            artifact_id=artifact_id,
+            config=config,
+        )
+    except Exception as e:
+        raise RuntimeError(
+            f"Failed to enable static hosting on artifact '{artifact_id}': {e}"
+        )
+
+    workspace, alias = artifact_id.split("/", 1)
+    static_site_url = f"{server_url}/{workspace}/artifacts/{alias}/"
+    logger.info(
+        f"Static hosting enabled for artifact '{artifact_id}' "
+        f"(website_root='{website_root}'). URL: {static_site_url}"
+    )
+    return static_site_url
 
 
 async def create_application_from_files(

--- a/bioengine/utils/artifact_utils.py
+++ b/bioengine/utils/artifact_utils.py
@@ -564,21 +564,21 @@ def get_static_site_url(artifact_id: str, server_url: str) -> str:
     return f"{server_url}/{workspace}/view/{alias}/"
 
 
-async def enable_static_hosting_on_artifact(
+async def configure_view_config_on_artifact(
     artifact_manager: ObjectProxy,
     artifact_id: str,
     frontend_entry: str,
     logger: Optional[logging.Logger] = None,
 ) -> None:
     """
-    Configure ``website_root`` on a staged artifact to enable static site hosting.
+    Configure ``view_config`` on a staged artifact to enable static site hosting.
 
-    Must be called while the artifact is in stage mode (before commit).  Sets the
-    ``website_root`` config key so the Hypha server serves the frontend files.
+    Must be called while the artifact is in stage mode (before commit). Sets the
+    ``view_config`` config key so the Hypha server serves the frontend files.
 
-    The ``frontend_entry`` path determines which subdirectory becomes the root:
-    - ``"frontend/index.html"``  →  ``website_root = "frontend"``
-    - ``"index.html"``           →  ``website_root = ""`` (artifact root)
+    The ``frontend_entry`` path determines ``root_directory`` and ``index``:
+    - ``"frontend/index.html"``  →  ``root_directory = "frontend"``, ``index = "index.html"``
+    - ``"index.html"``           →  ``root_directory = ""``, ``index = "index.html"``
 
     Args:
         artifact_manager: Hypha artifact manager service instance.
@@ -592,15 +592,21 @@ async def enable_static_hosting_on_artifact(
     if logger is None:
         logger = create_logger("ArtifactUtils")
 
-    # Derive website_root from the directory portion of frontend_entry
-    parent = str(PurePosixPath(frontend_entry).parent)
-    website_root = "" if parent == "." else parent
+    entry_path = PurePosixPath(frontend_entry)
+    parent = str(entry_path.parent)
+    root_directory = "" if parent == "." else parent
+    index = entry_path.name
 
     try:
         # Read current staged config so we don't overwrite other settings
         existing_artifact = await artifact_manager.read(artifact_id, stage=True)
         config = dict(existing_artifact.config or {})
-        config["website_root"] = website_root
+        config["view_config"] = {
+            "branch": "main",
+            "root_directory": root_directory,
+            "headers": {},
+            "index": index,
+        }
 
         await artifact_manager.edit(
             artifact_id=artifact_id,
@@ -609,12 +615,12 @@ async def enable_static_hosting_on_artifact(
         )
     except Exception as e:
         raise RuntimeError(
-            f"Failed to enable static hosting on artifact '{artifact_id}': {e}"
+            f"Failed to configure view_config on artifact '{artifact_id}': {e}"
         )
 
     logger.info(
-        f"Static hosting configured for artifact '{artifact_id}' "
-        f"(website_root='{website_root}')"
+        f"view_config configured for artifact '{artifact_id}' "
+        f"(root_directory='{root_directory}', index='{index}')"
     )
 
 
@@ -763,12 +769,12 @@ async def create_application_from_files(
                     f"Failed to remove old file '{file_name}': {e}. Continuing anyway..."
                 )
 
-    # Enable static hosting while still in stage mode (requires write access,
-    # which is guaranteed here since we just created/edited this artifact)
-    if application_manifest.get("static_hosting"):
-        frontend_entry = application_manifest.get("frontend_entry") or "index.html"
+    # Configure view_config for static site hosting while still in stage mode.
+    # Triggered whenever frontend_entry is specified in the manifest.
+    frontend_entry = application_manifest.get("frontend_entry")
+    if frontend_entry:
         try:
-            await enable_static_hosting_on_artifact(
+            await configure_view_config_on_artifact(
                 artifact_manager=artifact_manager,
                 artifact_id=artifact.id,
                 frontend_entry=frontend_entry,
@@ -776,7 +782,7 @@ async def create_application_from_files(
             )
         except Exception as e:
             logger.warning(
-                f"Failed to configure static hosting for artifact '{artifact.id}': {e}. "
+                f"Failed to configure view_config for artifact '{artifact.id}': {e}. "
                 "Continuing without static hosting."
             )
 

--- a/bioengine/utils/artifact_utils.py
+++ b/bioengine/utils/artifact_utils.py
@@ -545,42 +545,49 @@ async def commit_artifact(
     logger.info(f"Successfully committed artifact '{artifact_id}'")
 
 
+def get_static_site_url(artifact_id: str, server_url: str) -> str:
+    """
+    Return the static site URL for a BioEngine artifact.
+
+    The URL follows the Hypha convention::
+
+        {server_url}/{workspace}/view/{alias}/
+
+    Args:
+        artifact_id: Fully-qualified artifact ID (``workspace/alias``).
+        server_url: Public base URL of the Hypha server.
+
+    Returns:
+        The public static site URL.
+    """
+    workspace, alias = artifact_id.split("/", 1)
+    return f"{server_url}/{workspace}/view/{alias}/"
+
+
 async def enable_static_hosting_on_artifact(
     artifact_manager: ObjectProxy,
     artifact_id: str,
     frontend_entry: str,
-    server_url: str,
     logger: Optional[logging.Logger] = None,
-) -> str:
+) -> None:
     """
-    Enable static site hosting on a Hypha artifact and return the site URL.
+    Configure ``website_root`` on a staged artifact to enable static site hosting.
 
-    Configures the artifact's ``website_root`` config field so that the Hypha
-    server serves the frontend files as a static website.  The ``frontend_entry``
-    path determines which subdirectory becomes the website root.
+    Must be called while the artifact is in stage mode (before commit).  Sets the
+    ``website_root`` config key so the Hypha server serves the frontend files.
 
-    For example, if ``frontend_entry`` is ``"frontend/index.html"``, the
-    ``website_root`` is set to ``"frontend"`` and the resulting site URL is::
-
-        {server_url}/{workspace}/artifacts/{alias}/
-
-    If ``frontend_entry`` is at the artifact root (e.g. ``"index.html"``), the
-    ``website_root`` is set to ``""`` (empty string, i.e. the artifact root).
+    The ``frontend_entry`` path determines which subdirectory becomes the root:
+    - ``"frontend/index.html"``  →  ``website_root = "frontend"``
+    - ``"index.html"``           →  ``website_root = ""`` (artifact root)
 
     Args:
         artifact_manager: Hypha artifact manager service instance.
         artifact_id: Fully-qualified artifact ID (``workspace/alias``).
-        frontend_entry: Path to the entry HTML file relative to the artifact
-            root (e.g. ``"frontend/index.html"`` or ``"index.html"``).
-        server_url: Public base URL of the Hypha server
-            (e.g. ``"https://hypha.aicell.io"``).
+        frontend_entry: Path to the entry HTML file relative to the artifact root.
         logger: Optional logger instance.
 
-    Returns:
-        The public static site URL for the artifact.
-
     Raises:
-        RuntimeError: If reading or editing the artifact fails.
+        RuntimeError: If editing the staged artifact fails.
     """
     if logger is None:
         logger = create_logger("ArtifactUtils")
@@ -590,27 +597,25 @@ async def enable_static_hosting_on_artifact(
     website_root = "" if parent == "." else parent
 
     try:
-        # Read existing config to avoid overwriting other settings
-        existing_artifact = await artifact_manager.read(artifact_id)
+        # Read current staged config so we don't overwrite other settings
+        existing_artifact = await artifact_manager.read(artifact_id, stage=True)
         config = dict(existing_artifact.config or {})
         config["website_root"] = website_root
 
         await artifact_manager.edit(
             artifact_id=artifact_id,
             config=config,
+            stage=True,
         )
     except Exception as e:
         raise RuntimeError(
             f"Failed to enable static hosting on artifact '{artifact_id}': {e}"
         )
 
-    workspace, alias = artifact_id.split("/", 1)
-    static_site_url = f"{server_url}/{workspace}/artifacts/{alias}/"
     logger.info(
-        f"Static hosting enabled for artifact '{artifact_id}' "
-        f"(website_root='{website_root}'). URL: {static_site_url}"
+        f"Static hosting configured for artifact '{artifact_id}' "
+        f"(website_root='{website_root}')"
     )
-    return static_site_url
 
 
 async def create_application_from_files(
@@ -757,6 +762,23 @@ async def create_application_from_files(
                 logger.warning(
                     f"Failed to remove old file '{file_name}': {e}. Continuing anyway..."
                 )
+
+    # Enable static hosting while still in stage mode (requires write access,
+    # which is guaranteed here since we just created/edited this artifact)
+    if application_manifest.get("static_hosting"):
+        frontend_entry = application_manifest.get("frontend_entry") or "index.html"
+        try:
+            await enable_static_hosting_on_artifact(
+                artifact_manager=artifact_manager,
+                artifact_id=artifact.id,
+                frontend_entry=frontend_entry,
+                logger=logger,
+            )
+        except Exception as e:
+            logger.warning(
+                f"Failed to configure static hosting for artifact '{artifact.id}': {e}. "
+                "Continuing without static hosting."
+            )
 
     # Commit the artifact
     await commit_artifact(

--- a/bioengine/utils/artifact_utils.py
+++ b/bioengine/utils/artifact_utils.py
@@ -357,6 +357,19 @@ async def stage_artifact(
     # Define collection_id early so it's available for artifact creation
     collection_id = f"{workspace}/applications"
 
+    # Build view_config from frontend_entry if present
+    view_config = None
+    frontend_entry = manifest.get("frontend_entry")
+    if frontend_entry:
+        entry_path = PurePosixPath(frontend_entry)
+        parent = str(entry_path.parent)
+        view_config = {
+            "branch": "main",
+            "root_directory": "" if parent == "." else parent,
+            "headers": {},
+            "index": entry_path.name,
+        }
+
     # Check if artifact exists and handle collection placement
     artifact = None
     try:
@@ -377,17 +390,20 @@ async def stage_artifact(
             existing_artifact = None
 
         if existing_artifact:
-            # Edit existing artifact
+            # Edit existing artifact — preserve existing config, then apply overrides
+            artifact_config = dict(existing_artifact.config or {})
+            if permissions:
+                artifact_config["permissions"] = permissions
+            if view_config is not None:
+                artifact_config["view_config"] = view_config
+
             edit_kwargs = {
                 "artifact_id": artifact_id,
                 "manifest": manifest,
                 "type": "application",
                 "stage": True,
             }
-            if permissions:
-                # Set permissions in existing config
-                artifact_config = existing_artifact.config or {}
-                artifact_config["permissions"] = permissions
+            if artifact_config:
                 edit_kwargs["config"] = artifact_config
 
             artifact = await artifact_manager.edit(**edit_kwargs)
@@ -401,6 +417,12 @@ async def stage_artifact(
     # Create new artifact if it doesn't exist or was deleted
     if artifact is None:
         try:
+            initial_config = {}
+            if permissions:
+                initial_config["permissions"] = permissions
+            if view_config is not None:
+                initial_config["view_config"] = view_config
+
             create_kwargs = {
                 "parent_id": collection_id,
                 "type": "application",
@@ -408,8 +430,8 @@ async def stage_artifact(
                 "manifest": manifest,
                 "stage": True,
             }
-            if permissions:
-                create_kwargs["config"] = {"permissions": permissions}
+            if initial_config:
+                create_kwargs["config"] = initial_config
 
             artifact = await artifact_manager.create(**create_kwargs)
             logger.info(f"Created new artifact '{artifact.id}'")
@@ -564,65 +586,6 @@ def get_static_site_url(artifact_id: str, server_url: str) -> str:
     return f"{server_url}/{workspace}/view/{alias}/"
 
 
-async def configure_view_config_on_artifact(
-    artifact_manager: ObjectProxy,
-    artifact_id: str,
-    frontend_entry: str,
-    logger: Optional[logging.Logger] = None,
-) -> None:
-    """
-    Configure ``view_config`` on a staged artifact to enable static site hosting.
-
-    Must be called while the artifact is in stage mode (before commit). Sets the
-    ``view_config`` config key so the Hypha server serves the frontend files.
-
-    The ``frontend_entry`` path determines ``root_directory`` and ``index``:
-    - ``"frontend/index.html"``  →  ``root_directory = "frontend"``, ``index = "index.html"``
-    - ``"index.html"``           →  ``root_directory = ""``, ``index = "index.html"``
-
-    Args:
-        artifact_manager: Hypha artifact manager service instance.
-        artifact_id: Fully-qualified artifact ID (``workspace/alias``).
-        frontend_entry: Path to the entry HTML file relative to the artifact root.
-        logger: Optional logger instance.
-
-    Raises:
-        RuntimeError: If editing the staged artifact fails.
-    """
-    if logger is None:
-        logger = create_logger("ArtifactUtils")
-
-    entry_path = PurePosixPath(frontend_entry)
-    parent = str(entry_path.parent)
-    root_directory = "" if parent == "." else parent
-    index = entry_path.name
-
-    try:
-        # Read current staged config so we don't overwrite other settings
-        existing_artifact = await artifact_manager.read(artifact_id, stage=True)
-        config = dict(existing_artifact.config or {})
-        config["view_config"] = {
-            "branch": "main",
-            "root_directory": root_directory,
-            "headers": {},
-            "index": index,
-        }
-
-        await artifact_manager.edit(
-            artifact_id=artifact_id,
-            config=config,
-            stage=True,
-        )
-    except Exception as e:
-        raise RuntimeError(
-            f"Failed to configure view_config on artifact '{artifact_id}': {e}"
-        )
-
-    logger.info(
-        f"view_config configured for artifact '{artifact_id}' "
-        f"(root_directory='{root_directory}', index='{index}')"
-    )
-
 
 async def create_application_from_files(
     artifact_manager: ObjectProxy,
@@ -768,23 +731,6 @@ async def create_application_from_files(
                 logger.warning(
                     f"Failed to remove old file '{file_name}': {e}. Continuing anyway..."
                 )
-
-    # Configure view_config for static site hosting while still in stage mode.
-    # Triggered whenever frontend_entry is specified in the manifest.
-    frontend_entry = application_manifest.get("frontend_entry")
-    if frontend_entry:
-        try:
-            await configure_view_config_on_artifact(
-                artifact_manager=artifact_manager,
-                artifact_id=artifact.id,
-                frontend_entry=frontend_entry,
-                logger=logger,
-            )
-        except Exception as e:
-            logger.warning(
-                f"Failed to configure view_config for artifact '{artifact.id}': {e}. "
-                "Continuing without static hosting."
-            )
 
     # Commit the artifact
     await commit_artifact(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.6.12"
+version = "0.6.13"
 description = "BioEngine Worker for managing Ray clusters and datasets"
 requires-python = ">=3.11"
 authors = [

--- a/tests/demo-app
+++ b/tests/demo-app
@@ -1,0 +1,1 @@
+demo_app

--- a/tests/demo-app
+++ b/tests/demo-app
@@ -1,1 +1,0 @@
-demo_app

--- a/tests/demo_app/demo_deployment.py
+++ b/tests/demo_app/demo_deployment.py
@@ -47,8 +47,7 @@ logger = logging.getLogger("ray.serve")
         # Number of CPUs to allocate for the deployment
         "num_cpus": 1,
         # Number of GPUs to allocate for the deployment
-        # This can be set to 0 is the parameter `disable_gpu` is set to True when deploying
-        "num_gpus": 1,
+        "num_gpus": 0,
         # Memory limit for the deployment (0.5 GB)
         "memory": 0.5 * 1024**3,
         # Runtime environment for the deployment (e.g., dependencies, environment variables)

--- a/tests/demo_app/frontend/index.html
+++ b/tests/demo_app/frontend/index.html
@@ -1,0 +1,338 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>BioEngine Demo App</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      background: #0f172a;
+      color: #e2e8f0;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 2rem 1rem;
+    }
+
+    header {
+      text-align: center;
+      margin-bottom: 2rem;
+    }
+    header h1 { font-size: 2rem; font-weight: 700; color: #38bdf8; }
+    header p  { color: #94a3b8; margin-top: 0.25rem; }
+
+    .card {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 0.75rem;
+      padding: 1.5rem;
+      width: 100%;
+      max-width: 680px;
+      margin-bottom: 1.25rem;
+    }
+
+    .card h2 {
+      font-size: 0.85rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #64748b;
+      margin-bottom: 1rem;
+    }
+
+    label { display: block; font-size: 0.875rem; color: #94a3b8; margin-bottom: 0.25rem; }
+
+    input[type="text"] {
+      width: 100%;
+      background: #0f172a;
+      border: 1px solid #334155;
+      border-radius: 0.5rem;
+      color: #e2e8f0;
+      font-size: 0.875rem;
+      padding: 0.5rem 0.75rem;
+      outline: none;
+      margin-bottom: 0.75rem;
+    }
+    input[type="text"]:focus { border-color: #38bdf8; }
+
+    .btn {
+      background: #0284c7;
+      color: #fff;
+      border: none;
+      border-radius: 0.5rem;
+      padding: 0.5rem 1.25rem;
+      cursor: pointer;
+      font-size: 0.875rem;
+      font-weight: 600;
+      transition: background 0.15s;
+    }
+    .btn:hover  { background: #0369a1; }
+    .btn:active { background: #075985; }
+    .btn:disabled { background: #334155; color: #64748b; cursor: not-allowed; }
+
+    .status-dot {
+      display: inline-block;
+      width: 0.6rem;
+      height: 0.6rem;
+      border-radius: 50%;
+      margin-right: 0.4rem;
+      background: #64748b;
+    }
+    .status-dot.connected  { background: #22c55e; }
+    .status-dot.error      { background: #ef4444; }
+    .status-dot.connecting { background: #f59e0b; }
+
+    #status-line { font-size: 0.8rem; color: #94a3b8; display: flex; align-items: center; margin-top: 0.75rem; }
+
+    .result-block {
+      background: #0f172a;
+      border-radius: 0.5rem;
+      padding: 1rem;
+      font-size: 0.8rem;
+      color: #94a3b8;
+      white-space: pre-wrap;
+      word-break: break-all;
+      min-height: 3rem;
+      max-height: 18rem;
+      overflow-y: auto;
+    }
+
+    .ascii-block {
+      font-family: monospace;
+      font-size: 0.62rem;
+      color: #38bdf8;
+      white-space: pre;
+      overflow-x: auto;
+    }
+
+    .row { display: flex; gap: 0.75rem; align-items: flex-end; }
+    .row input { flex: 1; margin-bottom: 0; }
+
+    .kv-grid { display: grid; grid-template-columns: max-content 1fr; gap: 0.25rem 1rem; font-size: 0.875rem; }
+    .kv-key   { color: #64748b; }
+    .kv-value { color: #e2e8f0; word-break: break-all; }
+
+    .section-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 0.75rem;
+    }
+    .section-header h2 { margin-bottom: 0; }
+  </style>
+</head>
+<body>
+
+<header>
+  <h1>⚙️ BioEngine Demo App</h1>
+  <p>Interactive frontend for the BioEngine Demo Deployment</p>
+</header>
+
+<!-- Connection card -->
+<div class="card">
+  <h2>Connection</h2>
+
+  <label for="serverUrl">Hypha Server URL</label>
+  <input id="serverUrl" type="text" value="https://hypha.aicell.io" />
+
+  <label for="workerServiceId">Worker Service ID (workspace/client-id:bioengine-worker)</label>
+  <input id="workerServiceId" type="text" placeholder="my-workspace/client-id:bioengine-worker" />
+
+  <label for="token">Token (optional — leave blank for anonymous)</label>
+  <div class="row">
+    <input id="token" type="text" placeholder="Leave blank for anonymous access" />
+    <button class="btn" id="connectBtn" onclick="connect()">Connect</button>
+  </div>
+
+  <div id="status-line">
+    <span class="status-dot" id="dot"></span>
+    <span id="statusText">Not connected</span>
+  </div>
+</div>
+
+<!-- Ping card -->
+<div class="card">
+  <div class="section-header">
+    <h2>Ping</h2>
+    <button class="btn" id="pingBtn" onclick="callPing()" disabled>Ping</button>
+  </div>
+  <div class="kv-grid" id="pingResult">
+    <span class="kv-key">status</span><span class="kv-value">—</span>
+  </div>
+</div>
+
+<!-- ASCII art card -->
+<div class="card">
+  <div class="section-header">
+    <h2>ASCII Art</h2>
+    <button class="btn" id="asciiBtn" onclick="callAsciiArt()" disabled>Load</button>
+  </div>
+  <div class="result-block ascii-block" id="asciiResult">Press "Load" to fetch ASCII art…</div>
+</div>
+
+<!-- Raw status card (collapsible) -->
+<div class="card">
+  <div class="section-header">
+    <h2>Application Status (raw)</h2>
+    <button class="btn" id="statusBtn" onclick="callStatus()" disabled>Refresh</button>
+  </div>
+  <div class="result-block" id="statusResult">—</div>
+</div>
+
+<script type="module">
+// ── Hypha-RPC via ESM CDN ─────────────────────────────────────────────────────
+import { connectToServer } from "https://cdn.jsdelivr.net/npm/hypha-rpc@0.20.54/dist/hypha-rpc-websocket.mjs";
+
+// ── State ─────────────────────────────────────────────────────────────────────
+let server       = null;
+let workerSvc    = null;
+let appSvc       = null;   // websocket service for the deployed demo-app
+let appId        = null;   // Ray Serve application_id (e.g. "witty-hawk-1a2b")
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+function setStatus(state, text) {
+  const dot  = document.getElementById("dot");
+  const span = document.getElementById("statusText");
+  dot.className  = "status-dot " + state;
+  span.textContent = text;
+}
+
+function setButtons(enabled) {
+  ["pingBtn","asciiBtn","statusBtn"].forEach(id => {
+    document.getElementById(id).disabled = !enabled;
+  });
+}
+
+function showPingResult(data) {
+  const grid = document.getElementById("pingResult");
+  grid.innerHTML = Object.entries(data).map(([k,v]) =>
+    `<span class="kv-key">${k}</span><span class="kv-value">${v}</span>`
+  ).join("");
+}
+
+// Resolve the first running demo-app replica service from the worker.
+async function findDemoAppService() {
+  const apps = await workerSvc.list_applications({ _rkwargs: true });
+  // Look for a deployed app whose artifact_id ends in /demo-app
+  for (const [id, info] of Object.entries(apps)) {
+    if ((info.artifact_id || "").endsWith("/demo-app")) {
+      return { id, info };
+    }
+  }
+  return null;
+}
+
+// ── Actions ───────────────────────────────────────────────────────────────────
+window.connect = async function () {
+  const serverUrl       = document.getElementById("serverUrl").value.trim();
+  const workerServiceId = document.getElementById("workerServiceId").value.trim();
+  const token           = document.getElementById("token").value.trim() || undefined;
+
+  if (!workerServiceId) {
+    alert("Please enter the Worker Service ID.");
+    return;
+  }
+
+  document.getElementById("connectBtn").disabled = true;
+  setStatus("connecting", "Connecting…");
+  setButtons(false);
+
+  try {
+    const opts = { server_url: serverUrl };
+    if (token) opts.token = token;
+    server = await connectToServer(opts);
+    setStatus("connecting", "Getting worker service…");
+
+    workerSvc = await server.getService(workerServiceId, { _rkwargs: true });
+
+    setStatus("connecting", "Locating demo-app deployment…");
+
+    const result = await findDemoAppService();
+    if (!result) {
+      setStatus("error", "demo-app is not deployed on this worker.");
+      document.getElementById("connectBtn").disabled = false;
+      return;
+    }
+
+    appId = result.id;
+    const serviceIds = result.info.service_ids || [];
+    if (!serviceIds.length || !serviceIds[0].websocket_service_id) {
+      setStatus("error", `demo-app found (${appId}) but has no service endpoint yet. It may still be starting.`);
+      document.getElementById("connectBtn").disabled = false;
+      return;
+    }
+
+    const wsServiceId = serviceIds[0].websocket_service_id;
+    setStatus("connecting", `Connecting to app service (${wsServiceId})…`);
+    appSvc = await server.getService(wsServiceId, { _rkwargs: true });
+
+    setStatus("connected", `Connected — app: ${appId}`);
+    setButtons(true);
+  } catch (err) {
+    setStatus("error", "Error: " + err.message);
+    console.error(err);
+  } finally {
+    document.getElementById("connectBtn").disabled = false;
+  }
+};
+
+window.callPing = async function () {
+  if (!appSvc) return;
+  document.getElementById("pingBtn").disabled = true;
+  try {
+    const res = await appSvc.ping({ _rkwargs: true });
+    showPingResult(res);
+  } catch (err) {
+    showPingResult({ error: err.message });
+  } finally {
+    document.getElementById("pingBtn").disabled = false;
+  }
+};
+
+window.callAsciiArt = async function () {
+  if (!appSvc) return;
+  document.getElementById("asciiBtn").disabled = true;
+  const el = document.getElementById("asciiResult");
+  el.textContent = "Loading…";
+  try {
+    const lines = await appSvc.ascii_art({ _rkwargs: true });
+    el.textContent = Array.isArray(lines) ? lines.join("\n") : String(lines);
+  } catch (err) {
+    el.textContent = "Error: " + err.message;
+  } finally {
+    document.getElementById("asciiBtn").disabled = false;
+  }
+};
+
+window.callStatus = async function () {
+  if (!workerSvc || !appId) return;
+  document.getElementById("statusBtn").disabled = true;
+  const el = document.getElementById("statusResult");
+  try {
+    const res = await workerSvc.get_application_status({
+      application_ids: [appId],
+      _rkwargs: true,
+    });
+    el.textContent = JSON.stringify(res, null, 2);
+  } catch (err) {
+    el.textContent = "Error: " + err.message;
+  } finally {
+    document.getElementById("statusBtn").disabled = false;
+  }
+};
+
+// Auto-fill from URL hash: #server=URL&worker=SERVICE_ID&token=TOKEN
+(function readHash() {
+  const hash = location.hash.replace(/^#\/?colab\/?/, "").replace(/^#/, "");
+  if (!hash) return;
+  const params = new URLSearchParams(hash);
+  if (params.get("server"))  document.getElementById("serverUrl").value = params.get("server");
+  if (params.get("worker"))  document.getElementById("workerServiceId").value = params.get("worker");
+  if (params.get("token"))   document.getElementById("token").value = params.get("token");
+})();
+</script>
+</body>
+</html>

--- a/tests/demo_app/frontend/index.html
+++ b/tests/demo_app/frontend/index.html
@@ -146,11 +146,7 @@
 
   <div class="info-row">Service: <span>bioimage-io/demo-app</span> &nbsp;·&nbsp; Server: <span>https://hypha.aicell.io</span></div>
 
-  <label for="token">Token (optional — leave blank for anonymous)</label>
-  <div class="row">
-    <input id="token" type="text" placeholder="Leave blank for anonymous access" />
-    <button class="btn" id="connectBtn" onclick="connect()">Connect</button>
-  </div>
+  <button class="btn" id="connectBtn" onclick="connect()">Connect</button>
 
   <div id="status-line">
     <span class="status-dot" id="dot"></span>
@@ -207,14 +203,11 @@ function setButtons(enabled) {
 }
 
 window.connect = async function () {
-  const token = document.getElementById("token").value.trim() || undefined;
   document.getElementById("connectBtn").disabled = true;
   setStatus("connecting", "Connecting…");
   setButtons(false);
   try {
-    const opts = { server_url: SERVER_URL };
-    if (token) opts.token = token;
-    const server = await connectToServer(opts);
+    const server = await connectToServer({ server_url: SERVER_URL });
     setStatus("connecting", `Getting service ${SERVICE_ID}…`);
     svc = await server.getService(SERVICE_ID, { _rkwargs: true });
     setStatus("connected", `Connected to ${SERVICE_ID}`);
@@ -274,13 +267,6 @@ window.callListDatasets = async function () {
   }
 };
 
-// Auto-fill token from URL hash: #token=...
-(function () {
-  const params = new URLSearchParams(
-    location.hash.replace(/^#\/?(?:colab\/?)?/, "")
-  );
-  if (params.get("token")) document.getElementById("token").value = params.get("token");
-})();
 </script>
 </body>
 </html>

--- a/tests/demo_app/frontend/index.html
+++ b/tests/demo_app/frontend/index.html
@@ -144,7 +144,7 @@
 <div class="card">
   <h2>Connection</h2>
 
-  <div class="info-row">Service: <span>bioimage-io/demo-app</span> &nbsp;·&nbsp; Server: <span>https://hypha.aicell.io</span></div>
+  <div class="info-row">Server: <span id="infoServer">…</span> &nbsp;·&nbsp; Service: <span id="infoService">…</span></div>
 
   <button class="btn" id="connectBtn" onclick="connect()">Connect</button>
 
@@ -186,8 +186,13 @@
 <script type="module">
 import { connectToServer } from "https://cdn.jsdelivr.net/npm/hypha-rpc@0.20.54/dist/hypha-rpc-websocket.mjs";
 
-const SERVER_URL  = "https://hypha.aicell.io";
-const SERVICE_ID  = "bioimage-io/demo-app";
+const params     = new URLSearchParams(window.location.search);
+const SERVER_URL = params.get("server")        || "";
+const SERVICE_ID = params.get("ws_service_id") || "";
+
+// Populate the info row with resolved values
+document.getElementById("infoServer").textContent  = SERVER_URL  || "(not provided)";
+document.getElementById("infoService").textContent = SERVICE_ID || "(not provided)";
 
 let svc = null;
 
@@ -203,6 +208,10 @@ function setButtons(enabled) {
 }
 
 window.connect = async function () {
+  if (!SERVER_URL || !SERVICE_ID) {
+    setStatus("error", "Missing server or ws_service_id in URL params");
+    return;
+  }
   document.getElementById("connectBtn").disabled = true;
   setStatus("connecting", "Connecting…");
   setButtons(false);

--- a/tests/demo_app/frontend/index.html
+++ b/tests/demo_app/frontend/index.html
@@ -18,10 +18,7 @@
       padding: 2rem 1rem;
     }
 
-    header {
-      text-align: center;
-      margin-bottom: 2rem;
-    }
+    header { text-align: center; margin-bottom: 2rem; }
     header h1 { font-size: 2rem; font-weight: 700; color: #38bdf8; }
     header p  { color: #94a3b8; margin-top: 0.25rem; }
 
@@ -69,14 +66,13 @@
       font-weight: 600;
       transition: background 0.15s;
     }
-    .btn:hover  { background: #0369a1; }
-    .btn:active { background: #075985; }
+    .btn:hover   { background: #0369a1; }
+    .btn:active  { background: #075985; }
     .btn:disabled { background: #334155; color: #64748b; cursor: not-allowed; }
 
     .status-dot {
       display: inline-block;
-      width: 0.6rem;
-      height: 0.6rem;
+      width: 0.6rem; height: 0.6rem;
       border-radius: 50%;
       margin-right: 0.4rem;
       background: #64748b;
@@ -85,7 +81,26 @@
     .status-dot.error      { background: #ef4444; }
     .status-dot.connecting { background: #f59e0b; }
 
-    #status-line { font-size: 0.8rem; color: #94a3b8; display: flex; align-items: center; margin-top: 0.75rem; }
+    #status-line {
+      font-size: 0.8rem; color: #94a3b8;
+      display: flex; align-items: center;
+      margin-top: 0.75rem;
+    }
+
+    .section-header {
+      display: flex; justify-content: space-between; align-items: center;
+      margin-bottom: 0.75rem;
+    }
+    .section-header h2 { margin-bottom: 0; }
+
+    .kv-grid {
+      display: grid;
+      grid-template-columns: max-content 1fr;
+      gap: 0.25rem 1rem;
+      font-size: 0.875rem;
+    }
+    .kv-key   { color: #64748b; }
+    .kv-value { color: #e2e8f0; word-break: break-all; }
 
     .result-block {
       background: #0f172a;
@@ -111,17 +126,11 @@
     .row { display: flex; gap: 0.75rem; align-items: flex-end; }
     .row input { flex: 1; margin-bottom: 0; }
 
-    .kv-grid { display: grid; grid-template-columns: max-content 1fr; gap: 0.25rem 1rem; font-size: 0.875rem; }
-    .kv-key   { color: #64748b; }
-    .kv-value { color: #e2e8f0; word-break: break-all; }
-
-    .section-header {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      margin-bottom: 0.75rem;
+    .info-row {
+      display: flex; gap: 0.5rem; align-items: baseline;
+      font-size: 0.8rem; color: #64748b; margin-bottom: 0.5rem;
     }
-    .section-header h2 { margin-bottom: 0; }
+    .info-row span { color: #94a3b8; }
   </style>
 </head>
 <body>
@@ -135,11 +144,7 @@
 <div class="card">
   <h2>Connection</h2>
 
-  <label for="serverUrl">Hypha Server URL</label>
-  <input id="serverUrl" type="text" value="https://hypha.aicell.io" />
-
-  <label for="workerServiceId">Worker Service ID (workspace/client-id:bioengine-worker)</label>
-  <input id="workerServiceId" type="text" placeholder="my-workspace/client-id:bioengine-worker" />
+  <div class="info-row">Service: <span>bioimage-io/demo-app</span> &nbsp;·&nbsp; Server: <span>https://hypha.aicell.io</span></div>
 
   <label for="token">Token (optional — leave blank for anonymous)</label>
   <div class="row">
@@ -173,103 +178,46 @@
   <div class="result-block ascii-block" id="asciiResult">Press "Load" to fetch ASCII art…</div>
 </div>
 
-<!-- Raw status card (collapsible) -->
+<!-- Datasets card -->
 <div class="card">
   <div class="section-header">
-    <h2>Application Status (raw)</h2>
-    <button class="btn" id="statusBtn" onclick="callStatus()" disabled>Refresh</button>
+    <h2>List Datasets</h2>
+    <button class="btn" id="datasetsBtn" onclick="callListDatasets()" disabled>List</button>
   </div>
-  <div class="result-block" id="statusResult">—</div>
+  <div class="result-block" id="datasetsResult">—</div>
 </div>
 
 <script type="module">
-// ── Hypha-RPC via ESM CDN ─────────────────────────────────────────────────────
 import { connectToServer } from "https://cdn.jsdelivr.net/npm/hypha-rpc@0.20.54/dist/hypha-rpc-websocket.mjs";
 
-// ── State ─────────────────────────────────────────────────────────────────────
-let server       = null;
-let workerSvc    = null;
-let appSvc       = null;   // websocket service for the deployed demo-app
-let appId        = null;   // Ray Serve application_id (e.g. "witty-hawk-1a2b")
+const SERVER_URL  = "https://hypha.aicell.io";
+const SERVICE_ID  = "bioimage-io/demo-app";
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
+let svc = null;
+
 function setStatus(state, text) {
-  const dot  = document.getElementById("dot");
-  const span = document.getElementById("statusText");
-  dot.className  = "status-dot " + state;
-  span.textContent = text;
+  document.getElementById("dot").className = "status-dot " + state;
+  document.getElementById("statusText").textContent = text;
 }
 
 function setButtons(enabled) {
-  ["pingBtn","asciiBtn","statusBtn"].forEach(id => {
+  ["pingBtn", "asciiBtn", "datasetsBtn"].forEach(id => {
     document.getElementById(id).disabled = !enabled;
   });
 }
 
-function showPingResult(data) {
-  const grid = document.getElementById("pingResult");
-  grid.innerHTML = Object.entries(data).map(([k,v]) =>
-    `<span class="kv-key">${k}</span><span class="kv-value">${v}</span>`
-  ).join("");
-}
-
-// Resolve the first running demo-app replica service from the worker.
-async function findDemoAppService() {
-  const apps = await workerSvc.list_applications({ _rkwargs: true });
-  // Look for a deployed app whose artifact_id ends in /demo-app
-  for (const [id, info] of Object.entries(apps)) {
-    if ((info.artifact_id || "").endsWith("/demo-app")) {
-      return { id, info };
-    }
-  }
-  return null;
-}
-
-// ── Actions ───────────────────────────────────────────────────────────────────
 window.connect = async function () {
-  const serverUrl       = document.getElementById("serverUrl").value.trim();
-  const workerServiceId = document.getElementById("workerServiceId").value.trim();
-  const token           = document.getElementById("token").value.trim() || undefined;
-
-  if (!workerServiceId) {
-    alert("Please enter the Worker Service ID.");
-    return;
-  }
-
+  const token = document.getElementById("token").value.trim() || undefined;
   document.getElementById("connectBtn").disabled = true;
   setStatus("connecting", "Connecting…");
   setButtons(false);
-
   try {
-    const opts = { server_url: serverUrl };
+    const opts = { server_url: SERVER_URL };
     if (token) opts.token = token;
-    server = await connectToServer(opts);
-    setStatus("connecting", "Getting worker service…");
-
-    workerSvc = await server.getService(workerServiceId, { _rkwargs: true });
-
-    setStatus("connecting", "Locating demo-app deployment…");
-
-    const result = await findDemoAppService();
-    if (!result) {
-      setStatus("error", "demo-app is not deployed on this worker.");
-      document.getElementById("connectBtn").disabled = false;
-      return;
-    }
-
-    appId = result.id;
-    const serviceIds = result.info.service_ids || [];
-    if (!serviceIds.length || !serviceIds[0].websocket_service_id) {
-      setStatus("error", `demo-app found (${appId}) but has no service endpoint yet. It may still be starting.`);
-      document.getElementById("connectBtn").disabled = false;
-      return;
-    }
-
-    const wsServiceId = serviceIds[0].websocket_service_id;
-    setStatus("connecting", `Connecting to app service (${wsServiceId})…`);
-    appSvc = await server.getService(wsServiceId, { _rkwargs: true });
-
-    setStatus("connected", `Connected — app: ${appId}`);
+    const server = await connectToServer(opts);
+    setStatus("connecting", `Getting service ${SERVICE_ID}…`);
+    svc = await server.getService(SERVICE_ID, { _rkwargs: true });
+    setStatus("connected", `Connected to ${SERVICE_ID}`);
     setButtons(true);
   } catch (err) {
     setStatus("error", "Error: " + err.message);
@@ -280,25 +228,29 @@ window.connect = async function () {
 };
 
 window.callPing = async function () {
-  if (!appSvc) return;
+  if (!svc) return;
   document.getElementById("pingBtn").disabled = true;
   try {
-    const res = await appSvc.ping({ _rkwargs: true });
-    showPingResult(res);
+    const res = await svc.ping({ _rkwargs: true });
+    const grid = document.getElementById("pingResult");
+    grid.innerHTML = Object.entries(res).map(([k, v]) =>
+      `<span class="kv-key">${k}</span><span class="kv-value">${v}</span>`
+    ).join("");
   } catch (err) {
-    showPingResult({ error: err.message });
+    document.getElementById("pingResult").innerHTML =
+      `<span class="kv-key">error</span><span class="kv-value">${err.message}</span>`;
   } finally {
     document.getElementById("pingBtn").disabled = false;
   }
 };
 
 window.callAsciiArt = async function () {
-  if (!appSvc) return;
+  if (!svc) return;
   document.getElementById("asciiBtn").disabled = true;
   const el = document.getElementById("asciiResult");
   el.textContent = "Loading…";
   try {
-    const lines = await appSvc.ascii_art({ _rkwargs: true });
+    const lines = await svc.ascii_art({ _rkwargs: true });
     el.textContent = Array.isArray(lines) ? lines.join("\n") : String(lines);
   } catch (err) {
     el.textContent = "Error: " + err.message;
@@ -307,31 +259,27 @@ window.callAsciiArt = async function () {
   }
 };
 
-window.callStatus = async function () {
-  if (!workerSvc || !appId) return;
-  document.getElementById("statusBtn").disabled = true;
-  const el = document.getElementById("statusResult");
+window.callListDatasets = async function () {
+  if (!svc) return;
+  document.getElementById("datasetsBtn").disabled = true;
+  const el = document.getElementById("datasetsResult");
+  el.textContent = "Loading…";
   try {
-    const res = await workerSvc.get_application_status({
-      application_ids: [appId],
-      _rkwargs: true,
-    });
+    const res = await svc.list_datasets({ _rkwargs: true });
     el.textContent = JSON.stringify(res, null, 2);
   } catch (err) {
     el.textContent = "Error: " + err.message;
   } finally {
-    document.getElementById("statusBtn").disabled = false;
+    document.getElementById("datasetsBtn").disabled = false;
   }
 };
 
-// Auto-fill from URL hash: #server=URL&worker=SERVICE_ID&token=TOKEN
-(function readHash() {
-  const hash = location.hash.replace(/^#\/?colab\/?/, "").replace(/^#/, "");
-  if (!hash) return;
-  const params = new URLSearchParams(hash);
-  if (params.get("server"))  document.getElementById("serverUrl").value = params.get("server");
-  if (params.get("worker"))  document.getElementById("workerServiceId").value = params.get("worker");
-  if (params.get("token"))   document.getElementById("token").value = params.get("token");
+// Auto-fill token from URL hash: #token=...
+(function () {
+  const params = new URLSearchParams(
+    location.hash.replace(/^#\/?(?:colab\/?)?/, "")
+  );
+  if (params.get("token")) document.getElementById("token").value = params.get("token");
 })();
 </script>
 </body>

--- a/tests/demo_app/manifest.yaml
+++ b/tests/demo_app/manifest.yaml
@@ -14,6 +14,7 @@ git_repo: https://github.com/aicell-lab/bioengine-worker
 links: []
 tags: [test, bioengine]
 type: ray-serve
+version: 0.0.1
 deployments:
   - demo_deployment:DemoDeployment
 authorized_users:

--- a/tests/demo_app/manifest.yaml
+++ b/tests/demo_app/manifest.yaml
@@ -18,3 +18,5 @@ deployments:
   - demo_deployment:DemoDeployment
 authorized_users:
   - "*" # Allow all users to access the application
+static_hosting: true
+frontend_entry: "frontend/index.html"

--- a/tests/demo_app/manifest.yaml
+++ b/tests/demo_app/manifest.yaml
@@ -19,5 +19,4 @@ deployments:
   - demo_deployment:DemoDeployment
 authorized_users:
   - "*" # Allow all users to access the application
-static_hosting: true
 frontend_entry: "frontend/index.html"


### PR DESCRIPTION
Add opt-in static site hosting to BioEngine app deployments via two new manifest fields (`static_hosting` and `frontend_entry`).

Changes:
- **CLAUDE.md**: Initial project overview document covering architecture, manifest schema, deployment modes, API methods, and conventions.
- **manifest schema** (`app_builder.py`): Extend `AppManifest` TypedDict with optional `static_hosting: bool` and `frontend_entry: str` fields.  The `build()` method now propagates both fields into `app.metadata`.
- **artifact_utils.py**: Add `enable_static_hosting_on_artifact()` which sets `website_root` in the Hypha artifact config to activate static site hosting and returns the resulting public URL.
- **apps_manager.py** (`run_application`): At deployment time, if the manifest declares `static_hosting: true`, call `enable_static_hosting_on_artifact()` on the artifact so the Hypha server begins serving the frontend files.  The static site URL is stored in the deployment state and surfaced through `get_application_status()`.
- **version bump**: 0.6.12 → 0.6.13