### PR TITLE
fix: support PNG inference + tutorial with export/retrain/delete steps

### DIFF
--- a/bioengine_apps/cellpose-finetuning/main.py
+++ b/bioengine_apps/cellpose-finetuning/main.py
@@ -3294,7 +3294,16 @@ async def _images_from_artifact(
     imgs: list[npt.NDArray[Any]] = []
     for rel in image_paths:
         local_img = cache_dir / rel
-        imgs.append(imread(local_img))
+        suffix = local_img.suffix.lower()
+        if suffix in (".png", ".jpg", ".jpeg", ".bmp", ".gif"):
+            from PIL import Image
+            img_arr = np.array(Image.open(local_img))
+            # Ensure CHW layout expected by Cellpose when image is multi-channel
+            if img_arr.ndim == 3 and img_arr.shape[2] in (3, 4):
+                img_arr = img_arr.transpose(2, 0, 1)
+            imgs.append(img_arr)
+        else:
+            imgs.append(imread(local_img))
     return imgs
 
 
@@ -3384,6 +3393,7 @@ def _predict_and_encode(
                 "cellpose==4.0.7",
                 "numpy==1.26.4",
                 "tifffile",
+                "Pillow",
                 "hypha-artifact==0.1.2",
             ],
         },

--- a/bioengine_apps/cellpose-finetuning/manifest.yaml
+++ b/bioengine_apps/cellpose-finetuning/manifest.yaml
@@ -15,7 +15,7 @@ maintainers: []
 name: Cellpose Fine-Tuning
 tags: [cell-segmentation, deep-learning, biomedical-imaging, fine-tuning]
 type: ray-serve
-version: 0.0.15
+version: 0.0.16
 deployments:
   - main:CellposeFinetune
 authorized_users:

--- a/bioengine_apps/cellpose-finetuning/tutorial_cellpose_finetuning.ipynb
+++ b/bioengine_apps/cellpose-finetuning/tutorial_cellpose_finetuning.ipynb
@@ -2,1087 +2,345 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "49c6d19d",
    "metadata": {},
    "source": [
-    "# 🦒 Fine-tuning Cellpose with BioEngine ⚙️☁️\n",
-    "\n",
-    "Welcome to this tutorial on fine-tuning the Cellpose cell segmentation model using BioEngine!\n",
-    "\n",
-    "## 🔍 What You'll Learn\n",
-    "\n",
-    "In this guide, you'll discover how to:\n",
-    "1. 🔌 Connect to a Cellpose Fine-tuning service on BioEngine\n",
-    "2. 🚀 Start a new training session on annotated brightfield microscopy images\n",
-    "3. 📊 Visualize training and test losses after each session\n",
-    "4. 🔄 Continue training to accumulate more epochs\n",
-    "5. 📦 Export the trained model as a BioImage.IO-compatible artifact\n",
-    "6. 🗂️ List models trained on a given dataset\n",
-    "\n",
-    "## 🧪 How It Works\n",
-    "\n",
-    "BioEngine's Cellpose Fine-tuning service lets you train Cellpose on your own annotated data stored in the Hypha artifact manager:\n",
-    "\n",
-    "1. 📂 Your images and masks are stored in a Hypha artifact\n",
-    "2. 🏋️ The service downloads the data and runs GPU-accelerated training on the server\n",
-    "3. 📈 You poll for progress and inspect per-epoch metrics\n",
-    "4. 💾 When satisfied, you export the model as a BioImage.IO package\n",
-    "\n",
-    "## 📚 Dataset Used in This Tutorial\n",
-    "\n",
-    "We use the artifact **`bioimage-io/annotation-mnw8359y-ehab`** — a collection of annotated brightfield microscopy images gathered with the [BioImage.IO Colab](https://bioimage.io/#/colab) collaborative annotation platform. The artifact contains:\n",
-    "\n",
-    "| Folder | Contents |\n",
-    "|--------|----------|\n",
-    "| `train_images/` | 13 brightfield PNG images for training |\n",
-    "| `test_images/` | 2 brightfield PNG images for validation |\n",
-    "| `masks_cells/` | Instance-segmentation PNG masks (and GeoJSON files) for all 15 images |\n",
-    "\n",
-    "The service automatically matches each image to its corresponding mask by filename stem.\n",
-    "\n",
-    "## ⚠️ Important Note\n",
-    "\n",
-    "This tutorial uses the public Hypha server at [https://hypha.aicell.io](https://hypha.aicell.io) and the shared service **`bioimage-io/cellpose-finetuning`**. This service is provided by the AI4Life team for evaluation purposes and may change without notice.\n",
-    "\n",
-    "For production use or sensitive data, deploy your own BioEngine worker following the [Deployment Guidelines](https://github.com/aicell-lab/bioengine-worker).\n"
+    "# \ud83e\udd92 Fine-tuning Cellpose with BioEngine \u2699\ufe0f\u2601\ufe0f"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "467fa03e",
    "metadata": {},
    "source": [
-    "## 🧩 Setup and Installation"
+    "## Installation and module imports"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-13T07:43:39.639325Z",
-     "iopub.status.busy": "2026-04-13T07:43:39.638903Z",
-     "iopub.status.idle": "2026-04-13T07:43:43.490975Z",
-     "shell.execute_reply": "2026-04-13T07:43:43.490285Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: hypha-rpc in /home/weiouyang/.local/lib/python3.8/site-packages (0.20.39)\n",
-      "Requirement already satisfied: matplotlib in /home/weiouyang/.local/lib/python3.8/site-packages (3.7.5)\n",
-      "Requirement already satisfied: numpy in /home/weiouyang/.local/lib/python3.8/site-packages (1.24.4)\n",
-      "Requirement already satisfied: msgpack>=1.0.2 in /home/weiouyang/.local/lib/python3.8/site-packages (from hypha-rpc) (1.1.1)\n",
-      "Requirement already satisfied: websockets<=13.1; platform_system != \"Emscripten\" in /home/weiouyang/.local/lib/python3.8/site-packages (from hypha-rpc) (13.1)\n",
-      "Requirement already satisfied: shortuuid>=1.0.8 in /home/weiouyang/.local/lib/python3.8/site-packages (from hypha-rpc) (1.0.13)\n",
-      "Requirement already satisfied: munch in /home/weiouyang/.local/lib/python3.8/site-packages (from hypha-rpc) (4.0.0)\n",
-      "Requirement already satisfied: kiwisolver>=1.0.1 in /home/weiouyang/.local/lib/python3.8/site-packages (from matplotlib) (1.4.7)\n",
-      "Requirement already satisfied: packaging>=20.0 in /home/weiouyang/.local/lib/python3.8/site-packages (from matplotlib) (26.0)\n",
-      "Requirement already satisfied: cycler>=0.10 in /home/weiouyang/.local/lib/python3.8/site-packages (from matplotlib) (0.12.1)\n",
-      "Requirement already satisfied: python-dateutil>=2.7 in /home/weiouyang/.local/lib/python3.8/site-packages (from matplotlib) (2.9.0.post0)\n",
-      "Requirement already satisfied: contourpy>=1.0.1 in /home/weiouyang/.local/lib/python3.8/site-packages (from matplotlib) (1.1.1)\n",
-      "Requirement already satisfied: pillow>=6.2.0 in /home/weiouyang/.local/lib/python3.8/site-packages (from matplotlib) (10.4.0)\n",
-      "Requirement already satisfied: pyparsing>=2.3.1 in /home/weiouyang/.local/lib/python3.8/site-packages (from matplotlib) (3.1.4)\n",
-      "Requirement already satisfied: importlib-resources>=3.2.0; python_version < \"3.10\" in /home/weiouyang/.local/lib/python3.8/site-packages (from matplotlib) (6.4.5)\n",
-      "Requirement already satisfied: fonttools>=4.22.0 in /home/weiouyang/.local/lib/python3.8/site-packages (from matplotlib) (4.57.0)\n",
-      "Requirement already satisfied: six>=1.5 in /home/weiouyang/.local/lib/python3.8/site-packages (from python-dateutil>=2.7->matplotlib) (1.17.0)\n",
-      "Requirement already satisfied: zipp>=3.1.0; python_version < \"3.10\" in /home/weiouyang/.local/lib/python3.8/site-packages (from importlib-resources>=3.2.0; python_version < \"3.10\"->matplotlib) (3.20.2)\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "23c3efd0",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "try:\n",
     "    # For pyodide in the browser\n",
     "    import micropip\n",
     "\n",
-    "    await micropip.install(\n",
-    "        [\"pyodide-http\", \"hypha-rpc\", \"matplotlib\", \"numpy\"]\n",
-    "    )\n",
+    "    await micropip.install([\"pyodide-http\", \"hypha-rpc\", \"httpx\", \"kaibu-utils\", \"matplotlib\", \"tifffile\", \"numpy==1.26.4\"])\n",
     "\n",
+    "    # 2. Patch requests\n",
     "    import pyodide_http\n",
     "\n",
-    "    pyodide_http.patch_all()\n",
+    "    pyodide_http.patch_all()  # Patch all libraries\n",
     "except ImportError:\n",
-    "    # For native Python with pip\n",
+    "    # For native python with pip\n",
     "    import subprocess\n",
     "\n",
-    "    subprocess.call([\"pip\", \"install\", \"hypha-rpc\", \"matplotlib\", \"numpy\"])\n",
+    "    subprocess.call([\"pip\", \"install\", \"hypha-rpc\", \"httpx\", \"kaibu-utils\", \"matplotlib\", \"tifffile\", \"numpy==1.26.4\"])\n",
     "\n",
-    "import asyncio\n",
-    "import datetime\n",
-    "import json\n",
-    "import os\n",
+    "import zipfile\n",
+    "from pathlib import Path\n",
     "\n",
+    "import httpx\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "from hypha_rpc import connect_to_server, login"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 🔌☁️ Connect to the Hypha Server\n",
-    "\n",
-    "We connect to [https://hypha.aicell.io](https://hypha.aicell.io). A browser login will open if `HYPHA_TOKEN` is not set in your environment."
+    "from hypha_rpc import connect_to_server, login\n",
+    "from tifffile import imread"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-13T07:43:43.494426Z",
-     "iopub.status.busy": "2026-04-13T07:43:43.494202Z",
-     "iopub.status.idle": "2026-04-13T07:43:43.496652Z",
-     "shell.execute_reply": "2026-04-13T07:43:43.496214Z"
-    }
-   },
+   "execution_count": null,
+   "id": "e9be5a7e",
+   "metadata": {},
    "outputs": [],
    "source": [
+    "# Server URL: For this demo we will use the hypha.aicell.io server\n",
     "SERVER_URL = \"https://hypha.aicell.io\""
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-13T07:43:43.500051Z",
-     "iopub.status.busy": "2026-04-13T07:43:43.499657Z",
-     "iopub.status.idle": "2026-04-13T07:43:43.677184Z",
-     "shell.execute_reply": "2026-04-13T07:43:43.675913Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "✅ Connected to workspace: ws-user-github|478667\n"
-     ]
-    }
-   ],
+   "cell_type": "markdown",
+   "id": "d64ee9e3",
+   "metadata": {},
    "source": [
-    "token = os.getenv(\"HYPHA_TOKEN\") or await login({\"server_url\": SERVER_URL})\n",
-    "server = await connect_to_server(\n",
-    "    {\"server_url\": SERVER_URL, \"token\": token, \"method_timeout\": 300}\n",
-    ")\n",
+    "### Connect to the server"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da7ff719",
+   "metadata": {},
+   "outputs": [],
+   "source": "import os\n\n# Use HYPHA_TOKEN from environment if available (for automated execution)\n# otherwise fall back to interactive browser login\nif os.environ.get(\"HYPHA_TOKEN\"):\n    token = os.environ[\"HYPHA_TOKEN\"]\nelse:\n    token = await login({\"server_url\": SERVER_URL})\n\nserver = await connect_to_server(\n    {\"server_url\": SERVER_URL, \"token\": token}\n)\nworkspace = server.config.workspace\n\nprint(f\"Connected to workspace: {workspace}\")\n\nartifact_manager = await server.get_service(\"public/artifact-manager\")"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd6d8045",
+   "metadata": {},
+   "source": [
+    "### Access the BioEngine deployments\n",
     "\n",
-    "print(f\"✅ Connected to workspace: {server.config.workspace}\")"
+    "A public BioEngine instance is available with the service ID `bioimage-io/bioengine-apps`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fe3af1aa",
+   "metadata": {},
+   "outputs": [],
+   "source": "PUBLIC_BIOENGINE = \"bioimage-io/bioengine-apps\"\n\ntry:\n    bioengine = await server.get_service(PUBLIC_BIOENGINE)\n    print(f\"Connected to public BioEngine service: {PUBLIC_BIOENGINE}\")\nexcept Exception:\n    print(f\"Public BioEngine service not available, will use cellpose-finetuning service directly.\")\n    bioengine = None"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "64cd1d52",
+   "metadata": {},
+   "source": [
+    "If you have started your own BioEngine instance, you can first list your deployment services and then "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27092f91",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "services = await server.list_services({\"type\": \"bioengine-apps\"})\n",
+    "\n",
+    "for service in services:\n",
+    "    print(f\"BioEngine apps service ID: {service.id}\")\n",
+    "    PRIVATE_BIOENGINE = service.id\n",
+    "\n",
+    "if len(services) == 0:\n",
+    "    print(f\"No BioEngine apps service available in workspace '{server.config.workspace}'.\")\n",
+    "\n",
+    "bioengine = await server.get_service(PRIVATE_BIOENGINE)"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "d986f926",
    "metadata": {},
    "source": [
-    "## 🧬 Connect to the Cellpose Fine-tuning Service\n",
-    "\n",
-    "The public Cellpose Fine-tuning service is available at `bioimage-io/cellpose-finetuning`."
+    "### Visualize some collected data"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-13T07:43:43.681715Z",
-     "iopub.status.busy": "2026-04-13T07:43:43.681301Z",
-     "iopub.status.idle": "2026-04-13T07:43:43.700361Z",
-     "shell.execute_reply": "2026-04-13T07:43:43.699244Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "✅ Connected to service: bioimage-io/cellpose-finetuning\n"
-     ]
-    }
-   ],
-   "source": [
-    "CELLPOSE_SERVICE_ID = \"bioimage-io/cellpose-finetuning\"\n",
-    "\n",
-    "cellpose_svc = await server.get_service(CELLPOSE_SERVICE_ID)\n",
-    "\n",
-    "print(f\"✅ Connected to service: {CELLPOSE_SERVICE_ID}\")"
-   ]
+   "execution_count": null,
+   "id": "f32ce70d",
+   "metadata": {},
+   "outputs": [],
+   "source": "# We use an existing annotated dataset from the BioImage.IO collection.\n# This artifact contains HPA cell images with mask annotations.\ndata_artifact_id = \"bioimage-io/annotation-mnw8359y-ehab\"\nworkspace_part, data_artifact_alias = data_artifact_id.split(\"/\", 1)\n\n# Download a few example images locally for visualization\nimport tempfile, httpx, asyncio\ndata_dir = Path(tempfile.mkdtemp(prefix=\"hpa_demo_\"))\nprint(f\"Using artifact: {data_artifact_id}\")\nprint(f\"Downloading sample images to: {data_dir}\")"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a572424b",
+   "metadata": {},
+   "outputs": [],
+   "source": "# Fetch file listing and download sample image-mask pairs for visualization\nimport httpx\n\nasync def download_artifact_file(am, artifact_id, remote_path, local_path):\n    url = await am.get_file(artifact_id, file_path=remote_path)\n    async with httpx.AsyncClient(timeout=60) as client:\n        r = await client.get(url)\n        r.raise_for_status()\n        local_path.write_bytes(r.content)\n\ntrain_files = await artifact_manager.list_files(data_artifact_id, dir_path=\"train_images\")\nmask_files  = await artifact_manager.list_files(data_artifact_id, dir_path=\"masks_cells\")\n\n# Only keep PNG masks (exclude geojson)\ntrain_names = sorted(f[\"name\"] for f in train_files if f[\"name\"].endswith(\".png\"))\nmask_names  = sorted(f[\"name\"] for f in mask_files  if f[\"name\"].endswith(\".png\"))\n\n# Build paired list (match by stem)\nmask_by_stem = {Path(m).stem: m for m in mask_names}\nimage_annotation_pairs = [\n    (f\"train_images/{t}\", f\"masks_cells/{mask_by_stem[Path(t).stem]}\")\n    for t in train_names\n    if Path(t).stem in mask_by_stem\n]\nprint(f\"Found {len(image_annotation_pairs)} image-mask pairs in artifact\")\n\n# Download first 5 for local visualization\nsample_pairs = image_annotation_pairs[:5]\n(data_dir / \"train_images\").mkdir(parents=True, exist_ok=True)\n(data_dir / \"masks_cells\").mkdir(parents=True, exist_ok=True)\n\nfor img_path, mask_path in sample_pairs:\n    await download_artifact_file(artifact_manager, data_artifact_id, img_path, data_dir / img_path)\n    await download_artifact_file(artifact_manager, data_artifact_id, mask_path, data_dir / mask_path)\n\nimage_annotation_pairs_local = [\n    (data_dir / img, data_dir / mask)\n    for img, mask in sample_pairs\n]\nprint(f\"Downloaded {len(image_annotation_pairs_local)} pairs for visualization\")"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1d070410",
+   "metadata": {},
+   "outputs": [],
+   "source": "from PIL import Image\nimport numpy as np\n\nassert len(image_annotation_pairs_local) >= 5\n\n# Plot several annotations\nplt.figure(figsize=(15, 6))\n\nfor i in range(5):\n    plt.subplot(2, 5, i + 1)\n    img = np.array(Image.open(image_annotation_pairs_local[i][0]))\n    plt.imshow(img)\n    plt.title(image_annotation_pairs_local[i][0].stem[:20])\n    plt.axis(\"off\")\n\n    plt.subplot(2, 5, i + 6)\n    mask = np.array(Image.open(image_annotation_pairs_local[i][1]))\n    plt.imshow(mask)\n    plt.axis(\"off\")\n\nplt.tight_layout()\nplt.show()"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8536abd",
+   "metadata": {},
+   "source": "### Use the existing annotated dataset\n\nThe dataset is already available in the BioImage.IO Colab collection as `bioimage-io/annotation-mnw8359y-ehab`.\nWe will use it directly for training without re-uploading."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0a5ce0ec",
+   "metadata": {},
+   "outputs": [],
+   "source": "# The dataset artifact is already available \u2014 use it directly for training\nprint(f\"Using existing dataset artifact: {data_artifact_id}\")\nprint(f\"Artifact alias: {data_artifact_alias}\")"
+  },
+  {
+   "cell_type": "code",
+   "id": "34591462",
+   "metadata": {},
+   "source": "# Dataset already uploaded \u2014 skipping re-upload step",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3493f2ad",
+   "metadata": {},
+   "outputs": [],
+   "source": "# (skipped)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f5f1b13a",
+   "metadata": {},
+   "outputs": [],
+   "source": "# (skipped)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20a2871f",
+   "metadata": {},
+   "outputs": [],
+   "source": "# data_artifact_alias already set above"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed2e9669",
+   "metadata": {},
+   "source": "### Choose a pre-trained model to fine-tune\n\n**Note:** Cellpose 4.0.7 only supports the `cpsam` (Cellpose-SAM) model. This is a transformer-based segmentation model that is channel-order invariant and provides better performance than previous versions."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d42bb55a",
+   "metadata": {},
+   "outputs": [],
+   "source": "# Only Cellpose-SAM (cpsam) is supported in Cellpose 4.0.7\npretrained_models = [\"cpsam\"]\nprint(\"Available pretrained models: \\n -\", '\\n - '.join(pretrained_models))"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca85d7b8",
+   "metadata": {},
+   "source": "Here we choose the `cellpose` model `cpsam` (Cellpose-SAM 4.0) for segmentation.\n\n**Note:** Cellpose 4.0.7 only supports the `cpsam` model, which is a transformer-based model that is channel-order invariant."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "446c20bb",
+   "metadata": {},
+   "outputs": [],
+   "source": "initial_model = \"cpsam\""
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40ff235a",
+   "metadata": {},
+   "source": "### Start the fine-tuning\n\nWe pass the dataset artifact ID directly to `start_training()`. Training uses glob patterns to find\nimages and masks inside the artifact. No manual zip upload or presigned URL creation is needed."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5984ad4d",
+   "metadata": {},
+   "outputs": [],
+   "source": "# Confirm the dataset artifact we will train on\nprint(f\"Training dataset : {data_artifact_id}\")\nprint(f\"  - train images : train_images/*.png\")\nprint(f\"  - train masks  : masks_cells/*.png\")"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "294fffda",
+   "metadata": {},
+   "source": "### Run the Cellpose fine-tuning with Real-Time Progress Tracking\n\nThe async API allows you to start training and monitor its progress with comprehensive real-time updates. \n\n**Key Features:**\n- **Real-time epoch tracking**: See current epoch, total epochs, and progress\n- **Training metrics**: Monitor training and test losses as they update\n- **Dataset information**: View training/test sample counts immediately\n- **Timing information**: Track elapsed time and training start time\n- **Path-based file matching**: Use wildcard patterns to match image/annotation files\n\n**Parameters:**\n- `artifact`: Your training dataset artifact ID\n- `train_images`: Path pattern for training images (e.g., \"*.tif\", \"images/*.ome.tif\")\n- `train_annotations`: Path pattern for annotations (e.g., \"annotations/*_mask.tif\")\n- `test_images`, `test_annotations`: Optional test set patterns\n- `model`: Pretrained model to start from (default: \"cpsam\")\n- `n_epochs`: Number of training epochs\n- `n_samples`: Optional - limit number of samples to use\n\n**The API will:**\n1. Start training asynchronously and return a session ID\n2. Provide real-time status updates via `get_training_status(session_id)`\n3. Track comprehensive metrics: losses, timing, dataset info, epoch progress\n4. When complete, use the session ID as the model parameter for inference\n\n**Enhanced Status Information:**\nThe status now includes: `status_type`, `message`, `train_losses`, `test_losses`, `n_train`, `n_test`, `start_time`, `current_epoch`, `total_epochs`, and `elapsed_seconds` - giving you complete visibility into training progress!"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f8110789",
+   "metadata": {},
+   "outputs": [],
+   "source": "# Start the Cellpose fine-tuning asynchronously\nimport asyncio\n\n# Get the cellpose service\ncellpose_service = await server.get_service(\"bioimage-io/cellpose-finetuning\")\n\n# Start training with path patterns matching the artifact structure\nsession_status = await cellpose_service.start_training(\n    artifact=data_artifact_id,\n    train_images=\"train_images/*.png\",\n    train_annotations=\"masks_cells/*.png\",\n    model=initial_model,\n    n_epochs=10,\n    n_samples=None,  # Use all available samples\n    min_train_masks=1,\n)\n\nsession_id = session_status[\"session_id\"]\nprint(f\"Training session started with ID: {session_id}\")\nprint(f\"  start_time: {session_status.get('start_time')}\")\nprint()\nprint(\"Monitoring training progress with real-time updates...\\n\")\n\n# Monitor training progress\nwhile True:\n    status = await cellpose_service.get_training_status(session_id)\n    st = status['status_type']\n    msg = f\"[{st}] {status['message']}\"\n    if \"n_train\" in status:\n        msg += f\" | Train: {status['n_train']} samples\"\n    if \"current_epoch\" in status and \"total_epochs\" in status:\n        msg += f\" | Epoch: {status['current_epoch']}/{status['total_epochs']}\"\n    if \"elapsed_seconds\" in status:\n        msg += f\" | Time: {status['elapsed_seconds']:.1f}s\"\n    if status.get(\"train_losses\"):\n        losses = [l for l in status[\"train_losses\"] if l > 0]\n        if losses:\n            msg += f\" | Train Loss: {losses[-1]:.4f}\"\n    print(f\"\\r{msg}\", end=\"\", flush=True)\n    if st in (\"completed\", \"failed\"):\n        print(\"\\n\")\n        break\n    await asyncio.sleep(2)\n\nif status[\"status_type\"] == \"failed\":\n    raise RuntimeError(f\"Training failed: {status['message']}\")\n\nprint(\"=\" * 80)\nprint(\"Training Completed Successfully!\")\nprint(\"=\" * 80)\nprint(f\"Fine-tuned model session ID: {session_id}\")\n\nif status.get(\"train_losses\"):\n    valid_losses = [l for l in status[\"train_losses\"] if l > 0]\n    if valid_losses:\n        print(f\"Initial loss: {valid_losses[0]:.4f}\")\n        print(f\"Final loss: {valid_losses[-1]:.4f}\")\n        print(f\"Loss improvement: {((valid_losses[0] - valid_losses[-1]) / valid_losses[0] * 100):.1f}%\")"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16d1a097",
+   "metadata": {},
+   "source": "### Test the fine-tuned model\n\nNow let's test the fine-tuned model by running inference on a sample image."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d720aa60",
+   "metadata": {},
+   "outputs": [],
+   "source": "# Run inference with the fine-tuned model\n# Use the first image from the downloaded sample pairs\ntest_image_path = image_annotation_pairs[0][0]  # artifact-relative path\n\ninference_result = await cellpose_service.infer(\n    model=session_id,  # Use the fine-tuned model\n    artifact=data_artifact_id,\n    diameter=40,\n    image_paths=[test_image_path],\n)\n\nprint(f\"Inference completed!\")\nprint(f\"Result shape: {inference_result[0]['output'].shape}\")"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cca43975",
+   "metadata": {},
+   "outputs": [],
+   "source": "# Visualize the inference result\nfrom PIL import Image\n\ntest_img  = np.array(Image.open(image_annotation_pairs_local[0][0]))\ntest_mask = np.array(Image.open(image_annotation_pairs_local[0][1]))\npredicted_mask = inference_result[0]['output']\n\nplt.figure(figsize=(15, 5))\n\nplt.subplot(1, 3, 1)\nplt.imshow(test_img)\nplt.title(\"Original Image\")\nplt.axis(\"off\")\n\nplt.subplot(1, 3, 2)\nplt.imshow(predicted_mask)\nplt.title(f\"Predicted Mask\\n(Fine-tuned {initial_model})\")\nplt.axis(\"off\")\n\nplt.subplot(1, 3, 3)\nplt.imshow(test_mask)\nplt.title(\"Ground Truth Annotation\")\nplt.axis(\"off\")\n\nplt.tight_layout()\nplt.show()"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9cc0bc9b",
+   "metadata": {},
+   "outputs": [],
+   "source": "# Compare with pretrained model\npretrained_result = await cellpose_service.infer(\n    model=initial_model,\n    artifact=data_artifact_id,\n    diameter=40,\n    image_paths=[test_image_path],\n)\n\npretrained_mask = pretrained_result[0]['output']\n\nplt.figure(figsize=(15, 5))\n\nplt.subplot(1, 3, 1)\nplt.imshow(test_img)\nplt.title(\"Original Image\")\nplt.axis(\"off\")\n\nplt.subplot(1, 3, 2)\nplt.imshow(pretrained_mask)\nplt.title(f\"Pretrained {initial_model}\")\nplt.axis(\"off\")\n\nplt.subplot(1, 3, 3)\nplt.imshow(predicted_mask)\nplt.title(f\"Fine-tuned {initial_model}\")\nplt.axis(\"off\")\n\nplt.tight_layout()\nplt.show()\n\nprint(f\"\\nComparison complete!\")\nprint(f\"You can see how the fine-tuned model performs compared to the pretrained model.\")"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 📂 Dataset Configuration\n",
-    "\n",
-    "We use a pre-existing Hypha artifact with annotated brightfield images collected through the BioImage.IO Colab annotation platform.\n",
-    "\n",
-    "The artifact structure is:\n",
-    "```\n",
-    "bioimage-io/annotation-mnw8359y-ehab/\n",
-    "├── train_images/      ← 13 brightfield PNG images\n",
-    "├── test_images/       ← 2 brightfield PNG images\n",
-    "└── masks_cells/       ← PNG instance-segmentation masks for all 15 images\n",
-    "                         (+ GeoJSON files — excluded via *.png pattern)\n",
-    "```\n",
-    "\n",
-    "We use the `*.png` glob pattern to select only the PNG masks from `masks_cells/`, avoiding the GeoJSON annotation files. The service automatically matches each image to its mask by filename stem."
-   ]
+   "source": "### Export the fine-tuned model\n\nOnce training is complete, you can export the model as a BioImage.IO artifact. The exported model:\n- Is stored in the `bioimage-io/colab-annotations` collection\n- Can be used directly for inference by passing the `artifact_id` as the `model` argument to `infer()`\n- Can be used as the starting point for further fine-tuning by passing the `artifact_id` as the `model` argument to `start_training()`\n\nNote: Training sessions can be deleted via the `delete_training_session()` API, but published model artifacts are permanent and cannot be removed through this application."
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-13T07:43:43.705015Z",
-     "iopub.status.busy": "2026-04-13T07:43:43.704581Z",
-     "iopub.status.idle": "2026-04-13T07:43:43.712204Z",
-     "shell.execute_reply": "2026-04-13T07:43:43.710923Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Dataset artifact : bioimage-io/annotation-mnw8359y-ehab\n",
-      "Train images     : train_images/*.png\n",
-      "Train masks      : masks_cells/*.png\n",
-      "Test images      : test_images/*.png\n",
-      "Test masks       : masks_cells/*.png\n"
-     ]
-    }
-   ],
-   "source": [
-    "DATASET_ARTIFACT  = \"bioimage-io/annotation-mnw8359y-ehab\"\n",
-    "\n",
-    "TRAIN_IMAGES      = \"train_images/*.png\"\n",
-    "TRAIN_ANNOTATIONS = \"masks_cells/*.png\"\n",
-    "TEST_IMAGES       = \"test_images/*.png\"\n",
-    "TEST_ANNOTATIONS  = \"masks_cells/*.png\"\n",
-    "\n",
-    "print(f\"Dataset artifact : {DATASET_ARTIFACT}\")\n",
-    "print(f\"Train images     : {TRAIN_IMAGES}\")\n",
-    "print(f\"Train masks      : {TRAIN_ANNOTATIONS}\")\n",
-    "print(f\"Test images      : {TEST_IMAGES}\")\n",
-    "print(f\"Test masks       : {TEST_ANNOTATIONS}\")"
-   ]
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Export the fine-tuned model as a BioImage.IO artifact\nexport_result = await cellpose_service.export_model(\n    session_id=session_id,\n    model_name=f\"cellpose-finetuned-tutorial\",\n    description=\"Cellpose-SAM model fine-tuned on HPA demo dataset via the BioEngine tutorial.\",\n)\n\nexported_artifact_id = export_result[\"artifact_id\"]\nprint(f\"Model exported successfully!\")\nprint(f\"  Artifact ID : {exported_artifact_id}\")\nprint(f\"  Artifact URL: {export_result['artifact_url']}\")\nprint(f\"  Download ZIP: {export_result['download_url']}\")\n"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "---\n",
-    "\n",
-    "## 🏋️ Step 1: Start a Training Session (10 Epochs)\n",
-    "\n",
-    "We fine-tune the base **CellposeSAM (`cpsam`)** model for **10 epochs** with per-epoch validation (`validation_interval=1`) so we can inspect the loss curve in detail.\n",
-    "\n",
-    "`start_training` launches training asynchronously and immediately returns a `session_id`. We then poll `get_training_status` until the run finishes."
-   ]
+   "source": "### Continue fine-tuning from the exported model\n\nYou can resume or continue fine-tuning from any previously exported model artifact by passing its `artifact_id` as the `model` parameter. This lets you iteratively improve a model across multiple training runs."
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-13T07:43:43.716466Z",
-     "iopub.status.busy": "2026-04-13T07:43:43.716064Z",
-     "iopub.status.idle": "2026-04-13T07:43:43.831228Z",
-     "shell.execute_reply": "2026-04-13T07:43:43.829744Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "🚀 Training started!\n",
-      "{\n",
-      "  \"status_type\": \"preparing\",\n",
-      "  \"message\": \"Preparing for training...\",\n",
-      "  \"dataset_artifact_id\": \"bioimage-io/annotation-mnw8359y-ehab\",\n",
-      "  \"model\": \"cpsam\",\n",
-      "  \"n_epochs\": 10,\n",
-      "  \"learning_rate\": 1e-06,\n",
-      "  \"weight_decay\": 0.0001,\n",
-      "  \"min_train_masks\": 5,\n",
-      "  \"validation_interval\": 1,\n",
-      "  \"session_id\": \"edadb072-605f-49ca-a3cd-3ba9975431b6\"\n",
-      "}\n"
-     ]
-    }
-   ],
-   "source": [
-    "session_result = await cellpose_svc.start_training(\n",
-    "    artifact=DATASET_ARTIFACT,\n",
-    "    train_images=TRAIN_IMAGES,\n",
-    "    train_annotations=TRAIN_ANNOTATIONS,\n",
-    "    test_images=TEST_IMAGES,\n",
-    "    test_annotations=TEST_ANNOTATIONS,\n",
-    "    model=\"cpsam\",\n",
-    "    n_epochs=10,\n",
-    "    validation_interval=1,\n",
-    ")\n",
-    "\n",
-    "session_id = session_result[\"session_id\"]\n",
-    "\n",
-    "print(\"🚀 Training started!\")\n",
-    "print(json.dumps(session_result, indent=2, default=str))"
-   ]
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Start a new training session using the exported model as the starting point\nsession_status_continued = await cellpose_service.start_training(\n    artifact=f\"{workspace}/{data_artifact_alias}\",\n    train_images=\"*.tif\",\n    train_annotations=\"annotations/*_mask*.tif\",\n    model=exported_artifact_id,  # Use the exported model as starting point\n    n_epochs=5,\n    min_train_masks=1,\n)\n\nsession_id_continued = session_status_continued[\"session_id\"]\nprint(f\"Continued training session started: {session_id_continued}\")\nprint(f\"  last_continued_time: {session_status_continued.get('last_continued_time')}\")\nprint()\n\n# Monitor progress\nwhile True:\n    status = await cellpose_service.get_training_status(session_id_continued)\n    st = status[\"status_type\"]\n    msg = f\"[{st}] {status['message']}\"\n    if \"current_epoch\" in status and \"total_epochs\" in status:\n        msg += f\" | Epoch: {status['current_epoch']}/{status['total_epochs']}\"\n    if status.get(\"train_losses\"):\n        msg += f\" | Loss: {status['train_losses'][-1]:.4f}\"\n    print(f\"\\r{msg}\", end=\"\", flush=True)\n    if st in (\"completed\", \"failed\", \"stopped\"):\n        print()\n        break\n    await asyncio.sleep(2)\n\nif status[\"status_type\"] == \"failed\":\n    raise RuntimeError(f\"Continued training failed: {status['message']}\")\nprint(f\"Continued training completed!\")\n"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### ⏳ Wait for Training to Complete\n",
-    "\n",
-    "Poll `get_training_status` every 15 seconds until the session reaches a terminal state."
-   ]
+   "source": "### Delete training sessions\n\nTraining sessions can be deleted using `delete_training_session()`. Only the session owner can delete their own sessions.\n\n**Note:** This only deletes the local training session (model weights, logs, status). The exported model artifact (`exported_artifact_id`) is published to BioImage.IO and is not affected."
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-13T07:43:43.835473Z",
-     "iopub.status.busy": "2026-04-13T07:43:43.835074Z",
-     "iopub.status.idle": "2026-04-13T07:44:29.592289Z",
-     "shell.execute_reply": "2026-04-13T07:44:29.590882Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[preparing   ] epoch 0/?  train=?  test=?  elapsed=—  Listing files and matching training pairs from artifact...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[running     ] epoch 3/10  train=13  test=2  elapsed=9s  Training in progress (epoch 3/10)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[running     ] epoch 7/10  train=13  test=2  elapsed=25s  Validating epoch 7/10 (batch 2/2) - Val Acc: 0.6797\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[completed   ] epoch 10/10  train=13  test=2  elapsed=40s  Training completed successfully\n",
-      "\n",
-      "✅ Session 'edadb072-605f-49ca-a3cd-3ba9975431b6' finished with status: completed\n"
-     ]
-    }
-   ],
-   "source": [
-    "TERMINAL_STATES = {\"completed\", \"failed\", \"stopped\"}\n",
-    "\n",
-    "prev_epoch = -1\n",
-    "while True:\n",
-    "    status = await cellpose_svc.get_training_status(session_id=session_id)\n",
-    "    st      = status.get(\"status_type\", \"unknown\")\n",
-    "    epoch   = status.get(\"current_epoch\") or 0\n",
-    "    total   = status.get(\"total_epochs\") or \"?\"\n",
-    "    n_train = status.get(\"n_train\") or \"?\"\n",
-    "    n_test  = status.get(\"n_test\") or \"?\"\n",
-    "    elapsed = status.get(\"elapsed_seconds\")\n",
-    "    msg     = status.get(\"message\", \"\")\n",
-    "\n",
-    "    if epoch != prev_epoch or st in TERMINAL_STATES:\n",
-    "        elapsed_str = f\"{elapsed:.0f}s\" if elapsed is not None else \"—\"\n",
-    "        print(\n",
-    "            f\"[{st:12s}] epoch {epoch}/{total}  \"\n",
-    "            f\"train={n_train}  test={n_test}  elapsed={elapsed_str}  {msg}\"\n",
-    "        )\n",
-    "        prev_epoch = epoch\n",
-    "\n",
-    "    if st in TERMINAL_STATES:\n",
-    "        break\n",
-    "\n",
-    "    await asyncio.sleep(15)\n",
-    "\n",
-    "print(f\"\\n✅ Session '{session_id}' finished with status: {status['status_type']}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
+   "execution_count": null,
    "metadata": {},
-   "source": [
-    "---\n",
-    "\n",
-    "## 📊 Step 2: Visualise Training and Validation Metrics\n",
-    "\n",
-    "After the training run we inspect:\n",
-    "- **Train loss** per epoch\n",
-    "- **Test (validation) loss** per epoch\n",
-    "- **Pixel accuracy** per epoch (from `test_metrics`)"
-   ]
+   "outputs": [],
+   "source": "# Delete the continued training session\ndelete_result = await cellpose_service.delete_training_session(session_id=session_id_continued)\nprint(f\"Deleted continued session: {delete_result['deleted']}\")\n\n# Delete the original training session\ndelete_result_orig = await cellpose_service.delete_training_session(session_id=session_id)\nprint(f\"Deleted original session:  {delete_result_orig['deleted']}\")\n\nprint()\nprint(f\"The exported model artifact is still available at:\")\nprint(f\"  {export_result['artifact_url']}\")\n"
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-13T07:44:29.597636Z",
-     "iopub.status.busy": "2026-04-13T07:44:29.597187Z",
-     "iopub.status.idle": "2026-04-13T07:44:29.677672Z",
-     "shell.execute_reply": "2026-04-13T07:44:29.676330Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epochs completed : 10\n",
-      "Training samples : 13\n",
-      "Test samples     : 2\n",
-      "Elapsed time     : 40.2s\n",
-      "\n",
-      "Per-epoch summary:\n",
-      "  Epoch  1  train_loss=2.9766  test_loss=0.2979  pixel_acc=0.9560\n",
-      "  Epoch  2  train_loss=9.2461  test_loss=0.2979  pixel_acc=0.9560\n",
-      "  Epoch  3  train_loss=3.3164  test_loss=1.6182  pixel_acc=0.8033\n",
-      "  Epoch  4  train_loss=5.0625  test_loss=1.6172  pixel_acc=0.8034\n",
-      "  Epoch  5  train_loss=2.2217  test_loss=2.0400  pixel_acc=0.7922\n",
-      "  Epoch  6  train_loss=8.8984  test_loss=1.4004  pixel_acc=0.7947\n",
-      "  Epoch  7  train_loss=4.0312  test_loss=1.1426  pixel_acc=0.8176\n",
-      "  Epoch  8  train_loss=1.2734  test_loss=1.8213  pixel_acc=0.7938\n",
-      "  Epoch  9  train_loss=4.5859  test_loss=0.2969  pixel_acc=0.9560\n",
-      "  Epoch 10  train_loss=4.0703  test_loss=1.3594  pixel_acc=0.7949\n"
-     ]
-    }
-   ],
-   "source": [
-    "status = await cellpose_svc.get_training_status(session_id=session_id)\n",
-    "\n",
-    "train_losses = status.get(\"train_losses\") or []\n",
-    "test_losses  = status.get(\"test_losses\")  or []\n",
-    "test_metrics = status.get(\"test_metrics\") or []\n",
-    "n_epochs_run = len(train_losses)\n",
-    "epochs       = list(range(1, n_epochs_run + 1))\n",
-    "\n",
-    "print(f\"Epochs completed : {n_epochs_run}\")\n",
-    "print(f\"Training samples : {status.get('n_train')}\")\n",
-    "print(f\"Test samples     : {status.get('n_test')}\")\n",
-    "print(f\"Elapsed time     : {status.get('elapsed_seconds', 0):.1f}s\")\n",
-    "print()\n",
-    "print(\"Per-epoch summary:\")\n",
-    "for i, (tl, vl) in enumerate(zip(train_losses, test_losses)):\n",
-    "    acc = test_metrics[i][\"pixel_accuracy\"] if i < len(test_metrics) and test_metrics[i] else None\n",
-    "    acc_str = f\"{acc:.4f}\" if acc is not None else \"—\"\n",
-    "    print(f\"  Epoch {i+1:2d}  train_loss={tl:.4f}  test_loss={vl:.4f}  pixel_acc={acc_str}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-13T07:44:29.683307Z",
-     "iopub.status.busy": "2026-04-13T07:44:29.682694Z",
-     "iopub.status.idle": "2026-04-13T07:44:30.187384Z",
-     "shell.execute_reply": "2026-04-13T07:44:30.186249Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABW4AAAGGCAYAAADrbBjiAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjYsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvq6yFwwAAAAlwSFlzAAAPYQAAD2EBqD+naQAA9K5JREFUeJzs3XdYU9cbB/DvTYAww56CgIgyRJyouLBq3Xtr66q1dVSttlXbuqvUtlrr7tLaintUWycq1oWKezAEZMjeeyfn90dMfka2AjfA+3mePJCTm3vf5Gac++bc93CMMQZCCCGEEEIIIYQQQgghKkPAdwCEEEIIIYQQQgghhBBClFHilhBCCCGEEEIIIYQQQlQMJW4JIYQQQgghhBBCCCFExVDilhBCCCGEEEIIIYQQQlQMJW4JIYQQQgghhBBCCCFExVDilhBCCCGEEEIIIYQQQlQMJW4JIYQQQgghhBBCCCFExVDilhBCCCGEEEIIIYQQQlQMJW4JIYQQQgghhBBCCCFExVDilpAaNHXqVNjZ2b3RfVeuXAmO42o2IFIvzZ49G3379uU7jCqxs7PD1KlT+Q6D1DAvLy+0atWqRta1c+dONG3aFIWFhTWyPkIIIQ1LZGQkOI7DH3/8oWirTr+Y4zisXLmyRmPy8vKCl5dXja6zJtX2ccPly5fBcRwuX75ca9sgyg4dOgQjIyPk5OTwHUql3uaYt64sWbIEnTp14jsMQmoEJW5Jo8BxXJUujblzIpVK8cMPP8DR0RFaWlpwcHDArFmzqtR5kHe4q3KJjIx861jj4uKwcuVKPHjwoErL//HHH+A4Dnfu3Hnrbde2iIgI/Pbbb/jyyy+V2pOTkzF//nw4OTlBS0sLZmZm8PDwwOLFi+tFB6+m5eTkYMWKFejfvz+MjIxKHfC9qR07dmDMmDFo2rQpOI6rMCmdkZGBmTNnwtTUFDo6OujVqxfu3btXpe14eXmV+x5xcnJ668ehSqZOnYqioiL8/PPPfIdCCCHkLQ0dOhTa2trIzs4ud5lJkyZBQ0MDqampdRhZ9QUGBmLlypU10jetKfKEqfyirq6OZs2aYfLkyXj+/Dnf4VVo+/bt4DiOkmVvQCKRYMWKFfjkk0+gq6uraC8qKsJPP/2Etm3bQiwWw8DAAK6urpg5cyaCg4N5jJg/Ve2rL1iwAA8fPsTJkyfrNkBCaoEa3wEQUhf++usvpet//vknfH19S7U7Ozu/1XZ+/fVXSKXSN7rv119/jSVLlrzV9t/GTz/9hM8//xzDhw/H559/jqioKOzfvx+LFy9W6kCUxdTUtNRzuWHDBsTExODHH38stezbiouLw6pVq2BnZ4c2bdq89fpUyU8//QR7e3v06tVL0ZaWloYOHTogKysL06dPh5OTE1JTU/Ho0SPs2LEDs2bNqnQf1ZaQkBAIBHX/G2BKSgpWr16Npk2bwt3dvcZ+dFm/fj2ys7Ph4eGB+Pj4cpeTSqUYNGgQHj58iM8//xwmJibYvn07vLy8cPfuXTg6Ola6LWtra3h7e5dq19fXf6vHoGo0NTUxZcoUbNy4EZ988gmdWUAIIfXYpEmT8M8//+D48eOYPHlyqdvz8vJw4sQJ9O/fH8bGxm+8nbroFwcGBmLVqlXw8vIqNXrw/PnztbrtysybNw8dO3ZEcXEx7t27h19++QWnTp3C48ePYWVlxftxQ1l8fHxgZ2eH27dvIywsDM2bN+c7pHrjn3/+QUhICGbOnKnUPmrUKJw5cwYTJkzAhx9+iOLiYgQHB+Pff/+Fp6cnbz/2v80x79uqal/dwsICw4YNww8//IChQ4fWYYSE1DxK3JJG4b333lO6fvPmTfj6+pZqf11eXh60tbWrvB11dfU3ig8A1NTUoKbG31vywIEDcHV1xbFjxxSJlTVr1lTpS1lHR6fUc3ngwAGkp6dX+hyT/ysuLoaPjw8+/vhjpfbff/8d0dHRuH79Ojw9PZVuy8rKgoaGRl2GqUQkEvGyXUtLS8THx8PCwgJ37txBx44da2S9//33n+IX/IqS4UeOHMGNGzdw+PBhjB49GgAwduxYtGjRAitWrMC+ffsq3Za+vn6jeX+MHTsW3333Hfz8/PDOO+/wHQ4hhJA3NHToUOjp6WHfvn1lJm5PnDiB3NxcTJo06a22w3e/mM++FQB0795d0b+YNm0aWrRogXnz5mHPnj1YunQp78/P6yIiInDjxg0cO3YMH330EXx8fLBixQq+wypTbm4udHR0+A5Dye7du9G1a1c0adJE0RYQEIB///0Xa9euLXUm3tatW5GRkVHHUf7f2xzzvq2q9tUBWf9zzJgxeP78OZo1a1ZHERJS86hUAiEvyWs63r17Fz169IC2trbiS/LEiRMYNGgQrKysIBKJ4ODggDVr1kAikSit4/V6P/ISAj/88AN++eUXODg4QCQSoWPHjggICFC6b1m1qjiOw9y5c/H333+jVatWEIlEcHV1xdmzZ0vFf/nyZXTo0AGamppwcHDAzz//XK36VwKBAFKpVGl5gUBQo53CwsJCrFixAs2bN4dIJIKNjQ2++OKLUrUvfX190a1bNxgYGEBXVxctW7ZU7IvLly8rknTTpk1TnEpWE6fJ379/HwMGDIBYLIauri569+6NmzdvKi1TXFyMVatWwdHREZqamjA2Nka3bt3g6+urWCYhIQHTpk2DtbU1RCIRLC0tMWzYsEpPxbt27RpSUlLQp08fpfbw8HAIhUJ07ty51H3EYjE0NTWV2m7duoX+/ftDX18f2tra6NmzJ65fv660THZ2NhYsWAA7OzuIRCKYmZmhb9++Sqf6h4aGYtSoUbCwsICmpiasra0xfvx4ZGZmKpYpq8bt8+fPMWbMGBgZGUFbWxudO3fGqVOnlJaRnwp46NAhrF27FtbW1tDU1ETv3r0RFhZW4fMEyBLGFhYWlS5XXba2tlV6zxw5cgTm5uYYOXKkos3U1BRjx47FiRMnaqyeq/w9HBwcjLFjx0IsFsPY2Bjz589HQUGB0rIlJSVYs2aN4nPGzs4OX375ZZmxnDlzBj179oSenh7EYjE6duxYZrI5MDAQvXr1gra2Npo0aYLvvvuu1DJbtmyBq6srtLW1YWhoiA4dOpRaV/v27WFkZIQTJ0685TNCCCGET1paWhg5ciQuXryIpKSkUrfv27cPenp6GDp0KNLS0vDZZ5/Bzc0Nurq6EIvFGDBgAB4+fFjpdsrqwxYWFuLTTz+FqampYhsxMTGl7hsVFYXZs2ejZcuW0NLSgrGxMcaMGaPUD/vjjz8wZswYAECvXr1KlU0rq8ZtUlISPvjgA5ibm0NTUxPu7u7Ys2eP0jLV6ftXh/xHz4iIiDKfn927d4PjOOzatUvpfuvWrQPHcTh9+rSiLTg4GKNHj4aRkRE0NTXRoUOHtz6d3MfHB4aGhhg0aBBGjx4NHx+fMpfLyMjAp59+quh/WltbY/LkyUhJSVEsU1BQgJUrV6JFixbQ1NSEpaUlRo4cifDwcADl198tq1by1KlToauri/DwcAwcOBB6enqKHxWuXr2qOOVeflzy6aefIj8/v1Tc8n6YqakptLS00LJlS3z11VcAAD8/P3Ach+PHj5e63759+8BxHPz9/ct97goKCnD27Nky+/8A0LVr11L3EQqFpUa0x8bGYvr06TA3N1ccM77+egAq77dV5RihrBq3ubm5WLRoEWxsbCASidCyZUv88MMPYIwpLVed49uyVLWvDkDxnFL/k9R3qvMzHSEqIDU1FQMGDMD48ePx3nvvwdzcHICsc6erq4uFCxdCV1cXly5dwvLly5GVlYXvv/++0vXu27cP2dnZ+Oijj8BxHL777juMHDkSz58/r/QXy2vXruHYsWOYPXs29PT0sHnzZowaNQrR0dGKL+z79++jf//+sLS0xKpVqyCRSLB69epqlSWYNm0aPvroI/z888/46KOPqny/qpJKpRg6dCiuXbuGmTNnwtnZGY8fP8aPP/6IZ8+e4e+//wYAPH36FIMHD0br1q2xevVqiEQihIWFKRKPzs7OWL16NZYvX46ZM2eie/fuAFBqJGp1PX36FN27d4dYLMYXX3wBdXV1/Pzzz/Dy8sJ///2nqNe1cuVKeHt7Y8aMGfDw8EBWVhbu3LmDe/fuKSYUGzVqFJ4+fYpPPvkEdnZ2SEpKgq+vL6Kjoyss5H/jxg1wHIe2bdsqtdva2kIikeCvv/7ClClTKnwcly5dwoABA9C+fXusWLECAoEAu3fvxjvvvIOrV6/Cw8MDAPDxxx/jyJEjmDt3LlxcXJCamopr164hKCgI7dq1Q1FREfr164fCwkJ88sknsLCwQGxsLP79919kZGSUezp/YmIiPD09kZeXh3nz5sHY2Bh79uzB0KFDceTIEYwYMUJp+W+//RYCgQCfffYZMjMz8d1332HSpEm4detWhY+Tb/fv30e7du1KlYnw8PDAL7/8gmfPnsHNza3CdUgkEqUDFTktLa1SI0HGjh0LOzs7eHt74+bNm9i8eTPS09Px559/KpaZMWMG9uzZg9GjR2PRokW4desWvL29ERQUpHQw8ccff2D69OlwdXXF0qVLYWBggPv37+Ps2bOYOHGiYrn09HT0798fI0eOxNixY3HkyBEsXrwYbm5uGDBgAADZqXLz5s3D6NGjFcnkR48e4datW0rrAoB27dqV+gGBEEJI/TNp0iTs2bMHhw4dwty5cxXtaWlpOHfuHCZMmAAtLS08ffoUf//9N8aMGQN7e3skJibi559/Rs+ePREYGAgrK6tqbXfGjBnYu3cvJk6cCE9PT1y6dAmDBg0qtVxAQABu3LiB8ePHw9raGpGRkdixYwe8vLwQGBgIbW1t9OjRA/PmzcPmzZvx5ZdfKsqllVc2LT8/H15eXggLC8PcuXNhb2+Pw4cPY+rUqcjIyMD8+fOVln+bvn9Z5Em88spPTJs2DceOHcPChQvRt29f2NjY4PHjx1i1ahU++OADDBw4EICsvysf2blkyRLo6Ojg0KFDGD58OI4ePVqqn1ZVPj4+GDlyJDQ0NDBhwgTs2LEDAQEBSmdE5eTkoHv37ggKCsL06dPRrl07pKSk4OTJk4iJiYGJiQkkEgkGDx6MixcvYvz48Zg/fz6ys7Ph6+uLJ0+ewMHBodqxlZSUoF+/fujWrRt++OEHxdmUhw8fRl5eHmbNmgVjY2Pcvn0bW7ZsQUxMDA4fPqy4/6NHj9C9e3eoq6tj5syZsLOzQ3h4OP755x+sXbsWXl5esLGxgY+PT6nnz8fHBw4ODujSpUu58d29exdFRUVo166dUrutra1iHV27dq1wME1iYiI6d+6sSIqamprizJkz+OCDD5CVlYUFCxYAqFq/rbJjhLIwxjB06FD4+fnhgw8+QJs2bXDu3Dl8/vnniI2NLVU6ryrHtzVBX18fDg4OuH79Oj799NMaWy8hdY4R0gjNmTOHvf7y79mzJwPAdu7cWWr5vLy8Um0fffQR09bWZgUFBYq2KVOmMFtbW8X1iIgIBoAZGxuztLQ0RfuJEycYAPbPP/8o2lasWFEqJgBMQ0ODhYWFKdoePnzIALAtW7Yo2oYMGcK0tbVZbGysoi00NJSpqamVWmd5lixZwjQ0NJhQKGTHjh2r0n0qMmjQIKXn4q+//mICgYBdvXpVabmdO3cyAOz69euMMcZ+/PFHBoAlJyeXu+6AgAAGgO3evbtKsezevZsBYAEBAeUuM3z4cKahocHCw8MVbXFxcUxPT4/16NFD0ebu7s4GDRpU7nrS09MZAPb9999XKbZXvffee8zY2LhUe0JCAjM1NWUAmJOTE/v444/Zvn37WEZGhtJyUqmUOTo6sn79+jGpVKpoz8vLY/b29qxv376KNn19fTZnzpxyY7l//z4DwA4fPlxhzLa2tmzKlCmK6wsWLGAAlPZzdnY2s7e3Z3Z2dkwikTDGGPPz82MAmLOzMyssLFQs+9NPPzEA7PHjxxVu91XVfT1UlY6OjtJje/226dOnl2o/deoUA8DOnj1b4brlnzdlXT766CPFcvLPhaFDhyrdf/bs2QwAe/jwIWOMsQcPHjAAbMaMGUrLffbZZwwAu3TpEmOMsYyMDKanp8c6derE8vPzlZZ99TUjj+/PP/9UtBUWFjILCws2atQoRduwYcOYq6trhY9VbubMmUxLS6tKyxJCCFFdJSUlzNLSknXp0kWpXd6nO3fuHGOMsYKCAsX3vlxERAQTiURs9erVSm2vf4+/3i+Wf8/Nnj1baX0TJ05kANiKFSsUbWX12/39/Ut9rx0+fJgBYH5+fqWW79mzJ+vZs6fi+qZNmxgAtnfvXkVbUVER69KlC9PV1WVZWVlKj6Uqff+yyPtHu3btYsnJySwuLo6dOnWK2dnZMY7jFH3Zso4b4uPjmZGREevbty8rLCxkbdu2ZU2bNmWZmZmKZXr37s3c3NyUjl+kUinz9PRkjo6OpeIo67l53Z07dxgA5uvrq1iftbU1mz9/vtJyy5cvZwDKPM6Q90F27drFALCNGzeWu0x5sZX1OpoyZQoDwJYsWVJqfWW9Try9vRnHcSwqKkrR1qNHD6anp6fU9mo8jDG2dOlSJhKJlPrmSUlJTE1NTem1WZbffvutzL6vVCpV9MfMzc3ZhAkT2LZt20rFwRhjH3zwAbO0tGQpKSlK7ePHj2f6+vqKx1qVfltlxwiMlT7m/fvvvxkA9s033ygtN3r0aMZxnNKxbFWPb6uior663LvvvsucnZ2rtV5CVA2VSiDkFSKRCNOmTSvVrqWlpfg/OzsbKSkp6N69O/Ly8qo0o+e4ceNgaGiouC4fJVqV2WH79Omj9Oty69atIRaLFfeVSCS4cOEChg8frjRyoXnz5opRcZXZvHkzNm7ciOvXr2PChAkYP358qUkZRCIRli1bVqX1leXw4cNwdnaGk5MTUlJSFBf5qV9+fn4AAAMDAwCyU1rqqui9RCLB+fPnMXz4cKX6R5aWlpg4cSKuXbuGrKwsRXxPnz5FaGhomevS0tKChoYGLl++jPT09GrFkZqaqvQ6kTM3N8fDhw/x8ccfIz09HTt37sTEiRNhZmaGNWvWKE5BevDgAUJDQzFx4kSkpqYqnuPc3Fz07t0bV65cUTynBgYGuHXrFuLi4sqMRT6i9ty5c8jLy6vyYzh9+jQ8PDzQrVs3RZuuri5mzpyJyMhIBAYGKi0/bdo0pTpy1Xlv8Ck/P7/M+r7yshVlnWb3Ojs7O/j6+pa6yEdFvGrOnDlK1z/55BMAUJz6KP+7cOFCpeUWLVoEAIpSFb6+vsjOzsaSJUtKldh4/bQzXV1dpRq8Ghoa8PDwUNo3BgYGiImJqdLpn4aGhsjPz6/W64kQQojqEQqFGD9+PPz9/ZXKD+zbtw/m5ubo3bs3AFnfUX5mikQiQWpqqqIE1qunXVeF/Htu3rx5Su1lfWe+2m8vLi5GamoqmjdvDgMDg2pv99XtW1hYYMKECYo2dXV1zJs3Dzk5Ofjvv/+Uln+bvj8ATJ8+HaamprCyssKgQYOQm5uLPXv2oEOHDuXex8LCAtu2bYOvry+6d++OBw8eYNeuXRCLxQBkI6IvXbqEsWPHKo5nUlJSkJqain79+iE0NBSxsbFVfk7kfHx8YG5urphYl+M4jBs3DgcOHFAqK3f06FG4u7uXOapX3gc5evQoTExMFP2cspZ5E7NmzSrV9urrJDc3FykpKfD09ARjDPfv3wcAJCcn48qVK5g+fTqaNm1abjyTJ09GYWEhjhw5omg7ePAgSkpKKp3PIDU1FQBKHQNwHIdz587hm2++gaGhIfbv3485c+bA1tYW48aNU9S4ZYzh6NGjGDJkCBhjSsdZ/fr1Q2ZmpuJ1X5V+W2XHCGU5ffo0hEJhqffnokWLwBjDmTNnlNorO76tSYaGhmWe4UZIfUKJW0Je0aRJkzInI3j69ClGjBgBfX19iMVimJqaKr6EX633WZ7Xv+jlX8xVSey9fl/5/eX3TUpKQn5+fpkzt1ZlNtf8/HysWLECM2bMQIcOHRSn1Y8YMQLXrl0DIKt1WlRUpCgX8CZCQ0Px9OlTmJqaKl1atGiheByArKPbtWtXzJgxA+bm5hg/fjwOHTpUq0nc5ORk5OXloWXLlqVuc3Z2hlQqxYsXLwAAq1evRkZGBlq0aAE3Nzd8/vnnePTokWJ5kUiE9evX48yZMzA3N0ePHj3w3XffISEhoUqxsNfqQMlZWlpix44diI+PR0hICDZv3gxTU1MsX74cv//+OwAokslTpkwp9Tz/9ttvKCwsVLxev/vuOzx58gQ2Njbw8PDAypUrlTpL9vb2WLhwIX777TeYmJigX79+2LZtW6Wv96ioqHKfR/ntr3qb9waftLS0yqwdK687++rBQHl0dHTQp0+fUpeyZgh2dHRUuu7g4ACBQKA4YI6KioJAICj1nrewsICBgYHieZefatmqVatK47O2ti51kPTqZw8ALF68GLq6uvDw8ICjoyPmzJlTbjkE+Wv7bQ68CCGEqAZ5nVB5bcyYmBhcvXoV48ePh1AoBCArk/Xjjz/C0dERIpEIJiYmMDU1xaNHj6rUf36V/Hvu9VPly+pz5OfnY/ny5Ypam/LtZmRkVHu7r27f0dGxVImk2urfLF++HL6+vrh06RIePXqEuLg4vP/++5Xeb/z48Rg0aBBu376NDz/8UJFEB4CwsDAwxrBs2bJS/UT5RGJl1S2uiEQiwYEDB9CrVy9EREQgLCwMYWFh6NSpExITE3Hx4kXFsuHh4ZX2P8LDw9GyZcsanWNDTU0N1tbWpdqjo6MxdepUGBkZQVdXF6ampujZsyeA/x/fyfvGlcXt5OSEjh07KtX29fHxQefOnat0PAaUfQwgEonw1VdfISgoCHFxcdi/fz86d+6sVKYkOTkZGRkZ+OWXX0rtV/mAJPl+rUq/rbJjhLJERUXBysoKenp6Su1VfX8ApfuYNYUxRn1PUu9RjVtCXlFWsiUjIwM9e/aEWCzG6tWr4eDgAE1NTdy7dw+LFy+uUkJR3oF9XXlJupq6b1UEBQUhIyNDMfGVmpoajhw5gnfeeQeDBg2Cn58f9u/fryhM/6akUinc3NywcePGMm+3sbEBINsHV65cgZ+fH06dOoWzZ8/i4MGDeOedd3D+/Plyn4+60qNHD4SHh+PEiRM4f/48fvvtN/z444/YuXMnZsyYAUA2+mPIkCH4+++/ce7cOSxbtgze3t64dOlSqfq1rzI2Nq60w8JxHFq0aIEWLVpg0KBBcHR0hI+PD2bMmKF4LX7//fdo06ZNmfeXz746duxYdO/eHcePH8f58+fx/fffY/369Th27JhipPaGDRswdepUxWOdN2+eosZqWR3gN1Hbr+/aYmlpifj4+FLt8rbq1u2rrvI6oDXZMa3KvnF2dkZISAj+/fdfnD17FkePHsX27duxfPlyrFq1Sul+6enp0NbWrlJSmxBCiGpr3749nJycsH//fnz55ZfYv38/GGOKhC4gmxhr2bJlmD59OtasWQMjIyMIBAIsWLCgVn+Q/+STT7B7924sWLAAXbp0gb6+PjiOw/jx4+vsbK637d+4ubmVmqyqKlJTU3Hnzh0AsglGpVKpItksf+yfffYZ+vXrV+b9q5pklLt06RLi4+Nx4MABHDhwoNTtPj4+ePfdd6u1zsqU19d5fdJouVdHfr+6bN++fZGWlobFixfDyckJOjo6iI2NxdSpU9/odTJ58mTMnz8fMTExKCwsxM2bN7F169ZK7yev6Zqenl5h/9rS0hLjx4/HqFGj4OrqikOHDuGPP/5QxPree++VOxdG69atAVSt31aVY4S3VZf9//T0dJiYmNT4egmpS5S4JaQSly9fRmpqKo4dO4YePXoo2uWzuvLNzMwMmpqaCAsLK3VbWW2vk3d+5CNKAdlIwNOnT6Nbt27o168fCgoK8M0335R5anhVOTg44OHDh+jdu3elySWBQIDevXujd+/e2LhxI9atW4evvvoKfn5+6NOnT43/ampqagptbW2EhISUui04OBgCgUCRWAYAIyMjTJs2DdOmTUNOTg569OiBlStXKhK3gOzxLlq0CIsWLUJoaCjatGmDDRs2YO/eveXG4eTkBB8fH2RmZpY7+dermjVrBkNDQ0WyUD4KRSwWV6mzb2lpidmzZ2P27NlISkpCu3btsHbtWqVOmZubG9zc3PD111/jxo0b6Nq1K3bu3IlvvvmmzHXa2tqW+zzKb28I2rRpg6tXryodEAHArVu3oK2trRhJXlNCQ0Nhb2+vuB4WFgapVKqY7M7W1hZSqRShoaFKE6skJiYiIyND8bzLXyNPnjyp9sFZeXR0dDBu3DiMGzcORUVFGDlyJNauXYulS5cqlWOIiIgod9IXQggh9c+kSZOwbNkyPHr0CPv27YOjo6PSZFRHjhxBr169FGcGyWVkZFQ7kSL/npOPyJQrq89x5MgRTJkyBRs2bFC0FRQUKE4tl6tOf9LW1haPHj0q9b2vav2bOXPmIDs7G97e3li6dCk2bdqkKKMkLwemrq7+Rknhsvj4+MDMzAzbtm0rdduxY8dw/Phx7Ny5E1paWnBwcMCTJ08qXJ+DgwNu3bqF4uLicidxk49efn1/vj6qsyKPHz/Gs2fPsGfPHkyePFnR7uvrq7Sc/DmrLG5ANtp54cKF2L9/P/Lz86Guro5x48ZVej/5mVYRERGVTmwLyPZf69atERoaipSUFJiamkJPTw8SiaRK+7Uq/baqHCO8ytbWFhcuXEB2drbSqFtVeH9ERETA3d2dt+0TUhOoVAIhlZD/IvjqL4BFRUXYvn07XyEpEQqF6NOnD/7++2+lWkRhYWGl6gmVxc3NDebm5ti6davS6VHGxsbYvXs3UlJSkJ+fjyFDhrxVnGPHjkVsbCx+/fXXUrfl5+cjNzcXgKz+1uvko0flp6br6OgAKN1he1NCoRDvvvsuTpw4oVSrLTExEfv27UO3bt0U9cHkdajkdHV10bx5c0VseXl5itPl5RwcHKCnp1fmqfWv6tKlCxhjuHv3rlL7rVu3FM/Pq27fvo3U1FTFAUz79u3h4OCAH374ATk5OaWWT05OBiAbZfD6qYJmZmawsrJSxJiVlYWSkhKlZdzc3CAQCCp8HAMHDsTt27fh7++vaMvNzcUvv/wCOzs7uLi4VPQU1BujR49GYmIijh07pmhLSUnB4cOHMWTIkLf6kaMsrx8QbdmyBQAUHWj5bNGbNm1SWk4+wl0+6/a7774LPT09eHt7l3qdvskoh9ffDxoaGnBxcQFjDMXFxUq33bt3D56entXeBiGEENUkH127fPlyPHjwQGm0LSDrX73+3XL48OE3qqMq/77bvHmzUvvr33vlbXfLli2lRmRWpz85cOBAJCQk4ODBg4q2kpISbNmyBbq6uopT7Pl05MgRHDx4EN9++y2WLFmC8ePH4+uvv8azZ88AyPp6Xl5e+Pnnn8s8a0jeT6yq/Px8HDt2DIMHD8bo0aNLXebOnYvs7GycPHkSADBq1Cg8fPgQx48fL7Uu+f4aNWoUUlJSyhypKl/G1tYWQqEQV65cUbq9OsdmZR3fMcbw008/KS1namqKHj16YNeuXYiOji4zHjkTExMMGDAAe/fuhY+PD/r371+lHyjat28PDQ0NxUhpudDQ0FLbBGSvV39/fxgaGsLU1BRCoRCjRo3C0aNHy0wwv7pfK+u3VeUYoSwDBw6ERCIptd9+/PFHcBxXYyN1qyszMxPh4eHU/yT1Ho24JaQSnp6eMDQ0xJQpUzBv3jxwHIe//vpLpU7lXrlyJc6fP4+uXbti1qxZii/OVq1a4cGDBxXeV01NDVu3bsW4cePg5uaGjz76CLa2tggKCsKuXbvg5uaGmJgYDBs2DNevX1ckMKvr/fffx6FDh/Dxxx/Dz88PXbt2hUQiQXBwMA4dOoRz586hQ4cOWL16Na5cuYJBgwbB1tYWSUlJ2L59O6ytrRUTXjk4OMDAwAA7d+6Enp4edHR00KlTJ6URiWXZtWsXzp49W6p9/vz5+Oabb+Dr64tu3bph9uzZUFNTw88//4zCwkJ89913imVdXFzg5eWF9u3bw8jICHfu3MGRI0cUdaaePXuG3r17Y+zYsXBxcYGamhqOHz+OxMREjB8/vsL4unXrBmNjY1y4cEExaRsA/PXXX/Dx8cGIESMUnTv5/tHU1MSXX34JQDZS+bfffsOAAQPg6uqKadOmoUmTJoiNjYWfnx/EYjH++ecfZGdnw9raGqNHj4a7uzt0dXVx4cIFBAQEKEanXLp0CXPnzsWYMWPQokULlJSU4K+//lJ0DsuzZMkS7N+/HwMGDMC8efNgZGSEPXv2ICIiAkePHi11qtrb2Lp1KzIyMhQ/WPzzzz+IiYkBIDtNUj5q+Y8//sC0adOwe/duTJ06tcJ1/vPPP3j48CEA2YQmjx49UowuHjp0qOJUs9GjR6Nz586YNm0aAgMDYWJigu3bt0MikZQqEVCezMzMckdgvz6RRUREBIYOHYr+/fvD398fe/fuxcSJExUjCNzd3TFlyhT88ssvivIut2/fxp49ezB8+HDFhCFisRg//vgjZsyYgY4dO2LixIkwNDTEw4cPkZeXhz179lQpdrl3330XFhYW6Nq1K8zNzREUFIStW7di0KBBSiMu7t69i7S0NAwbNqxa6yeEEKK67O3t4enpiRMnTgBAqcTt4MGDsXr1akybNg2enp54/PgxfHx8lCaCrao2bdpgwoQJ2L59OzIzM+Hp6YmLFy+WeXbZ4MGD8ddff0FfXx8uLi7w9/fHhQsXFKekv7pOoVCI9evXIzMzEyKRCO+88w7MzMxKrXPmzJn4+eefMXXqVNy9exd2dnY4cuQIrl+/jk2bNpWq7VnXkpKSMGvWLPTq1UvRJ926dSv8/PwwdepUXLt2DQKBANu2bUO3bt3g5uaGDz/8EM2aNUNiYiL8/f0RExOj6ANVxcmTJ5GdnY2hQ4eWeXvnzp1hamoKHx8fjBs3Dp9//jmOHDmCMWPGYPr06Wjfvj3S0tJw8uRJ7Ny5E+7u7pg8eTL+/PNPLFy4ELdv30b37t2Rm5uLCxcuYPbs2Rg2bBj09fUxZswYbNmyBRzHwcHBAf/++2+16vM6OTnBwcEBn332GWJjYyEWi3H06NEyS5Zt3rwZ3bp1Q7t27TBz5kzY29sjMjISp06dKnWcNXnyZIwePRoAsGbNmirFoqmpiXfffRcXLlzA6tWrFe0PHz7ExIkTMWDAAHTv3h1GRkaIjY3Fnj17EBcXh02bNikS0N9++y38/PzQqVMnfPjhh3BxcUFaWhru3buHCxcuKAbGVNZvy8jIqPQYoSxDhgxBr1698NVXXyEyMhLu7u44f/48Tpw4gQULFpSqTf02qtpXB4ALFy6AMUb9T1L/MUIaoTlz5rDXX/49e/Zkrq6uZS5//fp11rlzZ6alpcWsrKzYF198wc6dO8cAMD8/P8VyU6ZMYba2torrERERDAD7/vvvS60TAFuxYoXi+ooVK0rFBIDNmTOn1H1tbW3ZlClTlNouXrzI2rZtyzQ0NJiDgwP77bff2KJFi5impmY5z4KyK1eusH79+jGxWMxEIhFr1aoV8/b2Znl5eezMmTNMIBCwd999lxUXF1dpfYMGDVJ6LhhjrKioiK1fv565uroykUjEDA0NWfv27dmqVatYZmam4nEMGzaMWVlZMQ0NDWZlZcUmTJjAnj17prSuEydOMBcXF6ampsYAsN27d5cby+7duxmAci8vXrxgjDF279491q9fP6arq8u0tbVZr1692I0bN5TW9c033zAPDw9mYGDAtLS0mJOTE1u7di0rKipijDGWkpLC5syZw5ycnJiOjg7T19dnnTp1YocOHarS8zZv3jzWvHlzpbZHjx6xzz//nLVr144ZGRkxNTU1ZmlpycaMGcPu3btXah33799nI0eOZMbGxkwkEjFbW1s2duxYdvHiRcYYY4WFhezzzz9n7u7uTE9Pj+no6DB3d3e2fft2xTqeP3/Opk+fzhwcHJimpiYzMjJivXr1YhcuXFDaVlmvxfDwcDZ69GhmYGDANDU1mYeHB/v333+VlvHz82MA2OHDh5Xa5e+Zivbnq9sub59GREQoltuyZQsDwM6ePVvpOqdMmVLuOl+PKS0tjX3wwQfM2NiYaWtrs549e7KAgIBKt8GY7POmoteknPxzITAwkI0ePZrp6ekxQ0NDNnfuXJafn6+0zuLiYrZq1Spmb2/P1NXVmY2NDVu6dCkrKCgotf2TJ08yT09PpqWlxcRiMfPw8GD79+9Xiq+sz8PXP+N+/vln1qNHD8VrzcHBgX3++eeK97Pc4sWLWdOmTZlUKq3S80MIIaR+2LZtGwPAPDw8St1WUFDAFi1axCwtLZmWlhbr2rUr8/f3Zz179mQ9e/ZULFfWd39Z/eL8/Hw2b948ZmxszHR0dNiQIUPYixcvSvWp09PT2bRp05iJiQnT1dVl/fr1Y8HBwWX2WX799VfWrFkzJhQKlfr1r8fIGGOJiYmK9WpoaDA3N7dSfYPq9P3LUl7/6HWvPz8jR45kenp6LDIyUmm5EydOMABs/fr1irbw8HA2efJkZmFhwdTV1VmTJk3Y4MGD2ZEjR0rF8epxzuuGDBnCNDU1WW5ubrnLTJ06lamrq7OUlBTGGGOpqals7ty5rEmTJkxDQ4NZW1uzKVOmKG5njLG8vDz21VdfKfozFhYWbPTo0Sw8PFyxTHJyMhs1ahTT1tZmhoaG7KOPPmJPnjwp9TqaMmUK09HRKTO2wMBA1qdPH6arq8tMTEzYhx9+yB4+fFhmn+/JkydsxIgRir5ty5Yt2bJly0qts7CwkBkaGjJ9ff1S/bSKHDt2jHEcx6KjoxVtiYmJ7Ntvv2U9e/ZklpaWTE1NjRkaGrJ33nlHaV+9uvycOXOYjY2N4nnr3bs3++WXXxTLVNZvq8oxgvx5ff04Lzs7m3366afMysqKqaurM0dHR/b999+X6vtV5/i2LNXpq48bN45169at0nUSouo4xlRo2CAhpEYNHz4cT58+RWhoKN+hkCp6/vw5nJyccObMGaWZgMmbGzt2LCIjI3H79m2+Q6m2lStXYtWqVUhOTq63EysUFhbCzs4OS5Yswfz58/kOhxBCCCGkVpSUlMDKygpDhgwpVdu5IhKJBC4uLhg7dmyVR+qSiiUkJMDe3h4HDhygEbek3qMat4Q0EPn5+UrXQ0NDcfr0aXh5efETEHkjzZo1wwcffIBvv/2W71AaBMYYLl++XO5kaqT27d69G+rq6vj444/5DoUQQgghpNb8/fffSE5OVprwrCqEQiFWr16Nbdu2lTlPBam+TZs2wc3NjZK2pEGgEbeENBCWlpaYOnUqmjVrhqioKOzYsQOFhYW4f/8+HB0d+Q6PEPIGGsKIW0IIIYSQhuzWrVt49OgR1qxZAxMTE9y7d4/vkAghDQhNTkZIA9G/f3/s378fCQkJEIlE6NKlC9atW0dJW0IIIYQQQgipJTt27MDevXvRpk0b/PHHH3yHQwhpYGjELSGEEEIIIZW4cuUKvv/+e9y9exfx8fE4fvw4hg8fXuF9Ll++jIULF+Lp06ewsbHB119/jalTp9ZJvIQQQgghpP6jGreEEEIIIYRUIjc3F+7u7ti2bVuVlo+IiMCgQYPQq1cvPHjwAAsWLMCMGTNw7ty5Wo6UEEIIIYQ0FDTilhBCCCGEkGrgOK7SEbeLFy/GqVOn8OTJE0Xb+PHjkZGRgbNnz9ZBlIQQQgghpL6r1zVupVIp4uLioKenB47j+A6HEEIIIYTUAMYYsrOzYWVlBYGgfp4g5u/vjz59+ii19evXDwsWLCj3PoWFhSgsLFRcl0qlSEtLg7GxMfV1CSGEEEIaiOr0det14jYuLg42NjZ8h0EIIYQQQmrBixcvYG1tzXcYbyQhIQHm5uZKbebm5sjKykJ+fj60tLRK3cfb2xurVq2qqxAJIYQQQgiPqtLXrdeJWz09PQCyByoWi3mOpnGQSqVITk6GqalpvR0BQ94c7f/GjfZ/40X7vnHjY/9nZWXBxsZG0ddrLJYuXYqFCxcqrmdmZqJp06aIioqivm4dkUqlSElJgYmJCX3eNUK0/xs32v+NF+37xo2P/Z+VlQVbW9sq9XXrdeJWfsqYWCymzmwdkUqlKCgogFgspg+0Roj2f+NG+7/xon3fuPG5/+tzeQALCwskJiYqtSUmJkIsFpc52hYARCIRRCJRqXYDAwPq69YRqVSKoqIiGBgY0OddI0T7v3Gj/d940b5v3PjY//LtVKWvS69IQgghhBBCaliXLl1w8eJFpTZfX1906dKFp4gIIYQQQkh9Q4lbQgghhBBCKpGTk4MHDx7gwYMHAICIiAg8ePAA0dHRAGRlDiZPnqxY/uOPP8bz58/xxRdfIDg4GNu3b8ehQ4fw6aef8hE+IYQQQgiphyhxSwghhBBCSCXu3LmDtm3bom3btgCAhQsXom3btli+fDkAID4+XpHEBQB7e3ucOnUKvr6+cHd3x4YNG/Dbb7+hX79+vMRPCCGEEELqn3pd45YQQgghjZdEIkFxcTHfYTR4UqkUxcXFKCgoqLG6X+rq6hAKhTWyrrri5eUFxli5t//xxx9l3uf+/fu1GBUhhBBCCGnIKHFLCCGEkHqFMYaEhARkZGTwHUqjwBiDVCpFdnZ2jU4WZmBgAAsLi3o9ARkhhBBCCCG1iRK3hBBCCKlX5ElbMzMzaGtrU+KvljHGUFJSAjU1tRp5rhljyMvLQ1JSEgDA0tLyrddJCCGEEEJIQ0SJW1JlEinD46hURMSmwT5fCDdbEwgFdLBMCCGk7kgkEkXS1tjYmO9wGoWaTtwCgJaWFgAgKSkJZmZm9a5sAiGEEEIIIXWBJicjVXItKB6TN1/C4r23sdMvAov33sbkzZdwLSie79AIIYQ0IvKattra2jxHQt6WfB9SnWLVcjPqMUbsWoSbUY/5DoUXN6Me48OT3o328RNCCGl8Gvt3v6qjxC2p1LWgeKw5cg8p2QVK7SnZBVhz5B4lbwkhhNQ5Ko9Q/9E+VD2MMWy+sh/P02Kx+cr+Cidja4gYY9h67SCisxKx9drBRvf4CSGEND6N/bu/PqBSCaRCEinDjnOBFS6z83wgurS0oLIJhBBCCCH12NXn9/E08TkA4Gnic2y/cRhOZnb8BlWHgpMilR7/jchH6GrvznNUhBBCSO25EfmIvvtUHCVuSYWeRKeVGmn7uuSsAjyJToO7HdUaJIQQQuqSnZ0dFixYgAULFvC6DlL/Mcaw7fohpbZf/I/xFA3/OHDYdu0gPO1a0+hwQgghDRJjDN/7/anUtvnqfvruUzGUuCUVSsupOGlb3eUIIYQQVSGRMjyJTkNaTgGMdDXRqqlRrZ09Ulnnd8WKFVi5cmW11xsQEAAdHZ03jIqQ/7sR+QjBSZGl2psZW0Os2fBfY1kFuXieGqO4zsDwNPE5Ljy7hb4tO/MYGSGEEFLzGGPwvrgbEWmxSu3BSZE4+MAX49u+y1Nk5HWUuCUVMtLVrNHlCCGEEFVwLSgeO84FKp1VYqKniVn9XNDN2bLGtxcf//968AcPHsTy5csREhKiaNPV1VX8zxiDRCKBmlrl3TRTU9OaDZQ0SowxbLt2EAJOACmTKtoFnABaahr4Y/zKBj3yhjGGSXu/KvX4AWDpqS0w1jFAO2snnqIjhBBCalZeUQFWn/8FZ4JvlHn7txd3QV0oxKjWves4MlIWmpyMVKhVUyOY6FWclDUVy0YpEUIIIfUBH5NuWlhYKC76+vrgOE5xPTg4GHp6ejhz5gzat28PkUiEa9euITw8HMOGDYO5uTl0dXXRsWNHXLhwQWm9dnZ22LRpk+I6x3H47bffMGLECGhra8PR0REnT56sVqzR0dEYNmwYdHV1IRaLMW7cOCQmJipuf/jwIXr16gU9PT2IxWK0b98ed+7cAQBERUVhyJAhMDQ0hI6ODlxdXXH69Ok3f+JInZDXt3s9aSllUkW9u4asvMcPAMVSCaYfWImf/Y9CIi19OyGEEFKfRKTGYpLP1+UmbQGAAVh9/lcsP7sT+cWFdRccKRMlbkmFhAIOs/q5VLjMx++60MRkhBBCeMMYQ0FRSZUuuQXF2H7uaYXr23EuELkFxVVaX03OvLtkyRJ8++23CAoKQuvWrZGTk4OBAwfi4sWLuH//Pvr3748hQ4YgOjq6wvWsWrUKY8eOxaNHjzBw4EBMmjQJaWlpVYpBKpVi2LBhSEtLw3///QdfX188f/4ckyZNUiwzadIkWFtbIyAgAHfv3sWSJUugrq4OAJgzZw4KCwtx5coVPH78GOvXr1caTUxUj3y0LYey+3LyWq8NdZbpyh4/IDuA3X79MGYeWoPE7NS6C44QQgipQedDbmLi3q/wPDUGagJhBd98MieeXMbkfcsQlV7zgxpI1VGpBFKpbs6WaGEpxrP4LKV2HZEaFg5pXSunlBJCCCFVVVgswbD152psfSnZBRj5/fkqLXticT9oatRMd2r16tXo27ev4rqRkRHc3f8/q++aNWtw/PhxnDx5EnPnzi13PVOnTsWECRMAAOvWrcPmzZtx+/Zt9O/fv9IYLl68iMePHyMiIgI2NjYAgD179qBVq1YICAiAh4cHoqOj8fnnn8PJSXbquKOjo+L+0dHRGDVqFNzc3AAAzZo1q8YzQPhQLClBQnYqGMpOzDIwJGSnolhSAg019TqOrvZV9vgBQFdDGxKpBHdigjBmz2Ks7PcR3nHsWIdREkIIIW+uWFKCTVf2Ye9d2VlQ7aydEJEai/T87HLvI9bUgZAT4llyNCb+9SVW9Z+FPi086ipk8gpK3JJK5RYWIyIpBwDw6aBWCHgWh2uhabAy1KakLSGEEFJDOnTooHQ9JycHK1euxKlTpxAfH4+SkhLk5+dXOuK2devWiv91dHQgFouRlJRUpRiCgoJgY2OjSNoCgIuLCwwMDBAUFAQPDw8sXLgQM2bMwF9//YU+ffpgzJgxcHBwAADMmzcPs2bNwvnz59GnTx+MGjVKKR6iejTU1LHvvbUVHrwZaYsbZNIWKP34pVIp0tLSYGRkBIFAdnKikbYYBSVFWPLvFgQmPsenJzZgXJt3sbDne9BU1+AzfEIIIaRCidlp+OLfn/AgVja3wjSPoZjbbRxSctIr/e4HOCz+9yfcjw3BopMbMbnDIMzrPgHqQkol1iV6tkmlbj1LQrFEChtjHfR1t0YzQwFuhKUjNCELsam5aGLc8GcaJqSxk0gZHkelIiI2Dfb5QrjZmlCJFKIyROpCnFjcr0rLPo5Ow9f7Aypd7psJHeFWhfrtInVhlbZbFTo6yt+nn332GXx9ffHDDz+gefPm0NLSwujRo1FUVFTheuRlC+Q4joO0Bmtzrly5EhMnTsSpU6dw5swZrFixAgcOHMCIESMwY8YM9OvXD6dOncL58+fh7e2NDRs24JNPPqmx7ZOaZyE2gYXYhO8wePPq45dKpUjidGBmZqZI3Mr9OXE1tlw9gD13/sXBB+dxNyYI6wfPQ3MTm7JWSwghhPDqdvRTLP53M9LyMqEn0saaAbPRq7lsoEBVv/t/HbsMm6/ux593TuHPO6fwOD4M3w2ZDzNdmueorlCNW1Kpqy8naenubAmO4yDWUkdbe2MAgN/TOD5DI4TUgWtB8Zi8+RIW772NnX4RWLz3NiZvvlQrEzgR8iY4joOmhlqVLu2amVZp0s12zUyrtD6Oq70fMK5fv46pU6dixIgRcHNzg4WFBSIjI2ttewDg7OyMFy9e4MWLF4q2wMBAZGRkwMXl/zXvW7RogU8//RTnz5/HyJEjsXv3bsVtNjY2+Pjjj3Hs2DEsWrQIv/76a63GTEhdUReqYaHXe9g+aimMtPURlvICk/Z+hSMPLzTYGsCEEELqH8YYdt06gY8Of4O0vEy0MG2Kfe+tUyRtq0NdqIZFXu9jw9CF0NXQwv3YEIz7cyluRT+phchJWShxSyqUV1iCgLBkAEB3l/+XRejpKvv/8pNY6qgS0oBdC4rHmiP3kJJdoNSekl2ANUfuUfKW1Dv1adJNR0dHHDt2DA8ePMDDhw8xceLEGh05W5Y+ffrAzc0NkyZNwr1793D79m1MmTIFPXr0QIcOHZCfn4+5c+fi8uXLiIqKwvXr1xEQEABnZ2cAwIIFC3Du3DlERETg3r178PPzU9xGSEPR1d4dR6ash6edOwpKirDG9zd8dvJHZBXk8B0aIYSQRi6rIBefntiAn67uh5QxDHXtgT8nrkFTQ4u3Wm+fFh7Y9/46tDBtirS8THx8eC1+u3kcUla7fVNCiVtSiduhsjIJTYx0YG+mp2j3bGkOdaEAL1Jz8Twxq4I1EELqK4mUYce5wAqX2Xk+EBIp/XhD6pduzpZYNrpdqZG3pmJNLBvdTmXqt2/cuBGGhobw9PTEkCFD0K9fP7Rr165Wt8lxHE6cOAFDQ0P06NEDffr0QbNmzeDj4wMAEAqFSE1NxeTJk9GiRQuMHTsWAwYMwKpVqwAAEokEc+bMgbOzM/r3748WLVpg+/bttRozIXww1jHAtlGLsbDne1ATCHEh9DbG7FmMezHBfIdGCCGkkQpOisTEvV/CL+wONITqWP7uh1jdfxa01EU1sn5bQ0v8NfEbDGvlBSlj2HLtIOYd+x6Z+fTDZW3iWD0eLpmVlQV9fX1kZmZCLBbzHU6DtObwXVwLTsC4rg6Y/o6TrO5XUhLMzMzwzdH7uB6cgDFdmmFGHxpN0xi8uv9fr/tGGp6Hkan44q+blS733fud4W5nXAcREb6o0nu/oKAAERERsLe3h6ZmxSUPKiORMjyJTkNaTgGMdDXRqqmRSoy0VTWMMZSUlEBNrWZLQ1S0L6mPJ0PPQ917k8+7pwnhWPLvFkRnJEDAcfioy2h82HkEhNRXqndU6fuO1D3a/41XQ9j3J55cxtoLv6OwpBhWYlNsGPopXCya1dr2jj/2g/fFXS+3Z4Ifhn4KVwuHWttebeJj/1enj1c/X5GkThQUlSAgTDYLdY8yRh/1amUFALj8NA7S+pv/J4SUIy2noPKFqrEcIapGKODgbmeMXq2awN3OmJK2hJA34mrhgAOTvTHYpTukjGHHjcP48NAaJGan8h0aIYSQBq6wpAirz/+C5Wd3orCkGN3t2+LA+961mrQFgBFuvfDnxDWwMTBHXFYKpuxfgUMPzlMpzVpAiVtSrtthySgskcLSUBsOFqV/AfBobgZtDTUkZxUg8EU6DxESQmqTkW7VRjNWdTlCCCGkodLR0MLagXPwzYDZ0FbXxN2YIIzZsxiXQgP4Do0QQkgDFZORhCn7V+Doo0vgwGFO17HYPPJz6Gvp1sn2nczsXk561hHFkhKsvbALX57ehrwiGthTkyhxS8p19eWkQ92dLcs8NVKkLoSnkzkA2ahbQkjD0qqpUakaoK8zFctOLyeEEEIIMMS1Bw5O/hau5s2QWZCDT09swFrf31FQXMR3aIQQQhqQK+H3MGHvUgQlRsBASw87Ri/FzC4jIeDqNs0n1tTBj8MWYmHPSRByApwOuoZJPl8jIjW2TuNoyChxS8pUUCzBrVBZmYTuzuXPPujlKiuXcCUwHpJanumaEFK3hAIOs/q5VLjMx++60OnlhBBCyCuaGlpgz8TVmNpxCADg0ENfTPL5CmEpL3iOjBBCSH0nkUqx9dpBfHL8O2QV5MLNsjkOvu+NLnateYuJ4zhM6TgEv41bBlMdQzxPjcHEvV/hbPAN3mJqSChxS8p0JywJhcUSmBtowdFSv9zl2tqbQF9bA5l5RbgfQXW8CGlo2juYlpmY1VQXYtnoduhWRv1rQgghpLFTF6rh056TsGP0Uhhr6yMs5QUm7v0Shx9eoPp/hBBC3khaXhZmH/XGrzePAwDGt+2H3eNXwkJswnNkMu2snXFgsjc62rgir7gAi//djG8v/oFiSQnfodVrlLglZboalACg/DIJcmpCAXq4yBI3fk9oKDwhDc3d8GRIpAwWBlr4dlJHDG4jH4HP0LaZanQQCCGEEFXlaeeOw1PWw9POHYUlxfjG9zcsOvkjMvNz+A6NEEJIPfIoLhTj/1qCm1GPoakmgveguVjaexrUhWp8h6bERMcAO8d8iQ86DQMA7L9/FtMOrER8VgrPkdVflLglpRQWS3ArNBFAxWUS5OTlEm4EJ6KwWFKrsRFC6pb/M9lngWdLC7jbmWB0ByvYmOigoFgK34cxPEdHCCGEqD5jHQNsG7UYC3u+BzWBEBdDb2Psn4txLyaI79AIIYSoOMYY9t+TJT8Ts9NgZ2QFn/e+wUDnbnyHVi41gRDzuk/A5hGfQ0+kg8fxYRj/11Jcj3jId2j1EiVuSSl3nycjv0gCU7EmWloZVLq8i40hTMWayCsqwe2wpNoPkBBSJyRSqaLWdZeWsokIOY7D0Pa2AIB/AqIgpdM9CSGEkEoJOAGmdByMPyeuRlMDCyRkp+KDg6ux88ZRmieCEEJImfKKCrD01BZ8e+kPlEgl6NuiE/a9txbNTWz4Dq1Kejq0x4H3veFsbo+M/GzMOfottl8/TN971USJW1LK1cB4AJWXSZATcJxi1O3lJ3G1GhshpO48fZGO7Pxi6Gmpw9XGUNHeu3UTaIvUEJOWi3vP6ZQXQgghpKpcLRxwYLI3hrj0gJQx7LhxGB8eWoMEOoWUEELIKyJSYzHJ52ucCb4BNYEQn/eajO+HLICOhhbfoVWLtYEZ9kxYhTHufcDA8LP/Ucw59i3S8rL4Dq3eoMQtUVJUIsHNZ7IRdt2qUCZBrlcrWeL2VmgScguKayU2QkjduhEiK5PQ2dEcQsH/vy60NNTwrrs1AOBEQCQfoRFCqikyMhIcx+HBgwd8h0JIo6ejoYVvBs7G2oFzoK2uibsxQRjz52JcDL3Nd2iEEEJUwLlgf0zc+xWep8bAVMcQv45dhvfaD6zSwDpVJFLTwNd9Z+CbAbOhqaYB/8hHGP/XEjyMe8Z3aPUCJW6JknvPU5BXVAITPU04WxtWfoeXmpmLYWOsg2KJVJHsIYTUX4wx+IfIJimUl0l41dAOdgCAgNAkxKXl1mVohLy9jGQgLrz8S0ZyjW+S47gKLytXrnyrdf/99981FishpG4MdumOg5O/hauFA7IKcrHwxEas9f0dBcVFfIdGCCGEB8WSEnzvtwdf/PsT8ooL0MHGBQcne6OdtRPfodWIIa49sHfSWtgaWiIxOw3TD6yCz93TYFR+r0KqNf0c4d3VIFmZhG7OFhBU49ccjuPg1aoJ/vrvGfyexqHvy9F4hJD6KTIpGwkZ+dBQE6B9M5NStzcx1kEHB1PcCU/GP3ej8FFfFx6iJOQNZCQDW+cAJRWcHaKmDszdBhiY1thm4+PjFf8fPHgQy5cvR0hIiKJNV1e3xrZFCKk/mhpaYM+EVdh67SD+CPgHhx764m5MENYPng9H0/pRw5AQQsjbS8xOwxf//oQHsbL+4TSPoZjbbRzUBEKeI6tZjqY22P/+Oqw89zPOh9zEd35/4kHsM6zoNxO6Im2+w1NJNOKWKBRLpPB/OVq2u7Nlte/f62Wd2/vPU5CRW1ijsRFC6pZ85HxbexNoapT9G9+wjnYAgPMPXqCgqKSuQiPk7eRlVZy0BWS313DdLQsLC8VFX18fHMcptR04cADOzs7Q1NSEk5MTtm/frrhvUVER5s6dC0tLS2hqasLW1hbe3t4AADs7OwDAiBEjwHGc4npV/Pfff/Dw8IBIJIKlpSWWLFmCkpL/v5ePHDkCNzc3aGtrw8LCAn379kVurmyE/eXLl+Hh4QEdHR0YGBiga9euiIqKevsnipBGSF2ohk97TsKO0UthrK2P8NQYTPL5Eoce+NIoJEIIaQRuRT/B+L+W4kFsCPRE2tg0/DMs6DGxwSVt5XQ0tPDd4Pn44p0pUBMIcf7ZTUzc+xVCk1/wHZpKosQtUbj/PAW5hSUw0hXBxabqZRLkmhjroIWlPqSM4UpgfOV3IISoLP9nssStZxllEuQ6NDeFpaE2cgpKcPFxbF2FRkj5igrKv7zNqcflrbOG+Pj4YPny5Vi7di2CgoKwbt06LFu2DHv27AEAbN68GSdPnsShQ4cQEhICHx8fRYI2ICAAALB7927Ex8crrlcmNjYWAwcORMeOHfHw4UPs2LEDv//+O7755hsAshHCEyZMwPTp0xEYGAhfX1+MGDECjDGUlJRg+PDh6NmzJx49egR/f3/MnDmz3tZdI0RVeNq54/CU79DVzh2FJcVYe+F3LDr5IzLzc/gOjRBCSC2QMil+v3UCHx9ei7S8TLQwbYp9761Dr+Yd+A6t1nEch0ntBmDX+BUw1zNCVHo83vP5Cv88vcJ3aCqHSiUQBXmZhK5O1SuT8CqvVlZ4Fp+Jy0/jMPTlaDxCSP2SnJWP0PhMcAA6OZafuBVwHIZ2sMXPvkE4ERCJge2aUuKG8GvdhPJvc2wPTPr6zda76aOyR+CuPP5m63vNihUrsGHDBowcORIAYG9vj8DAQPz888+YMmUKoqOj4ejoiG7duoHjONja2irua2oqK+dgYGAAC4uqTyq6fft22NjYYOvWreA4Dk5OToiLi8PixYuxfPlyxMfHo6SkBCNHjkTTpk1hbW2Ntm3bguM4pKWlITMzE4MHD4aDgwMAwNnZuUaeC0IaO2MdfWwdtRh7757BT1f24WLobTxNCIf3oLloZ03vM0IIaSiyCnKx7Mx2XA6/CwAY6toDX/b5AFrqIp4jq1vuVi1w4P1vsfTUFtyMeoyvz2zHg7hn+KLXZIjUNPgOTyXQiFsCACh5ZVKxHi7VL5Mg19PFChyApy/SkZSZX0PREULq0s2Xo22drQ1hqFtxx+HdNjYQqQsRlZyDR1FpdREeIQ1Kbm4uwsPD8cEHH0BXV1dx+eabbxAeHg4AmDp1Kh48eICWLVti3rx5OH/+/FtvNygoCF26dFH6saVr167IyclBTEwM3N3d0bt3b7i5uWHs2LH4/fffkZ6eDgAwMjLC1KlT0a9fPwwZMgQ//fSTUg1fQsjbEXACTO4wCH9NXIOmBhZIyE7FBwdXY+eNIyiRSvgOjxBCyFsKTorEhL+W4nL4XWgI1bH83Q+xuv+sRpe0lTPSFmP7qKX4uMsocOBw5OEFTN2/EjEZSXyHphJoxC0BADyITEVOQTEMdURwtTF64/WYiDXhZmuER1FpuPw0DmM9HWowSkJIXZD/iNOlgjIJcrqa6ujTuglO3Y3GiYBIuNsZ13Z4hJTvy/3l38a9xW/VC35+8/tWIidHdgr0r7/+ik6dOindJhTK6pq1a9cOEREROHPmDC5cuICxY8eiT58+OHLkSK3FJRQK4evrixs3buDcuXPYtm0bli9fjlu3bsHe3h67d+/GvHnzcPbsWRw8eBBff/01fH190blz51qLiZDGxsWiGQ5M9sa3F3fj5NMr2HHjCG5FP8G6gXNhKS49cSghhBDV9/fjy1h38XcUlhTDSmyKDUM/hYtFM77D4p1QIMCsrmPQ2qoFvjy9FYGJzzH+r6X4ZuBseDm05zs8XtGIWwLg1TIJ5hAK3u5U516tmgAA/J7EvXVchJC6lVtQjEeRqQAqrm/7qqEd7AAA/iEJNNKe8EtDs/yL+lucalXeOmuAubk5rKys8Pz5czRv3lzpYm9vr1hOLBZj3Lhx+PXXX3Hw4EEcPXoUaWmyUe7q6uqQSKo3Cs/Z2Rn+/v5KEx9dv34denp6sLa2BiCrPda1a1esWrUKAQEB0NDQwPHj/y8P0bZtWyxduhQ3btxAq1atsG/fvrd5KgghZdDR0MKaAbOxbuBc6Gho4V5MMMb+uRgXnt3mOzRCCCHVUFhShFXnfsGKcztRWFKM7vZtceB9b0ravqarvTsOvu8NN8vmyC7Mxfzj3+OnK/sb9RknlLglsjIJwQkAgO7Ob14mQa6bkwWEAg7PE7MQnZz91usjhNSdgLBklEgZbIx1YG2sW6X72Jnpwd3OGFIG/HuXZpUnpLpWrVoFb29vbN68Gc+ePcPjx4+xe/dubNy4EQCwceNG7N+/H8HBwXj27BkOHz4MCwsLGBgYAADs7Oxw8eJFJCQkKMoZVGb27Nl48eIFPvnkEwQHB+PEiRNYsWIFFi5cCIFAgFu3bmHdunW4c+cOoqOjcfz4cSQnJ8PZ2RkRERFYunQp/P39ERUVhfPnzyM0NJTq3BJSiwa5dMPByd5wtXBAVkEuFp3ciG98f0PB20y8SAghpE7EZCRhyv4VOPb4EjhwmNN1LDaP/Bz6WlU73mpsLMQm2D1+JSa26w8A2HX7BD46vBYpuRn8BsYTStwSPIpKQ1Z+MfS1NeBm++ZlEuTE2hpo7yCbLMXvKY26JaQ+8X8mL5NQ9UmOAGDYy8kIz95/gaKSxvtrKKkHtMWAmnrFy6ipy5arIzNmzMBvv/2G3bt3w83NDT179sQff/yhGHGrp6eH7777Dh06dEDHjh0RGRmJ06dPQyCQdeM2bNgAX19f2NjYoG3btlXaZpMmTXD69Gncvn0b7u7u+Pjjj/HBBx/g669lE7iJxWJcuXIFAwcORMuWLbFixQr88MMPGDBgALS1tREcHIxRo0ahRYsWmDlzJubMmYOPPvqodp4gQggAwMbAAnsmrMI0j6EAgMMPL2Di3i8RmvyC58gIIYSU50r4PYz/aymCEiNgqKWHHaOXYmaXkRC8TRmvRkBdqIbF70zF+sHzoK2uiTsvAjH+z6W4FxPEd2h1jmOvniNXz2RlZUFfXx+ZmZkQi+vuAKuh+enUY5y+F42B7Zpi/iC3CpeVSqVISkqCmZmZ4oCxLJcex2L93w9gZaSNXbO9aKb5BqKq+5/UT8USKcZu8EVeYQl+nOYJF2tDpdsr2v8SqRRTt15GUmY+Fg1tjXfdbeoydFLLVOm9X1BQgIiICNjb20NT8w3LFWQkA3lZ5d+uLQYMTN9s3Q0QYwwlJSVQU1Or0e/zivYl9fFk6Hmoe6r0eVcR/8hH+Or0NqTmZUKkpo7PvN7HGPe+1Od+S/Vl/5PaQfu/8aqNfS+RSrHjxmH8elNWZsrNsjl+GLIAFlSjvNoiUmOx6OSPCE+NgZATYH6PCZjcYXCNfefx8d6vTh+PPo0aOYlUiusvyyR0c67eCLuKdGlpDpGaAHFpeXgWn1lj6yWE1J5HkanIKyyBoY4ITk0MqnVfoUCAwe2bAgBO3I5EPf5NkDQGBqaAlUP5F0raEkJUXBe71jg85Tt0tXNHYUkx1l7YhYUnNyIzP4fv0AghpNFLy8vCrCPrFEnb8W37Yff4lZS0fUP2xk2wd9I3GOjcDRImxcb/fPDpiY3IKsjlO7Q6QYnbRu5xdBoy84og1lKHu23NzQavpaGGzi1kExtdpknKCKkX5GUSOrcwg+ANfr3s37Yp1IUChCVkISg2o4ajI4QQQsirjHX0sXXUYnzm9T7UBEJcCg3AmD+/wN0Xje80UkIIURUP455h/F9LcCv6CTTVRPAeNBdLe0+DulCN79DqNW0NTawbOAdf9fkA6kI1+IUFYOLeLxGcFMl3aLWO18StRCLBsmXLYG9vDy0tLTg4OGDNmjU0UqsOXQ2MBwB4trSAmrBmXw5erawAAP8FxkEipX1KiCpjjME/RF7f1vyN1qGvrYFeL9/3J25H1lRohBBCCCmHgBPg/Q6DsHfSN2hqaIHE7DTMOLQaO64fbtQzcBNCSF1jjGHfvbOYfmAVErPTYGdkBZ/3ZKNESc3gOA5j2/TFngmrYCU2wYuMRLzvswzHHl/iO7RaxWvidv369dixYwe2bt2KoKAgrF+/Ht999x22bNnCZ1iNhkTKcD1Ylqjp7mJZ4+vv4GAKXU01pGYX4kl0Wo2vnxBSc0LjM5GSXQBNdSHa2r/5KTxDX05SdjUoHqnZBTUUHSGEEEIq4mxuj4Pvf4uhrj0hZQw7/Y9ixsHViM9K4Ts0Qghp8PKKCrDk1Basv/QHSqQS9G3RCfveW4vmJjTvR21wtXDAgfe/RfdmbVEkKcaqc79g+dmdyC8u5Du0WsFr4vbGjRsYNmwYBg0aBDs7O4wePRrvvvsubt++zWdYjcbTF2lIzy2ErqY62tjVXJkEOQ01Ibo5yRLCfk9ia3z9hJCaIx9t28HBFBpqwjdej6OlPlysDSGRMpy+F11T4RFCCCGkEtoamlgzYBa8B82FjoYW7seGYMyexbjw7BbfoRFCSIP1PDUWk/Z+hbPBN6AmEOLzXpPx/ZAF0NHQ4ju0Bk1fSxebR3yOed3HQ8BxOPHkMibvW4ao9Hi+Q6txvCZuPT09cfHiRTx79gwA8PDhQ1y7dg0DBgzgM6xG42qQ7AXdpaV5jZdJkJOXS7galIBiibRWtkEIeXvy+rZvWibhVcNejro9fS+a3vek1kil9Nqq72gfElI7Bjp3w6HJ36KVhQOyC3Ox6OSPWOP7W4MdiUQIIXw5F+yPiXu/xPO0WJjqGOLXscvwXvuB4N5gvhBSfQJOgA86DcfOMV/BSFsfz5KjMfGvL3HhWcMaDMprdeQlS5YgKysLTk5OEAqFkEgkWLt2LSZNmlTm8oWFhSgs/H+HIysrC4Cs40+d/+qRMoZrQQkAgG5O5lV+/qRSKRhjVV6+lY0hDHVESM8txJ2wJHRyNHvjmAn/qrv/Sf0Qn56HiKRsCDgOHR1Myt2/Vd3/ni3NYKQrQlpOIa4GxsHL1ao2wiZ1SJXe+2pqauA4DnFxcTA1NYW6ujp1jutAcXEx1NXVa2RdjDEUFxcjKSkJHMdBTU2t1GtLFV5rhNRn1gbm+GPCKmy7fgi7b5/EkYcXcD8mGOsHz4ejKZ26SwhRdjPqMdZf/AOLe09FZ1s3vsNRecWSEvz4nw987p0BAHSwccF3g+fBWMeA38AaqU5NW+HA+95Y/O9PuB8bgkUnN2Jyh0GY131Cg5gUjtdHcOjQIfj4+GDfvn1wdXXFgwcPsGDBAlhZWWHKlCmllvf29saqVatKtScnJ6OggGopVsezhByk5RRCW0MIax0pkpKSqnQ/qVSKzMxMMMYgEFRtlG5He32cf5KEc3cjYK//NlETvr3J/ieqz/exbLRtCwsd5GdnID+77OWqs/97tjTC8bvxOHojDC6m9f/LsrFTtfe+np4esrKyEB0dTUnbOiKVSmt03zPGoKamBrFYjJSU0jU4s7PL+SAihFSZulANC3pMRKemrfD1me0IT43BJJ8v8ZnX+xjj3pc+PwkhAGTfyZuv7MfztFhsvrIfnd5rRZ8PFUjMTsMX/2zCgzjZmePTPIZibrdxUBO8ebk58vbM9Yzw69hl2Hx1P/68cwp/3jmFR/Fh+G7wfJjrGfEd3lvh9Wj6888/x5IlSzB+/HgAgJubG6KiouDt7V1m4nbp0qVYuHCh4npWVhZsbGxgamoKsVhcZ3E3BMceyA6SurS0gJWlRZXvJ5VKwXEcTE1Nq3wAN6CDBs4/ScK96EyIDYygqUFJnPrqTfY/UX1P4iIAAD1b2cDMrPxR8dXZ/6O76eOf+wkIS8pFpkQER0v61aY+U8X3voWFBUpKSiCR0KzptU0qlSItLQ1GRkY1tv+FQqFi9HRZNDU1a2Q7hBCgi11rHJq8HsvP7sC1iAdYe2EXbkQ+xqp+H0FfS5fv8AghPLsR+RBPE58DAJ4mPseNyIfoat+G36BU1K3oJ1j8z2ak52dBT6SNNQNmo1fzDnyHRV5SF6phkdf7cLdqiRVnd+BBbAjG/7UU3w7+BJ2atuI7vDfGawYtLy+v1AGAUCgs9/Q4kUgEkUhUql0gEKjMgWR9IGUM14NlI+x6uFhW+7njOK5az7mztSEsDbURn56H22Epirq3pH6q7v4nqi0rrwhPX6QBADydLCrdr1Xd/yZiLXR3sYTfkzj8czcanw11r7GYCT9U8b0vFNLIhroglUqRk5MDbW3tOtv/qvQ6I6QhMNbRx5aRX2DfvbP48T8f+IUFIDAxHN4DP0F7G2e+wyOE1BKJVIqU3Awk5qQiKTv95d80JGanIjEnDQlZqYjLSla6z5yj62FtYAZLsQks9IxhrmcMi5cXcz0TWIiNoSfS5ukR8UPKpNh9+yS2XjsIKWNoYdoUG4YuRFPDqg+CI3WnTwsPtDBtis9O/oiQ5Ch8fHgt5nQdi+mdhkHA1b8+Jq+J2yFDhmDt2rVo2rQpXF1dcf/+fWzcuBHTp0/nM6wGLzg2AynZBdDWUEO7Zia1vj2O49DTxRIHrofD72kcJW4JUSG3QpMgZYC9mR4sDGq2Azasox38nsTh8pM4zOjtBAOd0j+8EUIIIaRuCDgB3ms/EO2tnbH4382ISo/HjEOr8WHnkZjZZSTUBMJGX+fyZtRjePvuwtK+0+FpTz86E9VWLClBUk4aErPTkJiThqTs1P9fz05DYk4qUnIyIGHVqxvPwPAiIxEvMhLLXUZHQ0uR0LUUv57clV201BtG3z+rIAdfn9mB/8LvAgCGuvbAl30+aDCPr6FqamiBPyeuwbqLu3DiyWVsuXYQD2KfYe3AOfXubBNeE7dbtmzBsmXLMHv2bCQlJcHKygofffQRli9fzmdYDd7VoHgAQOcWZtBQq5vRSr1aNcGB6+G4E5aE7Pxi6GnVzAQnhJC34x8im6SwS0vzGl+3UxMDOFrqIzQ+E2fvv8D4bs1rfBuEEFKXtm3bhu+//x4JCQlwd3fHli1b4OHhUe7ymzZtwo4dOxAdHQ0TExOMHj0a3t7eVAqC8MrZ3B4H3vfGt5f+wIknl/Gz/1Hcin6CdQPmNOo6l4wxbL12ENFZidh67SC62LVuVI+fqJb84sJXkrCpr/2fjsTsVKTmZVZpXUJOAFNdQ5jrGcFc1xhmekYw1zOGmY4hdvofQVR6PKSMKZYXcByaGljgg07DkZSThoTsVCRkpyLx5d+sglzkFuXjeWoMnqfGlLtdAy29Ugld5eSukcpPHBWcFIlFJzYiJjMJGkJ1LOk9FSPd3qHPhnpCU10Dq/t/jLZNWsL74i5cjbiP8X8twQ9DP4WrhQPf4VUZr+8SPT09bNq0CZs2beIzjEaFMYZrQbJETXdnyzrbrp2ZHuzN9BCRlI1rwfEY0LZpnW2bEFK2wmIJ7jyX1bv2bFnzp/lwHIdhHe3ww8mH+PduFMZ4NoOQTn8mhNRTBw8exMKFC7Fz50506tQJmzZtQr9+/RASElJmffB9+/ZhyZIl2LVrFzw9PfHs2TNMnToVHMdh48aNPDwCQv5PW0MTq/t/jC62bljj+xsexIZg1J7PkV9cCEBe5/IRujaiUac3Ih+9VuezcT1+UjcYY8gpyn8tGZuGpJxUpZGyWQW5VVqfhlAdZrqGikSoma6R4n9zXdlfI239Mvvg1yMeIiItrlS7lDFEpsfDWMcAQ1v1LHV7XlGBIon7akI3ITsViVmyv3nFBcjIz0ZGfjZCkiLLjJ0DB2Md/bKTu2LZXxMdQ96OH44/9oP3xV0oLCmGldgUG4Z+CheLZrzEQt7OCLdecDa3x2cnf8SLjERM2b8CX/SaXG8m6lTtnzdIjQuJy0RSZj60NIRo72Bap9v2crVCRFIILj+Jo8QtISrgfkQKCoslMBVrorlF7Uzw2NPVEr9eCEJyVgH8QxLRrQ5/MCKEkJq0ceNGfPjhh5g2bRoAYOfOnTh16hR27dqFJUuWlFr+xo0b6Nq1KyZOnAgAsLOzw4QJE3Dr1q06jZuQigxw7go3y+b44p+fFElLuQV/fw9zPeOaOahllS9S/VXW3EoZY0jMSVNq++KfTehi2xq6mtrQ0dB65aIJHZE2dOX/a2gr2nVF2io/gpCU721LZTDGkJGfjcSclzVks9MUydmkV9ryiguqtD4tdREs9IxfJmNfjpJ95X9zXSMYaOm90XuUMYZt1w6CA1fme4kDh23XDsKzjJHn2hqasDduAnvjJuWuO7swr3RyN0s50VskKUZKbgZScjPwNCG8zHXJRwu/mtQ1F/8/0WuhZwwjbf23/px6dd+3s3bGt5d24/hjPwBAd/u29fL0eqLMycwO+95bh+Vnd8IvLABrL+zC/dhnWNZ3Bh7Ehqh0mRz6Vmlk5GUSOjmaQ6Ret5O6eLlaYbdfCB5GpiI1uwDGenSaICF88n8mq1vVuYV5rf3SqKEmxIC2NjhwPRwnAiIpcUsIqZeKiopw9+5dLF26VNEmEAjQp08f+Pv7l3kfT09P7N27F7dv34aHhweeP3+O06dP4/333y93O4WFhSgsLFRcz8rKAiCbIK68yXtJzZJKpWCMNarn20psipldRmL+3z8otRdJSiqscdnQ5RTlwze0+j+0aAjVoa2hCV0NLWi/TPbK/td8meyVteuKtKCtrgld0SttrySHtTW0oCao2+O1m1GP8Z3fn/ii1+RGV+OYMYYt1w4gOisRW64dQKemyqVCJFIp0vIyX6spKxsdm5ST/vL/NBRJiqu0PbFI55URsrK/iqTsy3IGuhpalfbRGWNgrPo/YhSVFCM+O7XcH0AYGBKyU1FYXAQNteqXOdTV0IKusTUcjK3LXj9jSM/PViRx5UltWaI3BQnZaUjOSYOESRXJ3/KoC9Vg/nKksYV8tPGrI3h1jSHW1Cn3uXx132+4vBdCgQAhyVHgwGGW52h88HJCq8b0vdBQ6WpoYcOQBfjr7mlsvrofp4OuISjxOQScoNz3fm2pzuuJEreNCGNMkbjt5lz3sx9aGGrD2doAQTEZuBIYjxGd7Os8BkKIjETKcPNl4rY2yiS8alB7Wxy68RyPotIQkZgFe/PaGd1LCCG1JSUlBRKJBObmyvXAzc3NERwcXOZ9Jk6ciJSUFHTr1g2MMZSUlODjjz/Gl19+We52vL29sWrVqlLtycnJKCio2ggt8nakUikyMzPBGIOgkZT3YYxh29WDEHCcUp1LDhysxaZY0Glc3Z5KWsenrTLGsOnmQcRkJSklsThwMNHWx4DmXZBfUoj8kkLkFRUgr6QQecUFyCsuQH6x/P9CFEqKAABFkmIU5RcjIz/7rWMTCdWhra4JbXVNaKmLFP9rq4mgraEJLTVZm87rt7/8X0tNfl+NSmdSZ4zhx8t7EZEWix8v78Xm/gvrxSnEjDFIGYOUSSFhUkgVl5dt0v//L2+XLydhsh/FpIzhafJzBCZGAAACEyPwyeFvIRAIkZKXgZS8DKTmZ0FaxUm+DDR1YaJtABNtA5hqG8BEWx/G2vov/5dd11SrYGIrKZCfmYN85NTEU1Sun/otQGZB+dsw0NRDRlp6rcZgzOnAWKwDV3HpM3IlUinSC7KQnJuB5LwMJOemy/6+8n96fjaKJSWIyUxCTGZSudvRVNOAqbYBTHUMZX9f+T8xN02x78NSXwAA9EU6WNxtMtpbtkRKckrtPHjCm/5NO6JJXyOsu7pHqVxIYGIEzjy8gg5WzrUeQ3Z21b8jKHHbiITGZyIxIx8idSE6Ni9di60u9HK1QlBMBvyexFHilhAeBcemIyO3CDoiNbS2NarVbZnpa8GzpTmuBSfg5J0ozB/UuEZwEEIap8uXL2PdunXYvn07OnXqhLCwMMyfPx9r1qzBsmXLyrzP0qVLsXDhQsX1rKws2NjYwNTUFGIx/ehVF6RSKTiOg6mpaaNJ3N6IfIhnL5MVr2JgeJGVBE09bXjaqd6pozXlRuRDvMgqPbKYgSE5LwOdmreu0uMvkUqQV5SP3KIC5BblI6co/+X1V9oKy2grYzn5qM1CSTEKJcVIL3j7JLC2uqZs9O/Lkb46Ii3oqGvJ/mpoIT0vS/E6eJb6AlvuHYGV2EwpwalIjL7yv0Ra+nZZslT5f8mr/0tfT5yWtQ4GiVRS6XLSNxhtWhXXYx6XahNwHEx0DGGuaySb4KuM0bKmOoZvNEKVD2bgJydQHZaoeIBJsaQEyTnpSiUYErNTkfCyNEVCdioy8rNRUFKEF1lJeJFVfnJXTktNhP3ve8NSbFJTD4OooN5mZmht54Thuxcpypdw4LDvqS8GuPeo9R+uqjNRLSVuG5GrLycl82huBs06LpMg18PFCjvPByIkLgNxabmwMtLhJQ5CGjv/ENkBSsfmZlAT1v6B6TAPO1wLTsDFx7GY/o4T9LTqR4eWEEIAwMTEBEKhEImJysmdxMREWFiUfVC5bNkyvP/++5gxYwYAwM3NDbm5uZg5cya++uqrMpOCIpEIIlHpUVgCgaDRJBFVAcdxjeY5Z4xh+/XDFda53H79MLrat6kXoy+rqyYfv4ZAAA01dRhov/2PLMWSEkWiN7eo9EWeAJYlfQuQU5SH3MJ85BYXyP6+smyJVAIAilHCyblVG0F5Kuj6Wz8OVSDgOAg4AYQCgewvJ3tvC7mX1wVClEhKkJafVeq+Y1r3Rme71i+TtMYw1tGv8/IVpGIigQasDc1hbWhe7jIFxUVIzFGePE2e4A1PjUF8lvKI2vySQkSmx6OJgeontsnbCUuNUao5zcDwNPE5bkY/qfXJKavTx6DEbSPxapmEHi781Zg01BXB3c4E9yNScPlpHCZ2d+QtFkIaM3l92y4ty+/k1CS3pkawN9NDRFI2zj98gVGdaUZWQkj9oaGhgfbt2+PixYsYPnw4ANnIzIsXL2Lu3Lll3icvL69Up1wolB3wv0k9QkJqQ7GkBAlVqHNZLCmpN6MIq0NVH7+6UA0GWnow0NJ7q/UwxlAkKZYleotLJ4JlCeACBCVF4GzwjVL379GsHawNzMpNeJZOhionSZWXF0DICcu9rextVHyb4LX/1QTC127jqlQjdtLer5BRkKNUCkHACRCYGIGv+s5okD9aNCaa6hqwNbSEraFyHkS+7xOz00rt+/ImZiMNh3yCPgEnUPn9T4nbRiI8IQvx6XkQqQnQsbkpr7H0amWF+xEp8HsShwndmqvMm4GQxiI6JQcxqblQE3B19nnAcRyGdrTDT6ce4587URjRyR4Ceu8TQuqRhQsXYsqUKejQoQM8PDywadMm5ObmYtq0aQCAyZMno0mTJvD29gYADBkyBBs3bkTbtm0VpRKWLVuGIUOGKBK4hPBNQ00d+95bi/QK6rEaaYsbZNIWKP34pVIp0tLSYGRkpPjhpT4/fo7jIFLTgEhNA8bQL3MZefKqrORFam4GNo/4vEEfr92IfISnic9LtUuZFE8Tn+NG5KNaH3lH+EH7vnGrT/ufEreNhHy0bYfmZtDS4He3d3WywJbTTxCdkoOIpGw0o4mKCKlT8jIJ7vYm0BHV3YHIO62s8PvFIMSn5yEgLAmdHOtmtC8hhNSEcePGITk5GcuXL0dCQgLatGmDs2fPKiYsi46OVhph+/XXX4PjOHz99deIjY2FqakphgwZgrVr1/L1EAgpk4XYBBaNuJbjq49fKpUiidOBmZlZoyiVAdSv5EVNk4+4q6hUhqqNvCM1g/Z941bf9n/j+DZq5GRlEmT1bXs481cmQU5XU10xyu/yk7hKliaE1DT/Z7LPgy4t6jZxqqmhhn5tbAAAJwKi6nTbhBBSE+bOnYuoqCgUFhbi1q1b6NSpk+K2y5cv448//lBcV1NTw4oVKxAWFob8/HxER0dj27ZtMDAwqPvACSGkDK8mL8oiT1401PIu1SmVQRoW2veNW33b/zTithGISMpGbFou1IUCeDiqRoFtL1cr3AhJxOXAOEx7p6VK/IpBSGOQllOA4JgMAHWfuAWAIR3scOxmBO6GJ+NFSg5sTHTrPAZCCCGEEKK6NX7rSkMvlUHKR/u+catv+58St42AvExCx+am0Bapxi7v1MIcWhpCJGbkIyg2Ay7WhnyHREijcPNZEhiAFlb6MBFr1vn2LQ214eFohluhSfj3bhRm9XOt8xgIIYQQQgjVOAaoVEZjRvu+catP+181snik1jDGcDVQlrjtrgJlEuQ01YXwbGmBi49jcflJHCVuCakj/s9k9W35GG0rN6yjHW6FJuH8gxhM8WqpMj8oEUIIIYQ0No29xjEhhKg61UslkxoVlZyDF6myMgmdVKRMgpyXqxUA4L/AOEik0kqWJoS8rfyiEtx/ngIA8GxpwVscbZuZwNpYB3lFJbjwKIa3OAghhBBCCCGEEFVGidsGTl4moX0zE+hoqtYpLu2amUCspY6M3CI8iEzlOxxCGry74ckolkhhaagNW1P+assKOA5DO9gCAE4GRDbYCS8IIYQQQgghhJC3QYnbBk6euO2mQmUS5NSEAkVcl5/E8RwNIQ3fjZCXZRJamvM+IWAfd2toaQjxIjUX9yPohxtCCCGEEEIIIeR1lLhtwKKTsxGVnAM1AYcuLfmrZ1mRd1rJyiVcD05AUYmE52gIabgkUiluhyUBADx5rG8rpyNSR193awDAiYBIfoMhhBBCCCGEEEJUECVuG7CrQQkAZCUJdFWsTIKca1MjmIg1kVtYgoCwZL7DIaTBehKdjuz8Yoi11OFioxqTAQ7pYAcAuPUsEQnpefwGQwghhBBCCCGEqBhK3DZgqlwmQU7AcejpIovPj8olEFJr/J/JyiR0cjSHUKAaH/1NTXTRrpkJGIB/7kbxHQ4hhBBCCCGEEKJSVOPondS4mNQcRCRlQ6jCZRLkerVqAgC4FZqIvMISnqMhpOFhjOFGiGwEvqeKfR4M62gHADh7/wUKiqlcCiGEEEIIIYQQIkeJ2wZKXiahjb0JxFoaPEdTseYWYlgb6aCoRAr/l8klQkjNiUjKRmJGPjTUBGjXzITvcJR0bG4GCwMt5BQUw+9JLN/hEEIIIYQQQgghKoMStw3UtZdlEno4W/AcSeU4joPXy0nK/J5SuQRCapp/iKxMQjt7E2hqqPEcjTKhgMPgDrYAgBO3I8EY4zkiQgghhBBCCCFENVDitgGKS8tFWEIWBByHLi1VP3ELAF6ussTtvecpyMwr4jkaQhoWeX1bVS2b0q+NDURqAkQkZePJi3S+wyGEEEIIIYQQQlQCJW4boP+XSTCGvrZql0mQszHRRXMLMSRSpphUjRDy9pIy8xEanwkOQOcWqpm4FWtp4B03Wa3rE7cj+Q2GEEIIIYQQQghREZS4bYDkic/uzpY8R1I98nIJl59QuQRCasrNl6NtXWwMYaAj4jma8g19OUnZ9eAEJGfl8xsMIYQQQgghhBCiAihx28AkpOchND4TAk71Zo+vTE8XWeL2cXQakjIpcUNITVCUSVDR0bZyzczFcGtqBCljOHU3mu9wCCGEEEIIIYQQ3lHitoG5Giwbbdva1lilR9eVxUxfC62aGgEA/gukUbeEvK2cgmI8jEwFoLr1bV817OWo29P3olFUIuE3GEIIIYQQQgghhGeUuG1grgbK6tt2q2dlEuTkk5RRuQRC3l5AWBIkUoamJrqwNtblO5xKeTqZw0Ssicy8IlwJpFrXhBBCCCGEEEIaN0rcNiCJGXkIicsAB6CbkwXf4byRHi6WEAo4hCVk4UVKDt/hEFKv+YfUjzIJckKBAIPaNQUAnAiI5DcYQgghhBBCCCGEZ5S4bUCuBctG27rZGsFQt36VSZDT19ZAu2YmAIDLT2nULSFvqlgiRUB4MoD6USZBbmC7plAXCvAsLhPBsel8h0MIIYQQQgghhPCGErcNyNUg2anF9bVMgtyr5RIYYzxHQ0j99CgyFXmFJTDSFaFlEwO+w6kyAx0RerrKPsNOBkTxHA0hhBBCCCGEEMIfStw2EMlZ+QiKqd9lEuQ8W1pAQ02AmLRchCVk8R0OIfXSjRDZCPzOLcwh4Dieo6ke+SRl/z2NQ3pOIb/BEEIIIYQQQgghPKHEbQNxLUiWpHGxMYSxnibP0bwdbZEaOjnKTu2mcgmEVB9jDDefJQGoP/VtX9XCygBOTQxQImU4fS+a73AIIYQQQgghhBBeUOK2gZCXSejhUr/LJMj1avWyXMLTOEipXAIh1RIan4mU7AJoqgvRxt6Y73DeiHzU7al7USiRSPkNhhBCCCGEEEII4QElbhuA1OwCBL6QTeLTtZ6XSZDr2NwU2iI1pGQV4Gl0Gt/hEFKv+IckAgA6OJhCQ03IczRvpruLJQx1REjNLsT1lxMvEkIIIYQQQgghjQklbhuAa8EJYACcrQ1gKtbiO5waoaEmVCSh/ahcAiHVcuNl4tazZf0rkyCnLhRgYLumAIATAZH8BkMIIYQQQgghhPCAErcNwDV5mQTnhlEmQU5eLuFqYDydKk1IFcWn5yEyORsCjkNHRzO+w3krg9o3hVDA4emLdIQnZPIdDiGEEEIIIYQQUqcocVvPpeUU4HGUrJRAtwaWuG1jZwwDHQ1k5Rfj3vMUvsMhpF7wD5GVFXCzNYJYS4PnaN6OsZ4mur0ceX8yIIrnaAghhBBCCCGEkLpFidt67npwIhgApyYGMNNvGGUS5IQCgWKytctULoGQKpGXSejSov6WSXjVMA87AMClJ7HIyiviNxhCCCGEEEIIIaQOUeK2nrv6skxCN+eGMSnZ67xcZeUSboQkoKBYwnM0hKi2zLwiPH0hG4HfpR7Xt32Vi7UhHMzFKCqR4uyDF3yHQwghhBBCCCGE1BlK3NZjGbmFeByVCgDo7tSwyiTIuVgbwtxAC/lFEtwOTeI7HEJU2u3QJEgZ0MxcDAsDbb7DqREcxylG3f57JwoSKeM3IEIIIYQQQgghpI5Q4rYeuxGSCCkDWljqw8KwYSRpXsdxHLxcZKNu/Z7E8hwNIapNXt+2oZRJkPNytYJYSx2Jmfm4FZrIdziEEEIIIYQQQkidoMRtPXYlUF4moWGOtpXzaiVL3AaEJSOnoJjnaAhRTYXFEtx5OYlfQymTICdSF6J/26YAgBMBkfwGQwghhBBCCCGE1BFK3NZTmXlFeBj5skxCA61vK2dvpoemJroolkhxPTiB73AIUUn3I1JQWCyBqVgTzS3EfIdT4wa3bwoBBzyISEVUcjbf4RBCCCGEEEIIIbWOErf11I2QBEgZQ3MLMayMdPgOp1ZxHIdeL0fdXn4ax3M0hKgm/xBZCYEuLc3BcRzP0dQ8cwNtdH5ZAuKfO1E8R0MIIYQQQgghhNQ+StzWU1eDZCNPG3qZBDkvV1ni9kFECtJyCniOhhDVIpEy3HxZ+7VLi4Y7An9YRzsAgO/DGORS2RRCCCGEEEIIIQ0cJW7roaz8IjyIkNWybOhlEuSsjHTQ0soAUgZcfVnblxAiExybjozcIuiI1NDa1ojvcGqNu50xmprooqBYgvMPY/gOhxBSD6xYsQJRUTRKnxBCCCGE1E+UuK2H/EMSIZEy2JvpwdpYl+9w6ox8kjI/KpdAiBJ5mQQPRzOoCRvuxzrHcRj6ctTtyTuRkDLGb0CEEJV34sQJODg4oHfv3ti3bx8KCwv5DokQQgghhJAqa7hH+A3YtSDZiNMeLo2jTIJcTxdLcACCYjKQkJHHdziEqAxFfduXNWAbsj6tm0BHpIa4tDzcDU/mOxxCiIp78OABAgIC4Orqivnz58PCwgKzZs1CQEAA36ERQgghhBBSKUrc1jM5BcW491xWJqGx1LeVM9bThLudMQDgPxp1SwgAIDolBzFpuVATcOjQ3JTvcGqdloYa3m1jAwA4GRDJbzCEkHqhbdu22Lx5M+Li4vD7778jJiYGXbt2RevWrfHTTz8hMzOT7xAJIYQQQggpEyVu6xn/kESUSBlsTXXR1KTxlEmQU5RLeEKJW0IAwD9ENlFhG3sT6IjUeY6mbgxpbwsACAhLRmxaLs/REELqC8YYiouLUVRUBMYYDA0NsXXrVtjY2ODgwYN8h0cIIYQQQkgplLitZ67KyyQ0stG2ct2cLKEm4BCRlI3IpGy+wyGEd4oyCS0bfpkEuSbGOujY3BQMwD93aNIhQkjF7t69i7lz58LS0hKffvop2rZti6CgIPz3338IDQ3F2rVrMW/ePL7DJIQQQgghpBTeE7exsbF47733YGxsDC0tLbi5ueHOnTt8h6WSchtxmQQ5PS11dHCQnQ5+mcolkEYuLacAwbEZABpHfdtXDXs5Sdn5By+QX1TCbzCEEJXl5uaGzp07IyIiAr///jtevHiBb7/9Fs2bN1csM2HCBCQnU81sQgghhBCienhN3Kanp6Nr165QV1fHmTNnEBgYiA0bNsDQ0JDPsFTWrdAkFEukaGqiCzszPb7D4U2vVk0AyBK3jGaVJ43YzWdJYABaWOnDWE+T73DqVHsHU1gZaSO3sAQXH8fyHQ4hREWNHTsWkZGROHXqFIYPHw6hUFhqGRMTE0ilUh6iI4QQQgghpGJqfG58/fr1sLGxwe7duxVt9vb2PEak2q4EysokdHO24DkSfnVuYQaRuhDx6XkIicuAUxNK9JPGSV7f1rNl4/tMEHAchnSww8/nA3EyIBKD2jUFx3F8h0UIUTHLli3jOwRCCCGEEELeGK8jbk+ePIkOHTpgzJgxMDMzQ9u2bfHrr7/yGZLKyisswZ1w2Wl8jbW+rZymhpritHCapIw0VvlFJbgfkQqg8ZVJkOvnbg1NdSGiknPwMCqV73AIISpo1KhRWL9+fan27777DmPGjOEhIkIIIYQQQqqO1xG3z58/x44dO7Bw4UJ8+eWXCAgIwLx586ChoYEpU6aUWr6wsBCFhYWK61lZWQAAqVTa4E9xu/ksAcUSKZoY6aCpiQ5vj1cqlYIxxvvz3dPFApefxuG/p/GY0dsJQgGNtKsLqrL/CRAQJiudYmmoDRtj7TrZJ6q2/7U0hOjt1gSn7kXjxO1ItG5qxHdIDZaq7XtSt/jY/zW1rStXrmDlypWl2gcMGIANGzbUyDYIIYQQQgipLbwmbqVSKTp06IB169YBANq2bYsnT55g586dZSZuvb29sWrVqlLtycnJKCgoqPV4+XTxgWzm9HZN9XidQEMqlSIzMxOMMQgE/A3YbqrHoCMSIj23EFcfhsOliZi3WBoTVdn/BPB7KPtMcLfWrbPPBFXc/572ujh1D/B/lojA8Bcw0RPxHVKDpIr7ntQdPvZ/dnZ2jawnJycHGhoapdrV1dUVAwAIIYQQQghRVbwmbi0tLeHi4qLU5uzsjKNHj5a5/NKlS7Fw4ULF9aysLNjY2MDU1BRiccNN3OUXleBRzH0AQL/2DjAz4++xSqVScBwHU1NT3g/euzun4OyDF3gQmw+vts0rvwN5a6q0/xuzEokUj2IeAQB6t7GHmVndjDRVxf1vZga42yXiYWQqbkblYfo7NnyH1CCp4r4ndYeP/a+pWTMTLrq5ueHgwYNYvny5UvuBAwdK9UEJIYQQQghRNbwmbrt27YqQkBCltmfPnsHW1rbM5UUiEUSi0qOpBAJBgz6QvBOegqIS2SnRzS31eZ+Ah+M4lXjOe7lZ4eyDF7gekoC5A1tBQ630TNGk5qnK/m/MAqPTkFNQDH1tDbg2NYagDkuFqOL+H97RDg8jU3HuwQu837MFROr0WVAbVHHfk7pT1/u/prazbNkyjBw5EuHh4XjnnXcAABcvXsT+/ftx+PDhGtkGIYQQQgghtYXXo69PP/0UN2/exLp16xAWFoZ9+/bhl19+wZw5c/gMS+VcDZLNHN/D2ZL3pK0qcWtqDCNdEXIKSnA3PIXvcAipM/4hiQAAD0czqu8MoFMLc5jpayErvxiXn9KEhYSQ/xsyZAj+/vtvhIWFYfbs2Vi0aBFiYmJw4cIFDB8+vNrr27ZtG+zs7KCpqYlOnTrh9u3bFS6fkZGBOXPmwNLSEiKRCC1atMDp06ff8NEQQgghhJDGhtfEbceOHXH8+HHs378frVq1wpo1a7Bp0yZMmjSJz7BUSkGxBLfDkgAA3V0seY5GtQgFHLxcrQCAkjWk0WCMwf+ZLHHr2cKc52hUg1DAYXB72ZkaJwMiwRjjOSJCiCoZNGgQrl+/jtzcXKSkpODSpUvo2bNntddz8OBBLFy4ECtWrMC9e/fg7u6Ofv36ISkpqczli4qK0LdvX0RGRuLIkSMICQnBr7/+iiZNmrztQyKEEEIIIY0Er6USAGDw4MEYPHgw32GorICwJBQWS2BuoIXmFg23ju+b8mplhWO3IuAfkoD8ohJoafD+kiakVj1PzEZiRj5EagK0czDlOxyVMaCtDfZeeYawhCwExqTD1aZu6v4SQhqPjRs34sMPP8S0adMAADt37sSpU6ewa9cuLFmypNTyu3btQlpaGm7cuAF1dXUAgJ2dXV2GTAghhBBC6jnKcqm4a1QmoUItLPVhaaiN+PQ8+Ick4h03GsVCGjb5aNu2zUyhSbVcFcTaGujVygrnHsTgZEAUJW4JIQAAiUSCH3/8EYcOHUJ0dDSKioqUbk9LS6vSeoqKinD37l0sXbpU0SYQCNCnTx/4+/uXeZ+TJ0+iS5cumDNnDk6cOAFTU1NMnDgRixcvhlBY9ud3YWEhCgsLFdezsrIAyCaIk0qlVYqVvB2pVArGGD3fjRTt/8aN9n/jRfu+ceNj/1dnW5S4VWGFxRLcfJmk6eZMZRLKwnEcerlaYd+1MFx+GkeJW9Lg+YfIfszxbEllEl43tIMdzj2IwdWgeMzMdoaxXs3MSk8Iqb9WrVqF3377DYsWLcLXX3+Nr776CpGRkfj777+xfPnyKq8nJSUFEokE5ubKn73m5uYIDg4u8z7Pnz/HpUuXMGnSJJw+fVpRZ7e4uBgrVqwo8z7e3t5YtWpVqfbk5GQUFBRUOV7y5qRSKTIzM8EYo8kYGyHa/40b7f/Gi/Z948bH/s/Ozq7yspS4VWF3w5NRUCyBmb4WWlrp8x2OyurVSpa4vROejKy8Ioi1NfgOiZBakZSZj7CELHAAOjma8R2OymluqQ9XG0M8fZGOU3ejMdmrBd8hEUJ45uPjg19//RWDBg3CypUrMWHCBDg4OKB169a4efMm5s2bV2vblkqlMDMzwy+//AKhUIj27dsjNjYW33//fbmJ26VLl2LhwoWK61lZWbCxsYGpqSnEYiqZVRekUik4joOpqSkdvDdCtP8bN9r/jRft+8aNj/2vqVn1QUaUuFVhV4LiAQDdnC2oTEIFmprqoZm5GM8Ts3AtOAED2zXlOyRCaoW8TIKLjSEMdEQ8R6Oahna0w9MX6Th9LxoTujeHupA6XoQ0ZgkJCXBzcwMA6OrqIjMzE4BsjoVly5ZVeT0mJiYQCoVITExUak9MTISFhUWZ97G0tIS6urpSWQRnZ2ckJCSgqKgIGhqlf2gWiUQQiUp/vgsEAjqQrEMcx9Fz3ojR/m/caP83XrTvG7e63v/V2Q69IlVUUYkEt57JZinuTmUSKuXlagUA8HsSy3MkhNQe/xBZwqALlUkoVzcnCxjpipCeW4irgfF8h0MI4Zm1tTXi42WfBQ4ODjh//jwAICAgoMwEaXk0NDTQvn17XLx4UdEmlUpx8eJFdOnSpcz7dO3aFWFhYUo1zJ49ewZLS8syk7aEEEIIIYS8jhK3Kure8xTkFZXARKwJpyYGfIej8rxcZcntx1FpSMmiGnCk4ckpKMajqFQAgGeLskd3EUBNKMCg9rYAgJMBkfwGQwjh3YgRIxTJ1k8++QTLli2Do6MjJk+ejOnTp1drXQsXLsSvv/6KPXv2ICgoCLNmzUJubi6mTZsGAJg8ebLS5GWzZs1CWloa5s+fj2fPnuHUqVNYt24d5syZU3MPkBBCCCGENGhUKkFFXXk5UqybkwUEVCahUuYG2orallcC4zCyczO+QyKkRgWEJUEiZWhqoosmxjp8h6PSBrazwf6roQiKzcCzuAy0sDLgOyRCCE++/fZbxf/jxo2Dra0tbty4AUdHRwwZMqRa6xo3bhySk5OxfPlyJCQkoE2bNjh79qxiwrLo6Gil095sbGxw7tw5fPrpp2jdujWaNGmC+fPnY/HixTXz4AghhBBCSINHiVsVVFQiwc2XtSx7uFCZhKrycrXC0xfp8HtCiVvS8NygMglVZqSriR4ulrj0JA4nA6Lw2TADvkMihPCguLgYH330EZYtWwZ7e3sAQOfOndG5c+c3XufcuXMxd+7cMm+7fPlyqbYuXbrg5s2bb7w9QgghhBDSuFGpBBV0PyIFuYUlMNIVwdnakO9w6o0eLpYQcByexWciNjWX73AIqTFFJRLcCUsGAHhS4rZKhnnYAQAuP41DRm4hv8EQQnihrq6Oo0eP8h0GIYQQQgghb4wStyroalACAKCbM5VJqA4DHRHa2hsDkCVrCGkoHkWlIa9I9mMOnfZfNS2tDNDCUh/FEinO3H/BdziEEJ4MHz4cf//9N99hEEIIIYQQ8kaoVIKKKZZI4R8iS9z2cKYyCdXVq1UT3H2eAr8nsZjYvTk4SnyTBkD+mdC5hTn9mFNFHMdhaEc7/HDyIf69G4Wxns0gFNBvlYQ0No6Ojli9ejWuX7+O9u3bQ0dHuUb4vHnzeIqMEEIIIYSQylHiVsU8iEhBTkEJDHVEcLEx4jucesfTyRzqpwR4kZqL54lZcLDQ5zskQt6KlDH4v6x5TWUSqqenqyV+vRCElKwC3AhJRHf6MYyQRuf333+HgYEB7t69i7t37yrdxnEcJW4JIYQQQohKo8Stirn2SpkEoYBG1lWXjkgdHo5muB6cAL8ncZS4JfVeaHwmUrMLoaUhhLudMd/h1CsaakIMaGuDA9fDcTIgkhK3hDRCERERfIdACCGEEELIG6PzRlVIiUSK6yH/T9ySN9PL1QoA8F9gPKSM8RwNIW/HP0Q22raDgyk01IQ8R1P/DO5gCwHH4VFUGp4nZvEdDiGEEEIIIYQQUmU04laFPIxKRXZ+MfS1NeDWlMokvCkPRzNoa6ghKTMfQTHpcKWSE6Qekyduu7SgMglvwlSsha5O5rgalICTAZFYMLg13yERQurQ9OnTK7x9165ddRQJIYQQQggh1UcjblWIvExCVycLmkTnLYjUhfB0kiW5/J7E8RwNIW8uLi0XkcnZEHAcPBwpcfumhnW0AwBcehyL7PxifoMhhNSp9PR0pUtSUhIuXbqEY8eOISMjg+/wCCGEEEIIqRCNuFUREqkU14NliVuqw/j2vFytcOFRLK4ExmNWPxdKhJN6ST4pWWtbI+hpqfMcTf3VqqkR7M30EJGUjXMPXmB0l2Z8h0QIqSPHjx8v1SaVSjFr1iw4ODjwEBEhhBBCCCFVR9ksFfE4Kg2ZeUUQa6nD3Y5O7X9bbe1NoK+tgcy8ItyPSOU7HELeiKJMQksabfs2OI7D0Jejbv+5EwmJlGpfE9KYCQQCLFy4ED/++CPfoRBCCCGEEFIhStyqiCtB8QAATyqTUCPUhAL0cJGNXL5M5RJqhETK8CgqFf5haXgUlUrJr1qWmVeEpy/SAFB925rwjlsT6GqqIyEjHwFhSXyHQwjhWXh4OEpKSvgOgxBCCCGEkApRqQQVIJEyKpNQC7xcrfDPnShcD07AJwNbQaQu5DukeutaUDx2nAtESnbBy5YImOhpYlY/F3Sj12ytuBWaCCkDHMzFMDfQ5jucek9TXYj+bW1wxP85TgZEojMlwwlpFBYuXKh0nTGG+Ph4nDp1ClOmTOEpKkIIIYQQQqrmjYZ2vnjxAjExMYrrt2/fxoIFC/DLL7/UWGCNydMXacjILYKupjra2BnzHU6D4WJjCFOxJvKKSnCbRti9sWtB8Vhz5N4rSVuZlOwCrDlyD9dejhYnNYvKJNS8we1twQG4+zwFL1Jy+A6HEFIH7t+/r3R59OgRAGDDhg3YtGkTv8ERQgghhBBSiTcacTtx4kTMnDkT77//PhISEtC3b1+4urrCx8cHCQkJWL58eU3H2aBdCXxZJqGlOdSEVCahpgg4Dl6uVjjs/xyXn8TRaOY3IJEy7DgXWOEyO88HoktLCwgFXB1F1fAVFktw93kKACqTUJMsDbXRydEMN0OTcPJOJOb0b8V3SISQWubn58d3CIQQQgghhLyxN8oSPnnyBB4eHgCAQ4cOoVWrVrhx4wZ8fHzwxx9/1GR8DZ6U/b9MgrwmK6k5vVpZAQBuhSYht7CY52jqnyfRaaVG2r4uOasAT6LT6iiixuF+RAoKiyUw09eCg4WY73AalKEedgAA34cx9JlASCMQERGB0NDQUu2hoaGIjIys+4AIIYQQQgiphjdK3BYXF0MkEgEALly4gKFDhwIAnJycEB9Pp01Xx9MX6UjLKYSuphra2JvwHU6D08xcDBtjHRRLpLgRnMh3OPVOWk7FSdvqLkeq5kaI7MecLi3MwXE0krkmtbU3gbWxDvKLJLjwKJbvcAghtWzq1Km4ceNGqfZbt25h6tSpdR8QIYQQQggh1fBGiVtXV1fs3LkTV69eha+vL/r37w8AiIuLg7Ex1WitDnl90C4tLKBOZRJqHMdx8GrVBADg9zSO52jqn5jU3CotZ6SrWcuRNB4SKcPNZ7KazFTftuYJOA5DO9oBAE4GRELKGL8BEUJq1f3799G1a9dS7Z07d8aDBw/qPiBCCCGEEEKq4Y0yhevXr8fPP/8MLy8vTJgwAe7u7gCAkydPKkookMpJGcO1INnIum7OFjxH03D1cpWVS7j/PAUZuYU8R1M/MMZw4FoY9l4pfXrp60zFmmjV1KgOomocgmPTkZlXBF1NNbjR81or+ra2hraGGmJSc3H/ZS1hQkjDxHEcsrOzS7VnZmZCIpHwEBEhhBBCCCFV90aJWy8vL6SkpCAlJQW7du1StM+cORM7d+6sseAauqCYdKRkF0BbpIZ2zahMQm1pYqyDFpb6kDKGq0FUyqMyRSUSbDj5CLv9QgAAHs1NK1x+Rh8nmpisBvmHyEp6dGxuRpMV1hJtkRr6ulsDkI26JYQ0XD169IC3t7dSklYikcDb2xvdunXjMTJCCCGEEEIqp/Ymd8rPzwdjDIaGhgCAqKgoHD9+HM7OzujXr1+NBtiQyUfbdmlhDg014f/au+/4qKr0j+OfmUnvpJEChF4DoUpXUKRaEPuigO7iqmBj3bW3VQF19YcFQVFAd8UuWFBRUaR3AqEXIaGFBAIphNSZ3x+XJMQQSCDJnWS+79drXmTunLn3mZzJcOa55z7H5Gjqtn6xUew8nM5vmw9xddfGZofjtNKz8/j35+vYnJSG1WLh3sFtubprY5ZuO8y0BVtLLVRmsYDDAVv3n6Bfu2gTo647HA4Hy08nbnu10iz86nR11xi+XrOPVbtSOHw8m8h6PmaHJCLV4KWXXuLSSy+lVatW9O3bF4AlS5aQkZHBr7/+anJ0IiIiIiLndkHTua699lo+/PBDAE6cOEH37t159dVXGT58ONOmTavSAOuqM2d/qkxC9busbRQWjMXgUtJPmR2OU0pKzeSBmcvYnJSGj6cbL9zarTjJ3adNJB/efzkv3XYJd/dvwku3XcJzN3UF4Os1+4pnicrF2X80i4NpJ3G3Wena7NwzneXiNAz1o0vTUBzAt2v3mR2OiFSTtm3bsmnTJm666SZSUlLIzMxk1KhRbN++ndjYWLPDExERERE5pwtK3K5fv7541sIXX3xB/fr1SUxM5MMPP+SNN96o0gDrqp2HTpCakYO3h00JmhoQGuBF+xijXugiLVJWxro/Unlw1nIOH88mIsibKXf0osuf3pc2q4UOMSH0bB5Mh5gQuresz4geTQB49duNHM3IOduupRJW7DQS4HGNQ/DxvKALIqQSihYpWxC/n5x81boUqauioqKYOHEi8+fP54svvuDpp58mOFg1xEVERETE+V1Q4jY7Oxt/f38AfvrpJ0aMGIHVaqVHjx4kJiZWaYB11ZLTZRK6t1CZhJrS7/QiZYs2K3F7pu/WJfLknDWczC2gXcN6vH5nb2LC/Cv03Dv6t6J5RACZp/J5ad4GCu2Oao62biuaudyzVX2TI3EN3ZqHE1nPh6ycAn5NOGh2OCJSDWbNmsXnn39eZvvnn3/OBx98YEJEIiIiIiIVd0GJ2+bNmzNv3jz279/PggULGDhwIAApKSkEBARUaYB1kcPhYMlWo0xCX5VJqDF920Ris1rYcySDpNSyK0y7mkK7g+k/beXN7zdjdzi4on00k2/rTpCvZ4X34eFm4/ERnfFyt7EpMY1Pl+2uxojrtmOZOWw7eAIw6l5L9bNZLVzVJQYwFilzOHTiQaSumTRpEqGhZReADQ8PZ+LEiSZEJCIiIiJScReUuH366ad5+OGHady4MZdccgk9e/YEjNm3nTp1qtIA66Jdh9M5kn4KL3cb3ZqHmx2Oywjw8Si+/P83Fy+XkJ1bwLOfrWXuqr0AjOnfin9eG3dBs7+jQ3wZP8SoE/jf33exZX9alcbqKlbtSgGgVVQQIf5eJkfjOgZ1bIinu429KZkkJOm9K2UV2h1s3HeM3zYfZOO+Y7qyoJZJSkqiSZMmZbbHxMSQlJRkQkQiIiIiIhV3QUUUb7jhBvr06cPhw4eJi4sr3n7FFVdw3XXXVVlwddXi07NtL2kRjqe7yiTUpP7toli9K4VFWw4x6rKWWCwWs0OqcUdOZPPMp2vZm5KJh5uVf13bkb5tIy9qnwM6RLP+j1R+3XyIyXPjmXZXX/y83KsoYtewYodRPkVlEmqWv7c7V7SP5vv1SXyzZh8dYkLMDkmcyNJth5m2YCtHM0tqeIf6e3HPoLb0aXNxn5tSM8LDw9m0aRONGzcutX3jxo2EhOjvXURERESc2wXNuAWIiIigU6dOHDp0iAMHDgBwySWX0Lp16yoLri5yOBws3W4kaC7Vl74a17NVfTzdrBxKy2bX4XSzw6lx2w8e54GZy9mbkkmwnyf/Gd3zopO2ABaLhfFDY4ms50NK+immfJegy84rITu3gA17jwEqk2CGa7oa5RKWbT9CSvopk6MRZ7F022Ge/2J9qaQtwNHMHJ7/Yj1Ltx02KTKpjFtvvZX777+f3377jcLCQgoLC/n111954IEHuOWWW8wOT0RERETknC4ocWu32/n3v/9NYGAgMTExxMTEEBQUxPPPP4/dbq/qGOuU3ckZHD6ejaeblW7Nw8wOx+V4e7jR43RizNXKJSzacoiHP1jJ8ZO5NK0fwOt39qZVVFCV7d/X053HRnTCZrWwZNthftiwv8r2Xdet25NKfqGdqGAfYsL8zA7H5TSpH0CHmGDsDgfz12mBTTHKI0xbsPWcbab/tFVlE2qB559/nu7du3PFFVfg7e2Nt7c3AwcO5PLLL+fFF180OzwRERERkXO6oMTtE088wVtvvcXkyZPZsGEDGzZsYOLEibz55ps89dRTVR1jnbLk9Aydbs3D8fK4oEoVcpH6xUYB8PuWQy7xpdvhcPC/xbuY9NUG8gvt9GgRzmtjehIe6F3lx2oVFcQd/VsBMH3BFhK1CFyFrNh5BDBm27pi+Q5ncE23xgD8sGE/eQWF5gYjptuclFZmpu2fpWbksFl1kZ2eh4cHn376KTt27OCjjz7iq6++Ys+ePcycORNPz4ovxikiIiIiYoYLStx+8MEHvPfee9xzzz106NCBDh06cO+99zJjxgxmz55dxSHWHQ6HozhxWxWXp8uF6dosDD8vN45l5tb5L915BYW8NC+e//6+E4DrezTh6Zu64l2NJw2u79mULk1DyS2wM+mrDUqCnUdBob14YbKerSJMjsZ19WpVn9AAL9Kz8/h9iy6Bd3VpWedO2hb5evU+4vcdJTdfn3POrkWLFtx4441cddVV1KtXj2nTptG1a1ezwxIREREROacLStympaWdtZZt69atSUur24mwi/HHkUwOpWXj4Wale4tws8NxWR5uNnq3NhJki+pwuYQTJ3P5139X8tvmQ9isFh4Y1p67rmyLzVq9MzqtFgsPXxtHkK8He1MyeffnbdV6vNpuc1IaWTn5BPp40LZBPbPDcVk2q5Wruhi1br9Zs081ml1csJ9Xhdot25HMI/9dxfWv/MTDH6zgw0U7lch1Yr/99hu33347kZGRxSUURERERESc2QUlbuPi4njrrbfKbH/rrbfo0KHDRQdVVxUtZNKtWVi1zniU8+sfGw0YpSvyC+teXeZ9KZncP3MZ2w6cwM/LjYl/uYShnRvV2PGD/bx4+Jo4AL5dm8jyHck1duzapqhMQvcW4dWeVJdzG9KpIe42KzsPp7P94AmzwxETxTYKJtT/3MlbPy93LmsbSbCfJ/mFdhKS0vhoya7iRO4/PljBB4t2EL9XiVwzHTx4kBdffJHmzZtz4403MmfOHGbOnMnBgweZOnWq2eGJiIiIiJzTBWUPX375ZYYNG8Yvv/xCz549AVixYgX79+/n+++/r9IA6wqHw8Hi04nbPm1UJsFsHWJCCPbzJC0rl3V7UosXLKsL1uxOYeKXG8jOKyAq2Id/39yNhqE1v+BVt+bhXN+jCV+u3Mtr326iRWQgYQFVX1e3NnM4HKzYcbq+bau68x6srYJ8PenXLoqfNx3gmzX7aKMZ0C7LZrUwpn9L/vPNpnLbPHRVe/q0icThcHAoLZuNicfYdPpWVIpnc1Iac5bsxt1mpVV0EB1igukQE0KbBvXwcrfV4CtyPV9++SXvv/8+ixcvZsiQIbz66qsMGTIEX19f2rdvr3riIiIiIlIrXFDi9rLLLmPnzp1MnTqV7du3AzBixAjuuusuXnjhBfr27VulQdYFialZHDh2Eneble4tVSbBbDarhUvbRjJv9T4WbTlUZxK3X6/ey/SftmJ3QIeYYJ66oQsBPh6mxXPH5a3ZlJjGrsPpvDwvnsm39dCs0jP8cSSTI+mn8HSz0rlpmNnhCHBNtxh+3nSAxVsPM/bKNhW+ZF7qnoTTNdBtVkuphSzDAry4e2Db4pOwFouF6BBfokN8Gdq5UalEbkLiMTaeJZHrZrXQKjqIuJgQOjRWIrc63HzzzTzyyCN8+umn+Pv7mx2OiIiIiMgFueDr9aOionjxxRdLbdu4cSPvv/8+77777kUHVtcULUrWpVkYvp7uJkcjAP3aRTFv9T5W7DhCTn5hrf7SXGi3M23BVr5dmwjAwLgG3D+sPe62C6qGUmXcbVYeu64T495bwqbEND5ZupuRl7YwNSZnsuJ0CYnOTcNq9fuvLmkZFUSb6CC2HTzB9+v3c5very5pU+IxFsQfAODl23tQaHeQlpVDsJ8XsY2Cz3kC6qyJ3OPZxmzcfcfYlJjG0cwctuw/zpb9x5mztCSR2yEmhA4xIbRtqETuxfrrX//K1KlTWbRoEbfffjs333wz9eppFr2IiIiI1C4qtFpDFm81Erd922jVeGfROjqIiCBvkk+cYuXOI/RrF2V2SBfkZE4+L365nnV/HMUC3HlFa27s2dRpLgONDvFl/JBYXvl6I/9bvJOOTUJo1zDY7LCcQlF9W5VJcC7XdGvMtoPxzF+XyM29m5l+AkRqVl5BIW/MTwBgaOdGxDa6uM8ri8VCdLAv0cG+DOlUOpGbkJjGxn3HSiVyPz5bIrdBEF6qjV8p77zzDlOmTOGzzz5j5syZPPjggwwaNAiHw4HdXvdq24uIiIhI3aRvATUgMTWTpKNZuFkt9Kwjl+TXBRaLhX7tovhk2R5+23yoViZuDx/P5ulP1pB0NAtPdxuPDu9Ir9bOd3JgQIcGrP/jKAsTDjJ5bjxvj+2Lv7drzzxPST/F7uQMrBZjYTJxHn3bRvLuz9tIy8pl2fbkWvnZIBfuixV/sP/YSer5enLn5a2rfP9nS+QeLpqRm5jGxsRjHM0onci1WS20ijpdI7dxCO0a1FMitwK8vb0ZPXo0o0ePZteuXcyaNYu1a9fSu3dvhg0bxg033MCIESPMDlNEREREpFwa9deAJdtOXw7dLAxfL9dOVjmb/rHRfLJsD2t3p5B5Kr9WJRO37E/juc/WkZ6dR4i/J8/d3I0WkYFmh1Wu8UNi2XrgOIePZzPlu008eUNnp5kVbIai2bZtGtQjyNfT5GjkTO42K0M7N+KjJbv4Zs0+JW5dyMFjJ5mzZDcAdw9sWyP/J1gsFqKCfYkK9mXw6URu8olTbEo8xsZ9x4oTuVsPHGfrgeN8smyPErkXoEWLFkycOJEXXniB+fPn8/7773PrrbeSm5trdmgiIiIiIuWq1Cj/fLMSTpw4cTGx1FlLt6lMgrNqHO5P4zB/9qVmsmz7YQZ3amR2SBWycNMB/u+7BPIL7TSPCOC5m7sRGuDciyj5eLrx+IhOPDhrOUu3J/PDhv0M7Vw7ft/VYfnp+ra9WulzwRkN69KIT5btZsv+4+w+nE5zJz4pIlXD4XDwxg/G52qXZmFc1i7SlDgsFguR9XyIrOfDoI4NyyRyNyUeI/UsidyWUYF0iAkh7nSNXG8lcs/KarVy9dVXc/XVV5OSkmJ2OCIiIiIi51SpUX1g4Lm/uAYGBjJq1KiLCqiu2X80i70pmdisFnq2VILGGfWPjWLWbzv4bcshp0/c2h0O/rtoJ3OWGjPCereO4F/XxtWamVYto4K44/JWvPfLdqYt2ELbBvVoHO56q31n5eSTkGisWK/6ts4pxN+Lvm0iWbTlEF+v2cc/rokzOySpZr8mHCR+7zE83KzcNyTWaa4IOFsi98iJU2xMPFaczE3NyGHbgRNsO3CCT89M5DYKMWbkKpF7VuHhKlMjIiIiIs6tUqP4WbNmVVccddaS07NtOzUJrVWX4buSfu2MxO3Gvcc4lplDiL9zzlzNzS/kP99sLF7o7uZezRhzeSusTpJcqKjrezRlw95jrNuTyuS5G3j9zt54utjq6at3pVBod9Ao1I/oYF+zw5FyXNMthkVbDvHb5kOMHdCGAB8Ps0OSapJxKo93ft4GwMi+LYis52NyROWzWCxE1PMh4iyJ3ITTNXJT0k+VJHKXn07kRhozciubyC20O0hIPMbeg2k0OWWjfUwoNmvt+n9HRERERKS20vSLarb0dH3bS9uac8mlnF9EPR/aRAex7eAJFm89zHXdm5gdUhlpWTk8++k6dhw6gZvVwgNXtWdgXEOzw7ogVouFf14Tx93vLmZvSiYzftnG+CGxZodVo4rq22q2rXNr26AezSMC2J2cwcxftxPXOIRgPy9iGwUrcVXHvL9wO+nZecSE+XF9z6Zmh1Mpf07kAiSfOL3Y2b40NiUe40j6KbYdPMG2g0Yi12opKa3QISaYdg2D8fEsOyRcuu0w0xZs5Whmzuktewn19+KeQW3p00bjGhERERGR6qbEbTU6mHaSPUcysFos9GypBI0z6xcbxbaDJ1i05ZDTJW73JGfwzKdrSM3Iwd/bnWdu7EL7mBCzw7oo9fw8+ee1HXlizmq+XZtI5yah9GrtGqVE8goKWbPbqKuo+rbOzWKx0KZBPXYnZ/DDhv38sGE/gBJXdUxCUho/nu7bB4a1x91mNTmiixcR5ENEkE/xCb7kE9nFs3E3JR7jyIlTbD94gu0HT/BZOYnc9X+k8vwX68vs+2hmDs9/sZ6nbuisvwERERERkWrmNN9OJk+ejMVi4cEHHzQ7lCpTtChZxyYhusTWyV3aNhKrBbYfPMHh49lmh1Ns5c4jTJi9nNSMHBqE+PL6nb1rfdK2SNdmYdxwembbq99uIiX9lMkR1YyN+45xKq+QYD9PWkZpwStntnTbYb5dm1hme1HiqugzXmqv/EI7b8xPAGBIp4a0axhsckTVIyLIhyvjGvDwNXF8eN/lfHBffx6+Jo4r4xoQEeSN3eEoTuI++fEaRry8gElfbTjnPqf/tJVCu6OGXoGIiIiIiGtyihm3a9as4Z133qFDhw5mh1Kllpwuk9BXM1KcXrCfF3GNQ9mw9yi/bT7IX/q2MDUeh8PBV6v2MuPnbTgwkv9PXt+lztVJHtO/FZv2HWPn4XRenhfPS7f3qPOXoBeVSejRsn6tq0/sSgrtDqYt2HrONtN/2krPVhF1/j1bl32x4g+SjmYR5OvBnVe0NjucGlM0I/fKuAYAHDmRzaZEo6zCpsRjJJ84RcF5krKpGTlsTkojrrHznUysV69ehReXS0tLq+ZoREREREQunOmJ26ysLEaOHMmMGTN44YUXzA6nyhw+ns2uw+lYLRZ6qY5lrdA/NooNe4+yaMshUxO3BYV2pv64he/XJwEwtHMjxg1uh1sduHz3z9xtVh4d0YlxM5aQkJTGx0t3c9ul5ibNq5Pd4WDl6cStPhec2+aktDPqep6dMyeu5PwOpp1kzpJdAPz9yrYEeLvulTH1g3y48oxE7rzVe8974gKM+uvOaMqUKWaHICIiIiJSJUxP3I4bN45hw4YxYMCA8yZuc3Nzyc3NLb6fkZEBgN1ux263V2uclbVk6yEAOsQEE+Dt7nTxXSi73Y7D4agzr+dMPVuG42azkJiaxZ7kdJqE+9d4DJmn8nnxqw1s3HcMCzB2QGuGX9IYiwWn+J1XR/9HBnkzfnA7XvlmEx8t3kmHmHrE1tHLlXccPMGxzFy8PWy0b1TPKfq0Mury3/+fHcusWOmOY5mnXOL3Udf63uFw8Ob3CeQV2OnUJITL2kbUmddWFRqH+VWoXT1fj2r7vV3MfkePHl2FkYiIiIiImMfUxO0nn3zC+vXrWbNmTYXaT5o0ieeee67M9tTUVHJynGvWx68JxkIncdG+pKSkmBxN1bHb7aSnp+NwOLBa694M0A4NAlmfeILv1+zmxm7RNXrsI+k5vLZgN8npuXi6Wbnn8iZ0ivElNTW1RuM4l+rq/9j67vRqHszy3WlM+nI9L1zfFt+zrHBe2y2MPwhAbHQAJ9KOmRxN5dX1v/8zWfIrlri15J+qU5/x5alrfb9idxob9h7D3Wbh1m4RTvU56wzCPR3U83Xn+Mn8ctsE+7oT7llQbe//zMzMKtvXnj17mDVrFnv27OH1118nPDycH374gUaNGtGuXbsqO46IiIiISFUzLTOyf/9+HnjgAX7++We8vLwq9JzHHnuMCRMmFN/PyMigYcOGhIWFERAQUF2hVtqR9FPsTc3GaoFBXZtTz8/T7JCqjN1ux2KxEBYWVie+vP/ZoM6FrE+MZ83edO4d2rHCNfIu1qbEY7zw7U4yT+UTFuDFszd1oWl953lPF6nO/v/H8GD2vb+MQ8ez+WhVMk9c36nGfv81ZdPBHQD069CQ8PBwk6OpvLr+93+mkNAwQhcnnbNcQliAF306NHWJGrd1qe8zT+XzyWpjQbJb+zSnfYtGJkfknMYNdvDCl+UvUHbv4FgiIqqv5EtFx4bn8/vvvzNkyBB69+7N4sWLefHFFwkPD2fjxo28//77fPHFF1VyHBERERGR6mBa4nbdunWkpKTQuXPn4m2FhYUsXryYt956i9zcXGw2W6nneHp64ulZNglqtVqd6ovk8h1GDcvYRsGEBHibHE3Vs1gsTvc7ryo9WkXg7WHjSPopdhzOoG2DetV+zAXx+3ljfgIFdgctowJ59qauhPhXzRfW6lBd/e/n7cHj13fmwZnLWLbjCD/GH2BYl5gqPYaZDqadJDE1C6vFQvcWEbX276cu//2fyWqFewa15fkv1pfb5tY+zXF3s5X7eF1TV/p+9qKdnDiZR6NQP27q3bzWv57q0rdtFE9ZLExbsLXUCYywAC/uHtiWPtW88GpV9cujjz7KCy+8wIQJE/D3LymBdPnll/PWW29Ven9Tp07llVdeITk5mbi4ON58800uueSS8z7vk08+4dZbb+Xaa69l3rx5lT6uiIiIiLgm0xK3V1xxBQkJCaW23XHHHbRu3ZpHHnmkTNK2Nlmy9TAAfav5S41UPS93Gz1b1ufXzYdYtPlQtSZu7Q4Hs37dwWfL9wDG++Wf18bh6V573/sXq0VkIHdc3poZv2xj+k9badcwmMYm1BquDitOn9Dp0DgYf293k6ORiujTJpKnbuhcJnHlZrVQYHfwy6aDDOrYsE4uHFhXbdmfVrzw4/3D2uOuvjunPm0i6dkqgoTEo+w9mEqT6DDax4TWqlnmCQkJzJkzp8z28PBwjh49Wql9ffrpp0yYMIHp06fTvXt3pkyZwqBBg9ixY8c5r6LYt28fDz/8MH379q10/CIiIiLi2kz7xuLv709sbGypm6+vLyEhIcTGxpoV1kVLST/FtoMnsAC9W0eYHY5cgP6xRm3bxVsPU1hNi67k5BXwwufripO2f+nbnMev7+TSSdsiI3o0oUuzMPIK7Ez6agO5+YVmh1QlVuw0Ere9WlbfpcVS9fq0ieTD+y/n5dt78Oh1HXn59h68e/dl+Hi6sfXAcT5YtNPsEKWC8gvtvD7fOGE8uGND2jeqm4sgVjWb1UKHmBB6Ng+mQ0xIrUraAgQFBXH48OEy2zds2EB0dOVq2b/22muMHTuWO+64g7Zt2zJ9+nR8fHyYOXNmuc8pLCxk5MiRPPfcczRt2rTS8YuIiIiIa9NUkyq2dHsyAO0aBTv15e5Svs5NQwnwduf4yVzi91X9AlJHM3L4xwcrWLbjCO42K48M78jofq2w1rF6rhfKarHwz2viqOfryb7UTN79eavZIV209Ow8tu5PA6CHEre1js1qIa5xCP1jo4lrHEJ0iC8Tru4AwGfL97B6V91fnKwu+HLFHySmZhHo48FfB7Q2OxypIbfccguPPPIIycnJWCwW7HY7y5Yt4+GHH2bUqFEV3k9eXh7r1q1jwIABxdusVisDBgxgxYoV5T7v3//+N+Hh4fz1r3+9qNchIiIiIq7JqZZtX7RokdkhXLSl24xZHZe20Wzb2srNZqVPm0i+X5/Eos2H6NI0rMr2vetwOs98uoZjmbkE+njwzE1daNdQs77+rJ6fJ/+8No7H56zmu3VJdG4aVqtnsK/adQS7A5rVD6B+kI/Z4UgV6Nsmkmu6xfDNmkRe+TqeqWP7Eh5Y92qa1xWHj2fz0ZJdAPz9yjYEeHuYHJHUlIkTJzJu3DgaNmxIYWEhbdu2pbCwkL/85S88+eSTFd7P0aNHKSwspH790iff6tevz/bt28/6nKVLl/L+++8THx9f4ePk5uaSm5tbfD8jIwMwFgi0V9NVQFKa3W7H4XDo9+2i1P+uTf3vutT3rs2M/q/MsZwqcVvbHc3IYcv+4wD0bq36trVZ/9govl+fxLLtydw3NBaPKliAaPn2ZCbPiyc3v5BGoX48f0s3IuopiVeeLs3CuLFnUz5f8QevfbuJFpGBtTYxtnz76TIJrTTbti4ZO6ANW/cfZ3dyBpO+2sAro3qo3q0TcjgcvPnDZvIK7HRsEsLl7St3ebzUbh4eHsyYMYOnn36ahIQEsrKy6NSpEy1atKjW42ZmZnL77bczY8YMQkNDK/y8SZMm8dxzz5XZnpqaSk5OzlmeIVXNbreTnp6Ow+HQ4oUuSP3v2tT/rkt979rM6P/MzMwKt1Xitgot227Mtm3boB6hASqTUJvFNgom1N+Lo5k5rN2dSq+LmO3pcDj4bPkfzPp1Ow6MhOQTIzrh66UFqs5ndP9WbEw8xs5D6bw0L56Xb++OrZb9R5qTX8j6P1IB6KnEbZ3i4Wbjies7M+69pcX1bv96hS7Bdza/bznMuj2puNus3D+kPRaVpXEpv/32G/3796dhw4Y0bNiw1GPvvPMOf//73yu0n9DQUGw2G0eOHCm1/ciRI0RElB0j7Nmzh3379nH11VcXbyuaWeHm5saOHTto1qxZmec99thjTJgwofh+RkYGDRs2JCwsjICAgArFKhfHbrdjsVgICwvTl3cXpP53bep/16W+d21m9L+XV8VzhkrcVqEl24z6tn3barZtbWe1WLisXSRfrtzLb1sOXXDiNr/QzhvzE/hp4wEAru4awz2D2ta65KNZ3G1WHruuE+NmLGVzUhofL9nNbZe1NDusStnwx1FyC+zUD/SmaX196a5rooJ9mXBVB174cj2fLd9D+0bBXNKi/NXlpWZl5eQz/SejTvatfZoTHeJrckRS0wYPHsz999/PxIkTcXc3TpgePXqUO+64g6VLl1Y4cevh4UGXLl1YuHAhw4cPB4xB/sKFCxk/fnyZ9q1btyYhIaHUtieffJLMzExef/31MknkIp6ennh6epbZbrVa9UWyBlksFv3OXZj637Wp/12X+t611XT/V+Y4ekdWkWOZOWxOMhYf6lOLa3FKif6xxuW0K3ceITu3oNLPz8jO47H/reKnjQewWuDewe0YPyRWSdtKigr25b6hsQB8tGQXCaf/zmqLFTuNEzo9WtbXTL86qm9bo94twCtfx5OaccrkiKTIzF+3c/xkLg1DfLmxV1OzwxET/Pbbb8ydO5du3bqxdetW5s+fT2xsLBkZGZWqPQswYcIEZsyYwQcffMC2bdu45557OHnyJHfccQcAo0aN4rHHHgOMWRSxsbGlbkFBQfj7+xMbG4uHh+osi4iIiMj5KYNURZbvSMYBtIkOqrV1OKW05hEBRAf7kldgZ8WO5Eo9d//RLO6fuYyEpDR8PNz49y3duLZb4+oJ1AVc3j6aAR2isTvgpbkbyDiVZ3ZIFVJod7ByZwqg+rZ13dgBbWgeEUDGqXwmfbWBQi1sYLqtB44zf10SAA8Ma18ltcql9unVqxfx8fHExsbSuXNnrrvuOh566CEWLVpETExMpfZ1880385///Ienn36ajh07Eh8fz48//li8YFlSUhKHDx+ujpchIiIiIi5KidsqUlQmoU8blUmoKywWC/1jowBYtOVQhZ+3Ye9RHpy1jMPHs6kf5M3/3dGLbs116fTFGjc4lqhgH1Izcpjy7SYcDofZIZ3XtgPHSc/Ow8/LjdhGwWaHI9WoqN6tj6cbW/Yf54PfdpodkksrKLTz+nfGZeoD4xrQPibE5IjETDt37mTt2rU0aNCguL5sdnb2Be1r/PjxJCYmkpuby6pVq+jevXvxY4sWLWL27NnlPnf27NnMmzfvgo4rIiIiIq5JidsqcOJkLgmJxwDo00ZlEuqSfu2MxO26P46Snn3+WZ7fr0/iiTmrycopoE2DIN64szeNw/2rO0yX4OPpxuMjOuNmtbBsxxHmr08yO6TzWrHTWMTmkubhuNn0cVvXFdW7Bfh0+R7W7E4xOSLX9eXKvexLzSTQx4OxA9qYHY6YaPLkyfTs2ZMrr7ySzZs3s3r1ajZs2ECHDh1YsWKF2eGJiIiIiJyTMglVYNn2ZOwOaBkVSESQj9nhSBVqGOpH84gACu0Olmwr//LHQruDd37eyuvzEyi0O+gfG8XLt/cgyLfsAiNy4VpEBnLnFa0BeOenrexLyTQ5ovI5HA6Wny6x0bOVTui4ir5tI7m6q3H59cvzVO/WDMnHs/losTHjeeyANgT4qJaoK3v99deZN28eb775ZnHd2dWrVzNixAj69etndngiIiIiIuekxG0VWHw6oddXZRLqpKJZt4s2n71cwqm8Av792Vq+WrkXgNsva8kjwzuqnmI1ua57E7o2CyOvwM7Er9aTk19odkhnlXQ0i0Np2bjbrHRtFmZ2OFKD7rpS9W7N4nA4ePOHzeQW2IlrHMKADtFmhyQmS0hIYMiQIaW2ubu788orr/DTTz+ZFJWIiIiISMUocXuRTpzMZdM+Y5V7JW7rpstOJ243J6WVmT2Xkn6KCbNXsHJXCu42K49d14nbLm2BxWIxI1SXYLVY+Oe1cdTz9SQxNYt3f95qdkhntWKHUSahY5MQfDzdTI5GapLq3Zpn8dbDrN2TirvNyv1DY/VZLISGhpb72GWXXVaDkYiIiIiIVJ6yCRdpxc4j2B0OmkcEEFlPZRLqovBAb2IbBbM5KY2Pl+ymfUwwwX5euNusPP/FOtKycgny9eDZm7rSpkE9s8N1CUG+nvxzeByPf7Sa+euS6Nwk1OkWBiyqb9uzZX2TIxEzRAX78tBVHXjxy/V8unwP7WOCtUhhNcvKyWf6T8aJnFt6N6NBiJ/JEYlZRowYwezZswkICGDEiBHnbPvVV1/VUFQiIiIiIpWnxO1FWrJVZRJcQcMQXzYnpTF/fVKZRbGahPvz3M1dqa/6xjWqS9MwbuzZlM9X/MH/fbeJllFBhAd6mx0WAMcyc9h+8AQAPZS4dVmXto1kU2IM365N5OV58bx9V1/CApzjPVoXzf5tB2lZuTQI9uWm3s3MDkdMFBgYWDzbOiAgQDOvRURERKTWUuL2ImRk57Fh7zFAidu6bOm2w/ywYX+5j9/Yq6mStiYZ3b8VGxOPsfNQOpPnbuCVUT2wWc2vALPy9Gzb1tFBhPh7mRyNmOmuK9uw7cBxdidnMOkr53mP1jXbDhznu7WJANw/rL1qjLu4WbNmFf88e/Zs8wIREREREblI+vZ4EYrKJDStH0B0iK/Z4Ug1KLQ7mLbg3DVUZ/26g0K7o4YikjMV1RX28TBqic5ZstvskACVSZASZerdLlK926pWUGjn9fkJOIAr4xoQ1zjE7JDECdjtdl566SV69+5Nt27dePTRRzl16tT5nygiIiIi4kSUuL0IS7YVlUmIMDkSqS6bk9I4mplzzjapGTlsTkqroYjkz6KCfblvaCwAc5bsIiHxmKnxZOcWEH96Jn7PVkrcSkm9W4BPl+1hze4UkyOqW+au2svelEwCvN0ZO6CN2eGIk3jxxRd5/PHH8fPzIzo6mtdff51x48aZHZaIiIiISKUocXuBMk/ls+GPo4DKJNRlaVnnTtpWtp1Uj8vbR3NlhwbYHTB5XjwZ2XmmxbJuTyr5hXaign1oFKrFkcRwadtIru4aA8ArX28kNUMz/6pC8ols/rt4FwBjr2xDoI+HyRGJs/jwww95++23WbBgAfPmzePbb7/lo48+wm63mx2aiIiIiEiFKXF7gVbuPEKB3UHjMH8aKjlTZwX7Vaw+aUXbSfUZN6Qd0cG+HM3I4f++24TDYU75iuU7kgHo1SpCC+JIKXdd2YbmEQGkZ+cx6asNFCqBdFEcDgdTf9hMbn4hHWKCubJDA7NDEieSlJTE0KFDi+8PGDAAi8XCoUOHTIxKRERERKRylLi9QMVlEtpqtm1dFtsomNDzLC4VFuBFbKPgGopIyuPt4cZjIzrhZrWwfMcRvluXVOMxFBTaWX36MnjVt5U/83Cz8fj1nYtrMqve7cVZui2Z1btTcbdZuW9oe50okVIKCgrw8ir9/7e7uzv5+fkmRSQiIiIiUnluZgdQG53MyWd9cZkE1bety2xWC/cMasvzX6wvt83dA9tisyph4AxaRAby1yta887P23jnp63ENqxHk/oBNXb8zUlpZOUUEOjjQZsG9WrsuFJ7RAf78uBV7Zn41QY+XbaH9o2C6dY83Oywap2TOfm8vWALADf1aqayJFKGw+FgzJgxeHp6Fm/Lycnh7rvvxte3ZEHZr776yozwREREREQqRDNuL8DKnUfIL7TTKNSPmDB/s8ORatanTSRP3dC5zMzbsAAvnrqhM31U49ipDO/ehG7Nw8gvtDPxqw3k5BfW2LFX7DwCQPcW4UrmS7kuaxelercXadZvO0jLyiU62Jdb+jQzOxxxQqNHjyY8PJzAwMDi22233UZUVFSpbSIiIiIizkwzbiuh0O5gc1IaX63aC0Dv1ppt6yr6tImkZ6sINielkZaVQ7CfUR5ByTnnY7VYePiaOO55dwlJR7N456etPDCsfbUf1+FwsHyHkbjt1UqfDXJud13Zhm0HjrM7OYNJX23glVE9sFl1LrUith88wXdrEwG4f2gsHm42kyMSZzRr1iyzQxARERERuWj6llhBS7cdZtQbv/Kv/65kd3IGAD9sSGLp6Vq3UvfZrBbiGofQPzaauMYhSto6sSBfT/55bUcswPfrk4prUlenP45kkJJ+Ck83K52ahlb78aR2U73bC1Not/P6/AQcwIAO0XRsor81ERERERGpu5S4rYCl2w7z/BfrOZqZU2r7iZN5PP/FeiVvRZxQ56ah3NjLuIR6ynebSEmv3svRV5yebdu5aRhe7poBKOdXVO8W4NNle1hzemE7Kd/cVfv440gG/t7ujB3QxuxwREREREREqpUSt+dRaHcwbcHWc7aZ/tNWCu2OGopIRCpqdL+WtIoKIiungMlzN1Bot1fbsYrq2/ZqXb/ajiF1z2XtoriqSyPAqHd7NCPnPM9wXUdOZPPh78bM5LED2hDk63meZ4iIiIiIiNRuStyex+aktDIzbf8sNSOHzUlpNRSRiFSUm83KYyM6FV+O/tHi3dVynCMnstmdnIHVAt1bKHErlfP3gW1pVj+A9Ow8JlXzCYbayuFwMPXHLeTmF9K+UTAD4xqYHZKIiIiIiEi1U+L2PNKyKjb7qaLtRKRmRdbz4f5hsQB8vHQXmxKPVfkxVp6ebdu2YTCBPh5Vvn+p2zzcbDxxut7t5qQ0PlS92zKWbU9m1a4U3KwW7h8ai8WiGuMiIiIiIlL3KXF7HsF+XlXaTkRqXv/YaK6Ma4DdAS/NjScjO69K97/8dOK2Z0vNtpULEx3iywOn691+smwPa/ekmhyR8ziZm8/bC7YAcFOvZjQK8zc5IhERERERkZqhxO15xDYKJtT/3EnZsAAvYhsF11BEInIhxg1uR4NgX45m5vDat5twOKqmLnXmqXwSEo1SKT1bKXErF67fGfVuX54Xr3q3p33w206OZeYSFezDLX2amx2OiIiIiIhIjVHi9jxsVgv3DGp7zjZ3D2yLzarLNkWcmbeHG4+N6IS7zcqKnUf4bl1ilex3ze4UCu0OYsL8iA72rZJ9iutSvdvSdhw6wTdr9gFw35D2eLrbzA1IRERERESkBilxWwF92kTy1A2dy8y8DQvw4qkbOtOnTaRJkYlIZTSPDOTOK1oD8M5P29h7JOOi97l8h8okSNVRvdsShXY7b8xPwAFc0T6azk1DzQ5JRERERESkRrmZHUBt0adNJD1bRbA5KY20rByC/YzyCJppK1K7XHdJYzb8kcrq3alM/GoDb/6tD14XOIsvr6CQtXtSAOjZKqIqwxQXVlTvdtJXG/hk2R7ax4TQtVmY2WHVuK9X72N3cgZ+Xu7cdWUbs8MRERERERGpcZpxWwk2q4W4xiH0j40mrnGIkrYitZDFYuEf18QR7OdJ0tEs3vlp6wXva+O+Y5zKKyTE35OWUYFVGKW4un7tohjmwvVuU9JP8cHp2cZ/G9CaIF9PkyMSERERERGpeUrciojLCfL15F/DO2IBvl+fxJKthy9oP0VlEnq0rI/VohM5UrXuHtiWpqfr3U52sXq3b/+4hZz8Qto1rMegjg3NDkdERERERMQUStyKiEvq1CSUm3o1A2DK/E0cOZFdqefbHQ5W7lR9W6k+Hm42nry+M94eNhKS0vjv77vMDqlGLN+ezIqdR3CzWnhgWHudFBEREREREZelxK2IuKxR/VrSOjqIrJwCJs+Nr9SMxp2H0knLysXHw424xiHVGKW4sugQXx4c1gGAT5buZu2eVJMjql7ZuQVM/XELADf0bEpMmL/JEYmIiIiIiJhHiVsRcVluNiuPXdcJH083th44zv8WV3xG4/IdyQB0bR6Gh9uFLW4mUhH9Yo16tw7qfr3bDxbt4GhmDpH1fPhL3xZmhyMiIiIiImIqJW5FxKVF1PPh/qGxAHy8ZDcb9x2r0PNW7FCZBKk5rlDvdtfhdL5Zsw+A+4bE4umuEyIiIiIiIuLalLgVEZfXPzaagXENimc0ZmTnnbP9wbSTJB3Nwma1cEmL8JoJUlxaXa93W2i3M+W7Tdgd0D82ii7NwswOSURERERExHRK3IqIAPcObkeDEF+OZubw6rebcDgc5bYtmm3bPiYYPy/3mgpRXFxdrnf7zZpEdidn4Oflxt+vbGt2OCIiIiIiIk5BiVsREcDbw43HruuEu83Kyp1H+HZtYrlti+rb9moVUVPhiQBGvduhnetWvdvUjFN8sGgHAH+9og31/DxNjkhERERERMQ5KHErInJa88hA/npFawDe/Xkbe5IzyrQ5cTKXbQeOA6pvK+aoa/Vup/24hVN5hbRtUI/BnRqaHY6IiIiIiIjTUOJWROQMwy9pzCUtwskvtDPpq/Xk5BWUenzVrhTsDmgeEUB4oLdJUYor83S38cT1nYrr3f6vFte7Xb4jmWU7jmCzWnhgWHusFovZIYmIiIiIiDgNJW5FRM5gsVj4x9UdCPbzZP+xk0z/aWupx4vq22q2rZipQYgfDwxrD8DHS3ezrhbWu83OLWDqj1sAuKFHUxqH+5sckYiIiIiIiHNR4lZE5E+CfD351/COWIAfNuxn8dbDFNodrNmdwprdKQB0b6HErZirf2x0cb3bl+bFcyyzdtW7/e/vOzmakUNEkDd/ubSF2eGIiIiIiIg4HSVuRUTOolOTUG7q3QyA/3wdz8jXF/Lkx2sosDsAePaztSzddtjMEEVqbb3bXYfTmbd6LwDjh8Ti5W4zOSIRERERERHno8StiEg5Rl3WkuhgH3IL7BzPyi312NHMHJ7/Yr2St2KqM+vdbkqsHfVuC+0O3pifgN0B/dpF0a15uNkhiYiIiIiIOCUlbkVEymGxWMjOKzxnm+k/baXw9CxcETPUtnq3363dx87D6fh6uvH3gW3MDkdERERERMRpKXErIlKOzUlpZWba/llqRg6bk9JqKCKRs6st9W5TM04x+7edANx5RWuC/bxMjkhERERERMR5KXErIlKOtKyKJb8q2k6kOt09sC1Nwv2dut7ttAVbyc4roE10EEM7NzI7HBEREREREaemxK2ISDmC/bwIc2TR3HG03FuYI0uzBsUpGPVuOzttvduVO4+wbHsyNquFB4a1x2qxmB2SiIiIiIiIU3MzOwAREWcVG1jITPvneFB+nds8bNgC+9dgVCLlaxhq1LudPDeej5fuJjYmmC5Nw8wOi1N5BUz9cQsAI7o3oUn9AJMjEhERERERcX6mzridNGkS3bp1w9/fn/DwcIYPH86OHTvMDElEpJjtVOY5k7YAHhRiO5VZQxGJnF+perdznaPe7X9/30lK+inqB3lz26UtzA5HRERERESkVjA1cfv7778zbtw4Vq5cyc8//0x+fj4DBw7k5MmTZoYlIiJSqzlTvds9yenMXbUPgPuGxOLloYt9REREREREKsLUxO2PP/7ImDFjaNeuHXFxccyePZukpCTWrVtnZlgiIoaMY2ZHIHJBytS7XWxOvdtCu4PX52/G7nBwadtIujUPNyUOERERERGR2sippr2kp6cDEBwcfNbHc3Nzyc3NLb6fkZEBgN1ux+6Eq2fXRXa7HYfDod+3i6qz/Z+fC8n74PAeaNQGIpoY248drNDZLbvDAXXtd3IWdbb/66joYB/uHxrLS/M28vGS3bRrUI/OTUMvaF8X2vffrU1kx6ET+Hi68fcBrfXeqaXM+NvXe0VERERExIkSt3a7nQcffJDevXsTGxt71jaTJk3iueeeK7M9NTWVnBzza/i5ArvdTnp6Og6HA6vV1AnbYoI60f+FhbilHcA9NQn3lH24pybhlnYIi8NIEmR2vYqTXX0B8HAL4OynkUpLS0vDfedGPA5sI7dxHLmN2uHw9KnGF2GOOtH/LqZtmBuXtQ7l9+1HmTx3A8+PaEM9X49K7+dC+v74yTxm/rodgBu6RlJwKoOUUxmVPraYz4y//cxM1Q4XEREREXGaxO24cePYvHkzS5cuLbfNY489xoQJE4rvZ2Rk0LBhQ8LCwggI0ArVNcFut2OxWAgLC1PixgXVuv63F0LqAbDaIKyBse1IItYvJ5dp6vANhKjm+DZqgW/46cu5C7MqdJjg4GAs677Dsi8B7z3rcFhtENMOR6tu0OoSCLywWY7Optb1vwDw0DUhJKatYF9KJu8vPcikkd2wVaT/0lMh20ie2e123PMzqFdow+o4/VwffwgMK/fpM77cQE6+nVZRgdx0aTtsVktVvBwxgRl/+15eXjVynMqaOnUqr7zyCsnJycTFxfHmm29yySWXnLXtjBkz+PDDD9m8eTMAXbp0YeLEieW2FxERERH5M6dI3I4fP57vvvuOxYsX06BBg3LbeXp64unpWWa71WpVEqEGWSwW/c5dmNP2v90OaYfh4C44tAcO7YbkvUYZhLh+cN0DRrvwRhAQaiRyo5pBVHOIao4lIAQsFkqlliwVSzRZLRa48nbYtgq2r8Jy9ADs3YRl7yb48X1o0ArunAjO9ju7AE7b/1Iub08rT17fmfHvLSUhKY05S/cwul+rcz/pRCpMvQ8K8gGjIH6ZFK2bO4yfCkFlk7erdh1h6fZkrBYLDwzrgLubrUpei5inpv/2nfEz5tNPP2XChAlMnz6d7t27M2XKFAYNGsSOHTsIDy9bv3nRokXceuut9OrVCy8vL1566SUGDhzIli1biI6ONuEViIiIiEhtY2ri1uFwcN999zF37lwWLVpEkyZNzAxHRGoLhwNyssHbKGlAQT785w7IOVm2rYc3WM5IANhs8NC7FUvK+gQYyanTyauzcnM32gWFQXQLGHAbHDsE21fD9lWwfwd4+ZRO2i6dC9HNoVFbIx6RatYw1I8HhrXnpXnxfLxkN7GNgunStPzZsmRnnPt9D8bj2RllErc5eQVM/WELACN6NKFZhK6IkbrhtddeY+zYsdxxxx0ATJ8+nfnz5zNz5kweffTRMu0/+uijUvffe+89vvzySxYuXMioUaNqJGYRERERqd1MTdyOGzeOOXPm8PXXX+Pv709ycjIAgYGBeHt7mxmaiDgLhwMy0+DgbmMWbdEttAH8dZLRxs0d/IONRFJk01IzaQmJKjvTtYIzaQkKM2YUZp+jLmdR0vZMIVHQe7hxyzoBp84ouZB+FH750PjZyw9adoHW3aFZR/DU555Un8vbR7Mp8Rg/bNjPS3PjmXZXX0L8q/5y9P8t3sWR9FOEB3pz+6Utqnz/ImbIy8tj3bp1PPbYY8XbrFYrAwYMYMWKFRXaR3Z2Nvn5+eUuwisiIiIi8memJm6nTZsGQL9+/UptnzVrFmPGjKn5gETEuXw9FXatg6zjZR9LSTLKIxQlZW97GvzqVf0M1qCws14KXmF+QcatSGE+dLwcdq41EsKbfjduNndo2gF6XmP8K1IN7hnUju0HT7A3JZPJczcw+bYeVVp7dk9yBl+u3AvAuMHt8PJwiopMIhft6NGjFBYWUr9+/VLb69evz/bt2yu0j0ceeYSoqCgGDBhQbpvc3Fxyc3OL72dkGCcO7XY7drv9AiKXyrLb7TgcDv2+XZT637Wp/12X+t61mdH/lTmW6aUSRMSFncoqqUd7aLdRV/OuV0pmxGanG0lbi9WoTXvmTNr6MaVn0taWBcCCI2H4fcbCaft3lJRUOJ5sJKk7XFbSNvM45GQZs4srOktY5Bw83W08cbre7abEND5avItR/VqWNHA4Lvi9Znc4eOP7BOwOB33bRNCjZf3zP0nERUyePJlPPvmERYsWnXPhtUmTJvHcc8+V2Z6amkpOTk51hiin2e120tPTcTgcTllrWaqX+t+1qf9dl/retZnR/5mZmRVuq6kwIudzIrXyl8rXJWe+focDt7Q0KMwqSe5U9vVvXgbbVxoJ27TDZR/POFaShO17A/QeARFNwKPswoS1mtUGMW2N28DRkLrfSOK26FzSZsMv8OscI9nb+hKjpEKDlsZzRS7QmfVu5yzZRedgB7FZ22HrCojtDT2uvqD9zl+XxPaDJ/DxcOOeQe2qOGoRc4WGhmKz2Thy5Eip7UeOHCEiIuKcz/3Pf/7D5MmT+eWXX+jQ4dxXVDz22GNMmDCh+H5GRgYNGzYkLCyMgADVi64Jdrsdi8VCWFiYvry7IPW/a1P/uy71vWszo//PdSL/z5S4FTmXE6nw1rjzL05Vzsrqtd6fXr8VKDOv9WyvPz8XkveWzKYdMtZYoAvgwA7YvLSkbb2I07NomxkLdvmc8cW0wRkzAesyi8WYURzeqPT2U1lgczMS3Mu/Nm4+AdCqG7S6xEjy2vQxLpV3ebQV94hEwg/G0+qr1JIHLJYLStwey8xh5q/G5eJjLm9VLbVzRczk4eFBly5dWLhwIcOHDweMQf7ChQsZP358uc97+eWXefHFF1mwYAFdu3Y973E8PT3x9Cx7otJqteqLZA2yWCz6nbsw9b9rU/+7LvW9a6vp/q/McfSNX+RcLmJl9Tqhoq8/eS/sXm8kaQ/uNurPOs6o2dLxCmgSa/zcpoeRfIxuDpHNwMe/+uKv7QbdAf1uMX6321eX1MXdsBC2LIN/fVjStiDfSKKLnIvdDjMfhwM76Ht6UyEW9no1oGn/wVjb9Kj8PjctZsH6I2Tn+tAyKpCrusRUacgizmLChAmMHj2arl27cskllzBlyhROnjzJHXfcAcCoUaOIjo5m0iRj4cyXXnqJp59+mjlz5tC4cePiRXj9/Pzw8/Mz7XWIiIiISO2hxK1IVXA4jITIn1ksJSUFKlLTubbWMd2/A5Z9VXqbb2BJPdqAkJLtReUBpGI8vaFdb+NWWACJW40krsVSkqh1OGD6BCMh3voSYzZuSKS5cYtzSNkPiVug22DjvtVq/G1arNA4lrSYLjy4ooAj+Z6MPNWcUQGnV7v3CTDeX+e72iDnJIVfv8VfCvOxWeLoOvi+Kl3sTMSZ3HzzzaSmpvL000+TnJxMx44d+fHHH4sXLEtKSio1e2LatGnk5eVxww03lNrPM888w7PPPluToYuIiIhILaXErUhVmPHPs2+/48WSJOXq7+GH98rfx8inSuqbrv8Fvplaftub/gVtexo/JyyBL/+v/LbX3Q9x/Yyfd6yBTyaX33bYXdB1kPHzH5vgw2fLb3um+o2haZwxi/bMZG1tTUQ7K5sbNO1g3M50PBmOHjB+TtoKP82GsIYlSdyo5qUXcpO6y+GAI4mwdblRs7bofdEszqiVDDBwDFxzL/gGEgyMCTlYXO82tlEwnZuGGlcQjJ9aXN/a7nCQlpZGcHAw1jPqW+d4+LLMrTVXFCZws2Mj/PAK3DABgsJr/KWL1ITx48eXWxph0aJFpe7v27ev+gMSERERkTpNiVuROqECs3mLm55lZnDxY3/eTwX3GxoFo56teAxStYIj4cF3jMT89lWwb4ux2FnqfljypVGzdPCdZkcp1enYYYhfaCRrjx0q2W51M5K2+Xkl2/40G/vy9tFsTDzGjxv289K8Dbw9tq9RozYorKQEjN1Ogc0PwsNLnQT4aOF2PivozmbfaO4vWIzlwA5j9vc140pOLomIiIiIiMgFUeJWpDwF+bDup4q1HfUcRDQuu93Tp+TnzgMgtm/ZNsVtvUt+bt8XWp5jEZMz99u6Ozw8q2L7bRoH/5hZsf02agMjn4aP/l1+e3EeQeHQfZhxO5UFu9YZJRV2ry89Q/fgLlg2z3jftOgC3r6mhSwXweEwPqPcPYz7R/YZSXoAmzs072QkTlt1A6/z9/G9g9qx4+AJ9qZk8tK8eCaN7H7ekgd7j2Tw5co/AOh+7XAsYcPhi9fg4E747GW4ZBgM+atm3ouIiIiIiFwgJW5Fzmb/dvjmbWPGYkV4+Ro1Ic/F3dO4VUSl2nqUJG+qsq2bO/ie5zWJc/L2gw6XGbeC/NKJs60rTl9GvxysNohpV1JS4WwL7J1ILb5cHocDt7Q0KMwq2adPQN1cmM8Z2e1GUnTrCuPW6Qrod7PxWPPO0K6P0Zctu5Y+YVMBnu42Hr++M/e9t5SN+44xZ8kubr+sZfmhOBy8Pj+BQruD3q0j6NHSqPHJnS/Cwo9g+Tzw8lHSVkRERERE5CIocStyNqu+N5K2Xn6Qk2V2NCIXrmgBsyLt+xoLU+1YbbzH924ybj+8BxFN4C9PlCwmdyIV3hpXvECVFQg92/7HT1XytrrYC43F/7Yuh60rIfNYyWO71pUkbj084cZ/XNShGoX68cCw9rw0L56PFhv1bjs1KdPjAPywPoltB0/g4+HGvYPalTxgc4OBo42Zvg1alWzPPVXpZLKYTCdtRERERERMp8StSJGC/JIk1+A7jVmLXa6E9x45/8rq55ttW1tVdGX5uvr666KIJsZtwG1GLdTtq40k7v4dkHEM/IJK2m5ecu6+B+Px7AwlcKqDwwFvP1iywBiAh7eRFG3bC5p3rPJDlqp3Ozeet+/qQ7CfV6k2aVk5vL9wOwCj+7ckNMCr7I6KFmUE4z0y60moHwNDxyqBWxvopI2IiIiIiFNQ4lYk8zj8+L5xGfLN/zK2+QXBsLuMn89YWf2s6vKsowquLF9nX39dFxIFvYcbt5PpcPSgUT4BjL+H5V+bGZ1rKSyAfZthbwJccZsxq9FigajmkHXcKGXRtic061h2FnUVu2dQO7YfOMG+1EwmzzXq3Z5Z8OCdn7ZxMreAFpGBXN218fl3uG+zUYM3+Q84sNOYGRzRpJqilyqRnaGTNiIiIiIiTkCJW3FdDgdsWAg/zYack8bl4yn7Ibxh6XZnrqzuiiqwsrzUAb6Bxq1Ifi40bAU71lTgyQ5Y8yMEhhmLpAWFgcdZZmFKaQX5RpmKrStg+ypjUTkwatVGnk5sDhoD19xb7cnaM3m523jihpJ6t/9bvJO4mGD2Hkwjb3cmi7YcwmqBB4a1P+8CZoCxUNqY542Fy44dhBmPwKA7oNtg1cAVERERERE5ByVuxTUdOwTfTjNmggFENoVrxpVN2oq4Kk9vuOzmiiVuc7Jh/jult/kElCRxW3SFTpcb2x0OIynsyondw3th5TdGmYrc7JLtPgHQpkfpBQTPTKbXoEahftw/NJaXv97InCW7mbOk9OPdmofTIrISscW0hXteg3lvws618P27RtL6mnFGWRoREREREREpQ4lbcS2FBcbl379/BgV54OYB/W+FHleDzWZ2dCK1U0E+tO4OJ1KMW85J4xLq7Aw4tBv8g4HTidtTmfDy6NKJ3aDwkltYI6gXburLqXL5ucatqBZ0djpsXGT87FcP2nQ3atY2autUn0Oe7uXHsmpXCku3HaZPm8iK79AnAG59HFZ+Bz9/CNtWGjNub/pXFUQrIiIiIiJS9yhxK66lIB/WLjCStk3j4Kq7ITjC7KhEaje/ILjl0ZL7p05CekpJIrf+GfVMT6Qa/56Z2D3TJcNg6N9O7ycLvn3bSOgG/inJ6+wLXOXlwK71RhmEnWuh60CjPABA41joda1Rt7Zhq5K6wk6k0O5g2oKt52wz/aet9GwVUbFyCUUsFuh5NTRqA99NhyvHXFygUvWStht130VERERExHRK3Erdl5dr1Ie0Wo1kzzX3GguSxfVTfUWR6uDtC95Nzr4AVVQzeOR/pxO7qSXJ3ROn74c1KGl7/IiR+DzrMfyNRdX6jDDu5+Ual95XZWL3RGrlFibMPWUkabeugF3rjBNERQ6ekaC2ucHAMRcfXzXanJTG0cycc7ZJzchhc1IacY1DKn+A6OZw1yulP4M3/AotOhsnAqTmHdoDv86B3evNjkRERERERE5T4lbqtt3x8N00I7nTdZCxrVlHMyMSqT18AoyTHudaXd7NvaQEQEWdK7F7Jv96MPivpRO7J1IgJ8souXDmTNVjB+HjiWccw690CYZW3YyZrmDU2T3fSZsTqfDWuPO/9vFTjeStwwHTHoITR0oer1ffKIHQtidENT/38ZxMWta5k7aVbXdWZ/bBrvXw9ZtG6YgRD0LTDhe+X6mcI4nw28fGAnlgLNTZqlvJfRERERERMY0St1I3ncyABbNg0yLj/uofoPOVxqxbEamYoDAjMXl61qnd4SAtLY3g4GCsRUm3P886rUr+wdDjqrLbc7IhPRV8/Eu2FRYYiwyeSDFKLBTdDv9Rsq+ixG3yXvjwmdKJ3TNv9eobr/lcSVswHj95wnj9FosxW3RPPLTrZSRsI5rU2ln9wX4VWzyuou3OKzAUwhpC6n748Fnoez30u8Wpav7WSdtWwacvAQ4jYdv+UrjsJmNW+O71VX/SRkREREREKkWJW6lbHA5IWAw/zjydbLIYiZ/+typpK3IhgsJKErN2OwU2PwgPN/fvycsHvGJKb2vQEv7+qvFzUWL3zDIMDVuVtD0zuVuU2D3TlaOhSfuKxZK8F6JbGD8PHGMks2ppsvZMsY2CCfX3Ome5hLAAL2IbBVfNAcMbwdhXjNqq63+GJV9A4ha4foKR1JWqU1hYkhBv2gF8A6FxO+h3s5E8L2LmSRsREREREQGUuJW65EQKfDsd9mww7ofHGPVsG7Q0Ny4RqVlFid36MWd/vHknuGdK2RIMRbeg8Iofy/+M+q7uHhcVtjOxWS3cM6gtz39Rfr3Tuwe2rdzCZOfj4Wl8ZjftAN9Og6RtMP0hGH6/cem+XJz0o7D4c+Nkxd9eKqn7ft9b4OVbtr0znrQREREREXExStxK3XEyA/7YCDZ341LP3sONyz1FRM7k7mkkdctL7DocZ5+JezZ1eCGtPm0ieeqGzkxbsLXUzNuwAC/uHtiWPm0iq+fAsX2MmsBfvAqHdkNudvUcx1VkpsGSr2DdAqOkCEDS1pLSIWdL2oqIiIiIiFNQVktqt+yMkhp70c1h2N+NSz5Do82NS0RqrzpQ6qCq9GkTSc9WESQkHmXvwVSaRIfRPia0amfank1wBNw5EbathPZ9S7afeZm/nNvJdFg216jxXpBnbItpB5f/BWLamhubiIiIiIhUiBK3Ujvl58Lvn8Gq+UZdxPDTdfm6DjQ3LhGROsZmtdAhJoQI70LCw0OwVnfStoibe+mkbdYJmPWkcUVFh0trJobaKvUAzPgn5J2eKd2glZGwbdJeJyZERERERGoRJW6l9tmbYNQ/TDts3N+yDMJvMTcmERGpXqu+g2MH4av/M8riDB0LHl5mR+U87PaS+rOh0RASZfzc/y/QorMStiIiIiIitZASt1J7nMqCnz6ADb8Y9/2DYehd0Ka7uXGJSN3jE2DM+CzIL7+Nm3tJqRapfv1vBaubscBW/K9wYCfc+HD5tYpdRV6OUQ5hw0K46xVjwTGLBUY+Bb6BStiKiIiIiNRiStxK7bBtJXz3Dpw8YdzvOhgG3KZFVUSkegSFwfipRh3t8vgEGO2kZlht0P8WY1Gtr/4Pjh6AGf+CwXdCl4Gul6DMzzMWHFvyVcn/jfG/Qvdhxs91eOE8ERERERFXocSt1A5ph40vpqHRcPW9WlhFRKpfUJgSs86oSSzc/RrMexN2rYPvpkNhQUnCsq4ryDdm1y7+AjKPGduC6kO/m6D9ZebGJiIiIiIiVUqJW3FOdjtkHYeAEON+j2vAzRO6XGlcniwiIq7LNxBufRxWfgvrf4a4/mZHVDPycmDag3D8iHE/IAQuvQk6XQ42DelclcPhoKCggMLCQrNDqRPsdjv5+fnk5ORgLaob7SJsNhtubm5YXO0KBhERESemUb44n5T98O3bcCoT7v4/I1Frs0H3oWZHJiIizsJqhV7XwiVDS07oORywfRW0uqRkoa7azuEoKQPh4QXRLSEvFy69ATpfCe4e5sYnpsrLy+Pw4cNkZ2ebHUqd4XA4sNvtZGZmumQC08fHh8jISDw89NkiIiLiDJS4FedRkA9LvjRu9gLjC2ryXmjQ0uzIRETEWZ15FcbqH+CHGdC8M1x3vzEzt7YqSkL//rmxCFtIpLF98J3g4Q0enubGJ6az2+3s3bsXm81GVFQUHh4eLplorGpFM5hdbeapw+EgLy+P1NRU9u7dS4sWLVxuxrGIiIgzUuJWnEPSNvjmbWOxGYCWXWHY3yEw1Ny4RESk9nD3ADcP2L0epk+AEQ8ZNXFrE4cDdq2H3+bA4T+MbcvmwjX3Gj9r0TE5LS8vD7vdTsOGDfHx8TE7nDrDVRO3AN7e3ri7u5OYmEheXh5eXl5mhyQiIuLylLgVcxXkw4KZsOZH475vIAwZC+16ud4K4SIicnE6D4DoFvD5f4wTgR88DZfdaNSBtdnMju7cHA7YmwC/fgQHdhrbPLygx9XQ8xpzYxOnplmRUpX0fhIREXEuStyKuWxucOyw8XOnK+DK0eDjb25MIiJSe9WPgbtegR/ehw2/wO+fwb7NxuxbZ76K45PJsGO18bObh1G7t/d14BtgblwiIiIiImIanVKVmpeZBjknjZ8tFrj6Hhj1HFw7XklbERG5eB5ecO04uH6C8XPSdkg/anZU5xbZ1DiZ2X0YPDAdBo5W0lZc1pgxYxg+fHiV7W/27NkEBQVV2f5EREREaopm3ErNcThg/S/w02yI7WMkbAHq1TduIiIiVal9X4hqDvu3Q6PWJdsdDnPL8STvhd8+hm5DoHknY1vPa4wrT5x5VrBIFRkzZgwffPABAO7u7jRq1IhRo0bx+OOP4+bmxuuvv47D4TA5ShERERHzKXErNePoQfh2GiRuMe4f/gPy84yFZERERKpLSKRxK5KSBPPfMa7yCI4s/3nVIWU/LPoEti437p/MKEncenobNxGTrExM4KWFs3nkijH0iGlf7ccbPHgws2bNIjc3l++//55x48bh7u7OY489RmBgYLUf39nl5eXh4aFxsoiIiKtTqQSpXoUFsPgLmPaQkbR194SBY+Cvk5W0FRGRmjf/XUjcCtP/AQlLauaYxw7DV1Pg7QdOJ20tENsXht9XM8cXOQ+Hw8Ebiz/mj7SDvLH44xqZ7erp6UlERAQxMTHcc889DBgwgG+++QYoXSohNTWViIgIJk6cWPzc5cuX4+HhwcKFCwHIzc3l4YcfJjo6Gl9fX7p3786iRYsqFc8jjzxCy5Yt8fX1pVWrVjz11FPk5+eXavPtt9/SrVs3vLy8CA0N5brrrit+LDc3l0ceeYSGDRvi6elJ8+bNef/994Gzl2qYN28eljNm/j/77LN07NiR9957jyZNmuDl5QXAjz/+SJ8+fQgKCiIkJISrrrqKPXv2lNrXgQMHuPXWWwkODsbX15euXbuyatUq9u3bh9VqZe3ataXaT5kyhZiYGOx2e6V+RyIiIlLzNONWqk/qAWNl75RE436zjnDV3SqLICIi5hnxIHz5GiRtM/7duwkG/w08PKvneL9/Bos+BcfpBEmbHtDvFmMRNZEq5nA4OJWfW+nnrUxMYMuRPwDYcuQPftu9tlKzbr3dPUslIS+Et7c3x44dK7M9LCyMmTNnMnz4cAYOHEirVq24/fbbGT9+PFdccQUA48ePZ+vWrXzyySdERUUxd+5cBg8eTEJCAi1atKjQ8f39/Zk9ezaRkZHEx8dzzz33EBAQwL/+9S8A5s+fz3XXXccTTzzBhx9+SF5eHt9//33x80eNGsWKFSt44403iIuLY+/evRw9Wrna2rt37+bLL7/kq6++wmazAXDy5EkmTJhAhw4dyMrK4umnn+a6664jPj4eq9VKVlYWl112GdHR0XzzzTdERESwfv167HY7jRs3ZsCAAcyaNYuuXbsWH2fWrFmMGTMGq1VzeERERJydErdSfXz8jYXIvP1h8J3Q4TJzawqKiIgEhsLo5+H3T40rQtb/Avt3wI0PQ3ijqj9eSJSRtG3RBfrfClHNqv4YIqedys+l5xtjLno/D339aqXar7h/Nj4eXhd0LIfDwcKFC1mwYAH33Xf2WehDhw5l7NixjBw5kq5du+Lr68ukSZMASEpKYtasWSQlJREVFQXAww8/zI8//sisWbNKzdQ9lyeffLI4ngYNGrB7924+/fTT4sTtiy++yC233MJzzz1X/Jy4uDgAdu7cyWeffcbPP//MgAEDAGjatGmlfxd5eXl8+OGHhIWFFW+7/vrrS7WZOXMmYWFhbN26ldjYWObMmUNqaipr1qwhODgYgObNmxe3/9vf/sbdd9/Na6+9hqenJ+vXrychIYGvv/660vGJiIhIzVPiVqrWwd3Gl1KLBXwD4ZZHITTa+FlERMQZ2Gxw+V+gcaxRwiB1P7z7T7hz4sUlVrNOwLK5Ru3cboONbW17wdgIiG5+zqeKuJrvvvsOPz8/8vPzsdvt/OUvf+HZZ58tt/1//vMfYmNj+fzzz1m3bh2ensYs+YSEBAoLC2nZsmWp9rm5uYSEhFQ4nk8//ZQ33niDPXv2kJWVRUFBAQEBAcWPx8fHM3bs2LM+Nz4+HpvNxmWXXVbh451NTExMqaQtwK5du3j66adZtWoVR48eLS5vkJSURGxsLPHx8XTq1Kk4aftnw4cPZ9y4ccydO5dbbrmF2bNn079/fxo3bnxRsYqIiEjNUOJWqsbJdPhxJiQshpv+BW17Gttj2pobl4iISHmadoC7X4O5b0BBLtRvfGH7yc6E5V/DqvmQnwO+QdCxv1HX3WpV0lZqjLe7Jyvun13h9g6Hg79++m92pO7DfkZdW6vFQquwxrx/89MVKoHg7V75UiP9+/dn2rRpeHh4EBUVhZvbub+W7Nmzh0OHDmG329m3bx/t2xulHLKysrDZbKxbt664vEARPz+/CsWyYsUKRo4cyXPPPcfAgQPx9fXliy++4LXXXitu4+1d/uKB53oMwGq1lqkb/Of6uQC+vr5ltl199dXExMQwY8YMoqKisNvtxMbGkpeXV6Fje3h4MGrUKGbNmsWIESOYM2cOr7/++jmfIyIiIs5DiduKOJEK2RnlP+4TAEFh5T9e2535+h0O3NLSoDDrdNkDh7HIy+Iv4FQmWKxw9ICp4YqIiFSYXxCMfBJyTxkzcQEK8uGPBPA7x9UiPgHg5QMrvoWV30JutrE9qjlcPhLctACn1DyLxVKpkgXL9m5kW8reMtvtDgfbUvYSf2gnvZvEVWWIxXx9fUtd0n8ueXl53Hbbbdx88820atWKv/3tbyQkJBAeHk6nTp0oLCwkJSWFvn37XlAsy5cvJyYmhieeeAKHw0FBQQGJiYml2nTo0IGFCxdyxx13lHl++/btsdvt/P7778WlEs4UFhZGZmYmJ0+eLE7OxsfHnzeuY8eOsWPHDmbMmFH82pYuXVomrvfee4+0tLRyZ93+7W9/IzY2lrfffpuCggJGjBhx3mOLiIiIc1Di9nxOpMJb44wvceVxc4fxU+tm8vZPr98KhJbXtn5juOZeiK7YIhAiIiJOwWoF7zNmun07HTb+ep7n2IwZtUUJ2/qNjfILLbuqnrvUCg6Hg6lLP8WCBQeOMo9bsDB16af0atzhohceu1hPPPEE6enpvPHGG/j5+fH9999z55138t1339GyZUtGjhzJqFGjePXVV+nUqROpqaksXLiQDh06MGzYsPPuv0WLFiQlJfHJJ5/QtWtXvv32W+bNm1eqzTPPPMMVV1xBs2bNuOWWWygoKOD777/nkUceoXHjxowePZo777yzeHGyxMREUlJSuOmmm+jevTs+Pj48/vjj3H///axatYrZs2efN6569eoREhLCu+++S2RkJElJSTz66KOl2tx6661MnDiR4cOHM2nSJCIjI9mwYQNRUVH07GlcAdemTRt69OjBI488wp133nneWboiIiLiPLSU6PlkZ5w7aQvG4+eakVubVeT1A3QbAne9oqStiIjUbvZCyEitWLvcbAhtYCxs9vdXoVU3JW2l1sgvLCA589hZk7YADhwkZx4jv7CghiMrbdGiRUyZMoX//ve/BAQEYLVa+e9//8uSJUuYNm0aALNmzWLUqFH84x//oFWrVgwfPpw1a9bQqFHFFhy85ppreOihhxg/fjydOnVixYoVxYuVFenXrx+ff/4533zzDR07duTyyy9n9erVxY9PmzaNG264gXvvvZfWrVszduxYTp48CUBwcDD/+9//+P7772nfvj0ff/zxOev5FrFarXzyySesW7eO2NhYHnroIV555ZVSbTw8PPjpp58IDw9n6NChtG/fnsmTJ5cpG/HXv/6VvLw87rzzzgr9TkRERMQ5WBx/LrhUi2RkZBAYGEh6enqpxQOq1KE98O7D5293/QQIawBefiUzb+2FkJJU/nM8faFeeMn95LKXqhXz8IbgiDPa7oNyBtq4e0FIZMn9I4nGitZn4+ZhLB5WJGU/2M8YoKcegC9fK/u8P7vrP1op2wXY7XZSUlIIDw/HatV5H1ej/nddLtf3h3Ybi5Wdz1X3QOcrjNm3dZgZ/V8jY7xa4Fy/h5ycHPbu3UuTJk3w8qp4eYQzJWcc5fipzHIfD/YJoL5/xRf4qguKSiW4ubmZPtO4Kj3//PN8/vnnbNq06ZztquJ9VZu53P93Uor633Wp712bs491VSqhqhQlN+P6w3X3Gz8X5MP0CeU/p20vuOmML4bnatuii1GDr8h7j0BB3tnbxrSDO14ouf/B0+XPCI5qbsyULfLR85BegZlGIiIidVYFkzVRzep80lbqtoiAUCICyi2CJXVAVlYW+/bt46233uKFF144/xNERETEqShxW1W8/cHmBl5nrgZrAb9653jOn1a6rWzb8hK3Pv6l7/sGlv/F0iegbNszL4krLDAWHRMRERERkVpl/PjxfPzxxwwfPlxlEkRERGohJW6ryu3PlC0V4OEJD8+s+D4q0/bB6RVvO+6Nire9q3TdrAqXihAREREREacye/bsCi2EJiIiIs5JxTtEREREREREREREnIwStyIiIiIiIiIiIiJORonb8/EJADf3c7dxcy9bK7aucPXXLyIirkf/90kt4nA4zA5B6hC9n0RERJyLU9S4nTp1Kq+88grJycnExcXx5ptvcskll5gdliEoDMZPheyM8tv4BBjt6qI/vX67w0FaWhrBwcFYLadX3a7Lr19ERFyPq//fL7WCu7txciE7Oxtvb2+To5G6Ijs7Gyh5f4mIiIi5TE/cfvrpp0yYMIHp06fTvXt3pkyZwqBBg9ixYwfh4eFmh2cICnPtL2dnvn67nQKbH4SHg1UTtkVEpI5y9f/7xenZbDaCgoJISUkBwMfHB0vRSXW5YA6Hg4KCAtzc3Fzq9+lwOMjOziYlJYWgoCBsNpvZIYmIiAhOkLh97bXXGDt2LHfccQcA06dPZ/78+cycOZNHH33U5OhERERERJxTREQEQHHyVi6ew+HAbrdjtVpdKnFbJCgoqPh9JSIiIuYzNXGbl5fHunXreOyxx4q3Wa1WBgwYwIoVK8q0z83NJTc3t/h+Rsbpy/ftdux2e/UHLNjt9uIBrbge9b9rU/+7LvW9azOj//VeqxiLxUJkZCTh4eHk5+ebHU6dYLfbOXbsGCEhIVhd7Ooyd3d3zbQVERFxMqYmbo8ePUphYSH169cvtb1+/fps3769TPtJkybx3HPPldmemppKTk5OtcUpJex2O+np6TgcDpcbzIr639Wp/12X+t61mdH/mZmZNXKcyqrsugyff/45Tz31FPv27aNFixa89NJLDB06tMrjstlsSrhVEbvdjru7O15eXvq8ExEREdOZXiqhMh577DEmTJhQfD8jI4OGDRsSFhZGQIBWdq4Jdrsdi8VCWFiYBrMuSP3v2tT/rkt979rM6H8vL68aOU5lVHZdhuXLl3PrrbcyadIkrrrqKubMmcPw4cNZv349sbGxJrwCEREREaltTE3choaGYrPZOHLkSKntR44cOWttJU9PTzw9Pctst1qt+iJZgywWi37nLkz979rU/65Lfe/aarr/nfF9Vtl1GV5//XUGDx7MP//5TwCef/55fv75Z9566y2mT59eo7GLiIiISO1k6qjYw8ODLl26sHDhwuJtdrudhQsX0rNnTxMjExERERExFK3LMGDAgOJt51qXAWDFihWl2gMMGjSo3PYiIiIiIn9meqmECRMmMHr0aLp27coll1zClClTOHnyZPFshnNxOBxAySJlUv3sdjuZmZmq++Wi1P+uTf3vutT3rs2M/i8a2xWN9cxW2XUZAJKTk8/aPjk5udzj/Hkh3vT0dABOnDihBdtqiN1uJyMjAw8PD33euSD1v2tT/7su9b1rM6P/KzPWNT1xe/PNN5OamsrTTz9NcnIyHTt25Mcffywz0D2booUrGjZsWN1hioiIiEgNy8zMJDAw0Owwakx5C/HGxMSYEI2IiIiIVKeKjHVNT9wCjB8/nvHjx1f6eVFRUezfvx9/f38sFks1RCZ/VrQg3P79+7UgnAtS/7s29b/rUt+7NjP63+FwkJmZSVRUVI0c73wquy4DQERERKXaQ9mFeO12O2lpaYSEhGisW0P0eefa1P+uTf3vutT3rs3Zx7pOkbi9UFarlQYNGpgdhksKCAjQB5oLU/+7NvW/61Lfu7aa7n9nmml75roMw4cPB0rWZShv8kHPnj1ZuHAhDz74YPG2n3/++ZzrOJxtId6goKCLDV8ugD7vXJv637Wp/12X+t61OetYt1YnbkVEREREasL51mUYNWoU0dHRTJo0CYAHHniAyy67jFdffZVhw4bxySefsHbtWt59910zX4aIiIiI1CJK3IqIiIiInMf51mVISkoqtaBFr169mDNnDk8++SSPP/44LVq0YN68ecTGxpr1EkRERESkllHiVirF09OTZ555psxlfOIa1P+uTf3vutT3rk39X+Jc6zIsWrSozLYbb7yRG2+8sZqjkqqk97trU/+7NvW/61LfuzZn73+Lw+FwmB2EiIiIiIiIiIiIiJSwnr+JiIiIiIiIiIiIiNQkJW5FREREREREREREnIwStyIiIiIiIiIiIiJORolbOa9JkybRrVs3/P39CQ8PZ/jw4ezYscPssMQkkydPxmKx8OCDD5oditSQgwcPcttttxESEoK3tzft27dn7dq1ZoclNaCwsJCnnnqKJk2a4O3tTbNmzXj++edRefy6afHixVx99dVERUVhsViYN29eqccdDgdPP/00kZGReHt7M2DAAHbt2mVOsCJVTONdKaKxruvRWNd1aazrWmrrWFeJWzmv33//nXHjxrFy5Up+/vln8vPzGThwICdPnjQ7NKlha9as4Z133qFDhw5mhyI15Pjx4/Tu3Rt3d3d++OEHtm7dyquvvkq9evXMDk1qwEsvvcS0adN466232LZtGy+99BIvv/wyb775ptmhSTU4efIkcXFxTJ069ayPv/zyy7zxxhtMnz6dVatW4evry6BBg8jJyanhSEWqnsa7AhrruiKNdV2bxrqupbaOdS0OnUqQSkpNTSU8PJzff/+dSy+91OxwpIZkZWXRuXNn3n77bV544QU6duzIlClTzA5Lqtmjjz7KsmXLWLJkidmhiAmuuuoq6tevz/vvv1+87frrr8fb25v//e9/JkYm1c1isTB37lyGDx8OGDMQoqKi+Mc//sHDDz8MQHp6OvXr12f27NnccsstJkYrUvU03nU9Guu6Jo11XZvGuq6rNo11NeNWKi09PR2A4OBgkyORmjRu3DiGDRvGgAEDzA5FatA333xD165dufHGGwkPD6dTp07MmDHD7LCkhvTq1YuFCxeyc+dOADZu3MjSpUsZMmSIyZFJTdu7dy/Jycml/g8IDAyke/furFixwsTIRKqHxruuR2Nd16SxrmvTWFeKOPNY183Uo0utY7fbefDBB+nduzexsbFmhyM15JNPPmH9+vWsWbPG7FCkhv3xxx9MmzaNCRMm8Pjjj7NmzRruv/9+PDw8GD16tNnhSTV79NFHycjIoHXr1thsNgoLC3nxxRcZOXKk2aFJDUtOTgagfv36pbbXr1+/+DGRukLjXdejsa7r0ljXtWmsK0WceayrxK1Uyrhx49i8eTNLly41OxSpIfv37+eBBx7g559/xsvLy+xwpIbZ7Xa6du3KxIkTAejUqRObN29m+vTpGsy6gM8++4yPPvqIOXPm0K5dO+Lj43nwwQeJiopS/4tInaXxrmvRWNe1aazr2jTWldpApRKkwsaPH893333Hb7/9RoMGDcwOR2rIunXrSElJoXPnzri5ueHm5sbvv//OG2+8gZubG4WFhWaHKNUoMjKStm3bltrWpk0bkpKSTIpIatI///lPHn30UW655Rbat2/P7bffzkMPPcSkSZPMDk1qWEREBABHjhwptf3IkSPFj4nUBRrvuh6NdV2bxrquTWNdKeLMY10lbuW8HA4H48ePZ+7cufz66680adLE7JCkBl1xxRUkJCQQHx9ffOvatSsjR44kPj4em81mdohSjXr37s2OHTtKbdu5cycxMTEmRSQ1KTs7G6u19FDBZrNht9tNikjM0qRJEyIiIli4cGHxtoyMDFatWkXPnj1NjEykami867o01nVtGuu6No11pYgzj3VVKkHOa9y4ccyZM4evv/4af3//4voegYGBeHt7mxydVDd/f/8y9d18fX0JCQlR3TcX8NBDD9GrVy8mTpzITTfdxOrVq3n33Xd59913zQ5NasDVV1/Niy++SKNGjWjXrh0bNmzgtdde48477zQ7NKkGWVlZ7N69u/j+3r17iY+PJzg4mEaNGvHggw/ywgsv0KJFC5o0acJTTz1FVFRU8Wq8IrWZxruuS2Nd16axrmvTWNe11NaxrsXhcDhMjUCcnsViOev2WbNmMWbMmJoNRpxCv3796NixI1OmTDE7FKkB3333HY899hi7du2iSZMmTJgwgbFjx5odltSAzMxMnnrqKebOnUtKSgpRUVHceuutPP3003h4eJgdnlSxRYsW0b9//zLbR48ezezZs3E4HDzzzDO8++67nDhxgj59+vD222/TsmVLE6IVqVoa78qZNNZ1LRrrui6NdV1LbR3rKnErIiIiIiIiIiIi4mRU41ZERERERERERETEyShxKyIiIiIiIiIiIuJklLgVERERERERERERcTJK3IqIiIiIiIiIiIg4GSVuRURERERERERERJyMErciIiIiIiIiIiIiTkaJWxEREREREREREREno8StiIiIiIiIiIiIiJNR4lZEpI6zWCzMmzfP7DBERERERKqcxroiUpcpcSsiUo3GjBmDxWIpcxs8eLDZoYmIiIiIXBSNdUVEqpeb2QGIiNR1gwcPZtasWaW2eXp6mhSNiIiIiEjV0VhXRKT6aMatiEg18/T0JCIiotStXr16gHFp17Rp0xgyZAje3t40bdqUL774otTzExISuPzyy/H29iYkJIS77rqLrKysUm1mzpxJu3bt8PT0JDIykvHjx5d6/OjRo1x33XX4+PjQokULvvnmm+p90SIiIiLiEjTWFRGpPkrcioiY7KmnnuL6669n48aNjBw5kltuuYVt27YBcPLkSQYNGkS9evVYs2YNn3/+Ob/88kupweq0adMYN24cd911FwkJCXzzzTc0b9681DGee+45brrpJjZt2sTQoUMZOXIkaWlpNfo6RURERMT1aKwrInLhLA6Hw2F2ECIiddWYMWP43//+h5eXV6ntjz/+OI8//jgWi4W7776badOmFT/Wo0cPOnfuzNtvv82MGTN45JFH2L9/P76+vgB8//33XH311Rw6dIj69esTHR3NHXfcwQsvvHDWGCwWC08++STPP/88YAyQ/fz8+OGHH1R/TEREREQumMa6IiLVSzVuRUSqWf/+/UsNVgGCg4OLf+7Zs2epx3r27El8fDwA27ZtIy4urnggC9C7d2/sdjs7duzAYrFw6NAhrrjiinPG0KFDh+KffX19CQgIICUl5UJfkoiIiIgIoLGuiEh1UuJWRKSa+fr6lrmcq6p4e3tXqJ27u3up+xaLBbvdXh0hiYiIiIgL0VhXRKT6qMatiIjJVq5cWeZ+mzZtAGjTpg0bN27k5MmTxY8vW7YMq9VKq1at8Pf3p3HjxixcuLBGYxYRERERqQiNdUVELpxm3IqIVLPc3FySk5NLbXNzcyM0NBSAzz//nK5du9KnTx8++ugjVq9ezfvvvw/AyJEjeeaZZxg9ejTPPvssqamp3Hfffdx+++3Ur18fgGeffZa7776b8PBwhgwZQmZmJsuWLeO+++6r2RcqIiIiIi5HY10RkeqjxK2ISDX78ccfiYyMLLWtVatWbN++HTBWwf3kk0+49957iYyM5OOPP6Zt27YA+Pj4sGDBAh544AG6deuGj48P119/Pa+99lrxvkaPHk1OTg7/93//x8MPP0xoaCg33HBDzb1AEREREXFZGuuKiFQfi8PhcJgdhIiIq7JYLMydO5fhw4ebHYqIiIiISJXSWFdE5OKoxq2IiIiIiIiIiIiIk1HiVkRERERERERERMTJqFSCiIiIiIiIiIiIiJPRjFsRERERERERERERJ6PErYiIiIiIiIiIiIiTUeJWRERERERERERExMkocSsiIiIiIiIiIiLiZJS4FREREREREREREXEyStyKiIiIiIiIiIiIOBklbkVEREREREREREScjBK3IiIiIiIiIiIiIk5GiVsRERERERERERERJ/P/hbtV0d6KPeYAAAAASUVORK5CYII=",
-      "text/plain": [
-       "<Figure size 1400x400 with 2 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "fig, axes = plt.subplots(1, 2, figsize=(14, 4))\n",
-    "\n",
-    "ax = axes[0]\n",
-    "ax.plot(epochs, train_losses, marker=\"o\", label=\"Train loss\", color=\"steelblue\")\n",
-    "if test_losses:\n",
-    "    ax.plot(epochs, test_losses, marker=\"s\", linestyle=\"--\", label=\"Test loss\", color=\"coral\")\n",
-    "ax.set_xlabel(\"Epoch\")\n",
-    "ax.set_ylabel(\"Loss\")\n",
-    "ax.set_title(\"Training & Test Loss (Session 1, 10 Epochs)\")\n",
-    "ax.legend()\n",
-    "ax.grid(True, alpha=0.3)\n",
-    "\n",
-    "ax = axes[1]\n",
-    "if test_metrics:\n",
-    "    acc_values   = [m[\"pixel_accuracy\"] if m else None for m in test_metrics]\n",
-    "    valid_epochs = [e for e, a in zip(epochs, acc_values) if a is not None]\n",
-    "    valid_acc    = [a for a in acc_values if a is not None]\n",
-    "    ax.plot(valid_epochs, valid_acc, marker=\"^\", color=\"seagreen\", label=\"Pixel accuracy\")\n",
-    "    ax.set_ylim(0, 1)\n",
-    "ax.set_xlabel(\"Epoch\")\n",
-    "ax.set_ylabel(\"Pixel Accuracy\")\n",
-    "ax.set_title(\"Validation Pixel Accuracy (Session 1)\")\n",
-    "ax.legend()\n",
-    "ax.grid(True, alpha=0.3)\n",
-    "\n",
-    "plt.tight_layout()\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
+   "execution_count": null,
+   "id": "38904131",
    "metadata": {},
-   "source": [
-    "---\n",
-    "\n",
-    "## 🗂️ Step 3: List Training Sessions for This Dataset\n",
-    "\n",
-    "`list_training_sessions` returns all sessions the server knows about, optionally filtered by dataset artifact ID. This is useful to find earlier sessions or check on sessions from previous notebook runs."
-   ]
+   "outputs": [],
+   "source": "# Additional notes about the API\n\nprint(\"\"\"\n### Cellpose Fine-Tuning API Summary (with Real-Time Progress Tracking)\n\nThe async API provides the following methods:\n\n1. start_training() - Start asynchronous fine-tuning\n   Parameters:\n   - artifact: Artifact ID containing training data\n   - train_images: Path pattern for training images (e.g., \"*.tif\" or \"images/*.ome.tif\")\n   - train_annotations: Path pattern for annotations (e.g., \"annotations/*_mask.tif\")\n   - test_images: Optional test images path pattern\n   - test_annotations: Optional test annotations path pattern\n   - model: Pretrained model to start from (default: \"cpsam\")\n   - n_epochs: Number of training epochs\n   - n_samples: Number of samples to use (optional)\n   - learning_rate, weight_decay: Training hyperparameters\n   \n2. get_training_status(session_id) - Monitor training progress with real-time updates\n   Returns comprehensive status dict with:\n   - status_type: \"waiting\", \"preparing\", \"running\", \"completed\", or \"failed\"\n   - message: Human-readable status message\n   - train_losses: Per-epoch training loss values (updated in real-time)\n   - test_losses: Per-epoch test loss values (computed periodically)\n   - n_train: Number of training samples\n   - n_test: Number of test samples\n   - start_time: Training start time (ISO 8601 format)\n   - current_epoch: Current epoch number (1-indexed)\n   - total_epochs: Total number of epochs\n   - elapsed_seconds: Elapsed time since training started\n   \n3. infer() - Run inference with a model\n   Parameters:\n   - model: Model ID (session_id for fine-tuned, or \"cpsam\" for pretrained)\n   - artifact: Artifact ID containing images\n   - image_paths: List of image paths within the artifact\n   - diameter: Expected cell diameter (optional, auto-detected if None)\n   - flow_threshold: Flow error threshold (default: 0.4)\n   - cellprob_threshold: Cell probability threshold (default: 0.0)\n   - niter: Number of iterations for dynamics (default: None, auto-set)\n   \n4. list_pretrained_models() - Get available pretrained models\n   \n### Key Features:\n- Real-time progress tracking with epoch-by-epoch updates\n- Comprehensive training metrics including losses, timing, and dataset info\n- Path-based training API with wildcard patterns for flexible file matching\n- Cellpose-SAM is channel-order invariant - no need to specify channel order\n- Automatically uses first 3 channels of your image\n- For best results, use flow_threshold=0.4, cellprob_threshold=0, niter=250\n\"\"\")"
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-13T07:44:30.191769Z",
-     "iopub.status.busy": "2026-04-13T07:44:30.191332Z",
-     "iopub.status.idle": "2026-04-13T07:44:30.322730Z",
-     "shell.execute_reply": "2026-04-13T07:44:30.321308Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Found 10 training session(s) for dataset 'bioimage-io/annotation-mnw8359y-ehab':\n",
-      "\n",
-      "  Session : 5115b385-4504-4969-b751-cadbd4d6eb20\n",
-      "    Status    : running  |  Epochs: 10/10  |  Elapsed: 38s\n",
-      "    Base model: cpsam  |  Exported: —\n",
-      "\n",
-      "  Session : edadb072-605f-49ca-a3cd-3ba9975431b6\n",
-      "    Status    : completed  |  Epochs: 10/10  |  Elapsed: 40s\n",
-      "    Base model: cpsam  |  Exported: —\n",
-      "\n",
-      "  Session : 1887bf8a-5ce1-4298-a0f9-bfbbc9baebe3\n",
-      "    Status    : completed  |  Epochs: 10/10  |  Elapsed: 43s\n",
-      "    Base model: 836013ce-b1a7-48ce-b3f9-4aa5c414b112  |  Exported: bioimage-io/cellpose-1887bf8a\n",
-      "\n",
-      "  Session : c11b13b2-1acc-4e2d-9bc0-dfcc6bee7594\n",
-      "    Status    : completed  |  Epochs: 10/10  |  Elapsed: 41s\n",
-      "    Base model: 836013ce-b1a7-48ce-b3f9-4aa5c414b112  |  Exported: —\n",
-      "\n",
-      "  Session : 092a8f89-63ce-4e66-8a07-d18ea62ab196\n",
-      "    Status    : completed  |  Epochs: 10/10  |  Elapsed: 43s\n",
-      "    Base model: cpsam  |  Exported: —\n",
-      "\n",
-      "  Session : 836013ce-b1a7-48ce-b3f9-4aa5c414b112\n",
-      "    Status    : completed  |  Epochs: 10/10  |  Elapsed: 42s\n",
-      "    Base model: cpsam  |  Exported: —\n",
-      "\n",
-      "  Session : aab49e8e-3526-4368-b80c-e1ab5728cd1c\n",
-      "    Status    : failed  |  Epochs: 0/?  |  Elapsed: —\n",
-      "    Base model: cpsam  |  Exported: —\n",
-      "\n",
-      "  Session : 491e5e88-74dc-4975-afeb-cdfc795f1933\n",
-      "    Status    : failed  |  Epochs: 0/?  |  Elapsed: —\n",
-      "    Base model: cpsam  |  Exported: —\n",
-      "\n",
-      "  Session : 3ee1888f-1fd1-4473-aa9f-8d43b0eb1d2c\n",
-      "    Status    : completed  |  Epochs: 10/10  |  Elapsed: 96s\n",
-      "    Base model: cpsam  |  Exported: —\n",
-      "\n",
-      "  Session : e617fc71-abfb-4473-9366-8e0869e31947\n",
-      "    Status    : completed  |  Epochs: 10/10  |  Elapsed: 98s\n",
-      "    Base model: cpsam  |  Exported: —\n",
-      "\n",
-      "✅ Session 'edadb072-605f-49ca-a3cd-3ba9975431b6' is present in the list.\n"
-     ]
-    }
-   ],
-   "source": [
-    "sessions = await cellpose_svc.list_training_sessions(\n",
-    "    dataset_artifact_ids=[DATASET_ARTIFACT]\n",
-    ")\n",
-    "\n",
-    "print(f\"Found {len(sessions)} training session(s) for dataset '{DATASET_ARTIFACT}':\\n\")\n",
-    "\n",
-    "for sid, s in sessions.items():\n",
-    "    st      = s.get(\"status_type\", \"unknown\")\n",
-    "    epoch   = s.get(\"current_epoch\") or 0\n",
-    "    total   = s.get(\"total_epochs\") or \"?\"\n",
-    "    model   = s.get(\"model\", \"?\")\n",
-    "    elapsed = s.get(\"elapsed_seconds\")\n",
-    "    elapsed_str = f\"{elapsed:.0f}s\" if elapsed is not None else \"—\"\n",
-    "    exported = s.get(\"exported_artifact_id\") or \"—\"\n",
-    "    print(\n",
-    "        f\"  Session : {sid}\\n\"\n",
-    "        f\"    Status    : {st}  |  Epochs: {epoch}/{total}  |  Elapsed: {elapsed_str}\\n\"\n",
-    "        f\"    Base model: {model}  |  Exported: {exported}\\n\"\n",
-    "    )\n",
-    "\n",
-    "assert session_id in sessions, \"⚠️  Our session was not found in the list!\"\n",
-    "print(f\"✅ Session '{session_id}' is present in the list.\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
+   "execution_count": null,
+   "id": "4f02e08e",
    "metadata": {},
-   "source": [
-    "---\n",
-    "\n",
-    "## 🔄 Step 4: Continue Training for 10 More Epochs\n",
-    "\n",
-    "`restart_training` creates a new session that picks up from the checkpoint of an existing **completed** session. The weights from the previous run become the starting model, accumulating training across sessions.\n",
-    "\n",
-    "Here we add 10 more epochs, bringing the effective total to **20 epochs**."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-13T07:44:30.327360Z",
-     "iopub.status.busy": "2026-04-13T07:44:30.326926Z",
-     "iopub.status.idle": "2026-04-13T07:44:30.525915Z",
-     "shell.execute_reply": "2026-04-13T07:44:30.524588Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "🔄 Continued training started!\n",
-      "{\n",
-      "  \"status_type\": \"preparing\",\n",
-      "  \"message\": \"Preparing for training...\",\n",
-      "  \"dataset_artifact_id\": \"bioimage-io/annotation-mnw8359y-ehab\",\n",
-      "  \"model\": \"edadb072-605f-49ca-a3cd-3ba9975431b6\",\n",
-      "  \"n_epochs\": 10,\n",
-      "  \"learning_rate\": 1e-06,\n",
-      "  \"weight_decay\": 0.0001,\n",
-      "  \"min_train_masks\": 5,\n",
-      "  \"validation_interval\": 1,\n",
-      "  \"session_id\": \"7e546f39-50dd-4919-88cf-88456b7ca298\",\n",
-      "  \"restarted_from\": \"edadb072-605f-49ca-a3cd-3ba9975431b6\"\n",
-      "}\n"
-     ]
-    }
-   ],
-   "source": [
-    "continued_result = await cellpose_svc.restart_training(\n",
-    "    session_id=session_id,\n",
-    "    n_epochs=10,\n",
-    ")\n",
-    "\n",
-    "continued_session_id = continued_result[\"session_id\"]\n",
-    "\n",
-    "print(\"🔄 Continued training started!\")\n",
-    "print(json.dumps(continued_result, indent=2, default=str))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-13T07:44:30.530745Z",
-     "iopub.status.busy": "2026-04-13T07:44:30.530075Z",
-     "iopub.status.idle": "2026-04-13T07:45:32.103432Z",
-     "shell.execute_reply": "2026-04-13T07:45:32.102059Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[preparing   ] epoch 0/?  elapsed=—  Listing files and matching training pairs from artifact...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[running     ] epoch 3/10  elapsed=8s  Training epoch 3/10 (batch 1/2)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[running     ] epoch 6/10  elapsed=23s  Training in progress (epoch 6/10)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[running     ] epoch 10/10  elapsed=38s  Training in progress (epoch 10/10)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[completed   ] epoch 10/10  elapsed=43s  Training completed successfully\n",
-      "\n",
-      "✅ Continued session '7e546f39-50dd-4919-88cf-88456b7ca298' finished with status: completed\n"
-     ]
-    }
-   ],
-   "source": [
-    "prev_epoch = -1\n",
-    "while True:\n",
-    "    status2 = await cellpose_svc.get_training_status(session_id=continued_session_id)\n",
-    "    st2     = status2.get(\"status_type\", \"unknown\")\n",
-    "    epoch2  = status2.get(\"current_epoch\") or 0\n",
-    "    total2  = status2.get(\"total_epochs\") or \"?\"\n",
-    "    elapsed2 = status2.get(\"elapsed_seconds\")\n",
-    "    msg2    = status2.get(\"message\", \"\")\n",
-    "\n",
-    "    if epoch2 != prev_epoch or st2 in TERMINAL_STATES:\n",
-    "        elapsed_str = f\"{elapsed2:.0f}s\" if elapsed2 is not None else \"—\"\n",
-    "        print(f\"[{st2:12s}] epoch {epoch2}/{total2}  elapsed={elapsed_str}  {msg2}\")\n",
-    "        prev_epoch = epoch2\n",
-    "\n",
-    "    if st2 in TERMINAL_STATES:\n",
-    "        break\n",
-    "\n",
-    "    await asyncio.sleep(15)\n",
-    "\n",
-    "print(f\"\\n✅ Continued session '{continued_session_id}' finished with status: {status2['status_type']}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "\n",
-    "## 📊 Step 5: Visualise Losses and Metrics for Both Sessions\n",
-    "\n",
-    "We plot the losses from **both** sessions as a combined 20-epoch view, with a vertical line marking the session boundary."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-13T07:45:32.107797Z",
-     "iopub.status.busy": "2026-04-13T07:45:32.107348Z",
-     "iopub.status.idle": "2026-04-13T07:45:32.185092Z",
-     "shell.execute_reply": "2026-04-13T07:45:32.183691Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Session 1: 10 epochs  (base model: cpsam)\n",
-      "Session 2: 10 epochs  (started from Session 1 checkpoint)\n",
-      "Total effective epochs: 20\n",
-      "\n",
-      "Session 2 per-epoch summary:\n",
-      "  Epoch 11  train_loss=3.1094  test_loss=0.2969  pixel_acc=0.9560\n",
-      "  Epoch 12  train_loss=8.9531  test_loss=0.2969  pixel_acc=0.9560\n",
-      "  Epoch 13  train_loss=3.5312  test_loss=0.2969  pixel_acc=0.9560\n",
-      "  Epoch 14  train_loss=3.7031  test_loss=0.2979  pixel_acc=0.9560\n",
-      "  Epoch 15  train_loss=3.3906  test_loss=1.6182  pixel_acc=0.8033\n",
-      "  Epoch 16  train_loss=8.8125  test_loss=0.2979  pixel_acc=0.9560\n",
-      "  Epoch 17  train_loss=4.5312  test_loss=0.2979  pixel_acc=0.9560\n",
-      "  Epoch 18  train_loss=0.8145  test_loss=0.2959  pixel_acc=0.9560\n",
-      "  Epoch 19  train_loss=3.6055  test_loss=0.2969  pixel_acc=0.9560\n",
-      "  Epoch 20  train_loss=4.0000  test_loss=0.2969  pixel_acc=0.9560\n"
-     ]
-    }
-   ],
-   "source": [
-    "status2 = await cellpose_svc.get_training_status(session_id=continued_session_id)\n",
-    "\n",
-    "train_losses2 = status2.get(\"train_losses\") or []\n",
-    "test_losses2  = status2.get(\"test_losses\")  or []\n",
-    "test_metrics2 = status2.get(\"test_metrics\") or []\n",
-    "n2 = len(train_losses2)\n",
-    "\n",
-    "all_train   = train_losses  + train_losses2\n",
-    "all_test    = test_losses   + test_losses2\n",
-    "all_metrics = test_metrics  + test_metrics2\n",
-    "all_epochs  = list(range(1, len(all_train) + 1))\n",
-    "\n",
-    "print(f\"Session 1: {n_epochs_run} epochs  (base model: cpsam)\")\n",
-    "print(f\"Session 2: {n2} epochs  (started from Session 1 checkpoint)\")\n",
-    "print(f\"Total effective epochs: {len(all_epochs)}\")\n",
-    "print()\n",
-    "print(\"Session 2 per-epoch summary:\")\n",
-    "for i, (tl, vl) in enumerate(zip(train_losses2, test_losses2)):\n",
-    "    acc = test_metrics2[i][\"pixel_accuracy\"] if i < len(test_metrics2) and test_metrics2[i] else None\n",
-    "    acc_str = f\"{acc:.4f}\" if acc is not None else \"—\"\n",
-    "    print(f\"  Epoch {n_epochs_run + i + 1:2d}  train_loss={tl:.4f}  test_loss={vl:.4f}  pixel_acc={acc_str}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-13T07:45:32.189278Z",
-     "iopub.status.busy": "2026-04-13T07:45:32.188848Z",
-     "iopub.status.idle": "2026-04-13T07:45:32.459580Z",
-     "shell.execute_reply": "2026-04-13T07:45:32.459072Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABW4AAAGGCAYAAADrbBjiAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjYsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvq6yFwwAAAAlwSFlzAAAPYQAAD2EBqD+naQABAABJREFUeJzs3Xd4U9UbwPFvku7J6GAUaIEyCh3IhrJkyxSRpSwFVBygggxBQEREkGUVEBnKkiE/wMGGyt6U1VLKpozuSXdyf3+EBEI60pkUzud5+kBu7r3n3JOb5Nw3575HJkmShCAIgiAIgiAIgiAIgiAIgmAy5MaugCAIgiAIgiAIgiAIgiAIgqBLBG4FQRAEQRAEQRAEQRAEQRBMjAjcCoIgCIIgCIIgCIIgCIIgmBgRuBUEQRAEQRAEQRAEQRAEQTAxInArCIIgCIIgCIIgCIIgCIJgYkTgVhAEQRAEQRAEQRAEQRAEwcSIwK0gCIIgCIIgCIIgCIIgCIKJEYFbQRAEQRAEQRAEQRAEQRAEEyMCt4IgCIIgCIIgCIIgCIIgCCZGBG4FoZQYNmwY7u7uBdp2+vTpyGSyoq2QUCqNHj2ajh07GrsaJqlt27bUr1/f2NUoETKZjOnTp2sfL126lKpVq5Kenm68SgmCIAgm5/bt28hkMlavXq1dlp9+5fPfN0Whbdu2tG3btkj3WZSKu98dGBiITCYjMDCw2MoQdG3atIly5cqRnJxs7KqYHM35Hh0dbeyqFLvnP3uCg4MxMzPj8uXLxquU8FIQgVtBKCSZTGbQ38vcuVKpVMybNw9PT0+sra2pUaMGH3zwgUGdH80FgyF/t2/fLnRdHzx4wPTp0wkKCjJo/dWrVyOTyThz5kyhyy5ut27d4tdff2Xy5MnaZffu3WPGjBk0adKEsmXL4uTkRNu2bdm3b1+2+4iPj2fUqFE4Oztja2tLu3btOHfunEHlt23bNsfXrk6dOkVyjKYqt2N/9s+Qi9v169ezcOHCIq3fsGHDyMjIYNmyZUW6X0EQBKHk9OzZExsbG5KSknJc56233sLCwoKYmJgSrFn+BQcHM3369CLp2xUVTcBU82dubk716tUZMmQIN2/eNHb1cvXzzz8jk8lo2rSpsatS6iiVSqZNm8bHH3+MnZ0dACkpKfz000906tSJihUrYm9vT4MGDViyZAlKpVJvHyqViu+//x4PDw+srKzw8fFhw4YNBpWvCYzm9Pfo0aMiPV5Tktexa/4M+SHn2LFjTJ8+nfj4+CKrn5eXF926deOrr74qsn0KQnbMjF0BQSjt1qxZo/P4999/Z+/evXrL69atW6hyli9fjkqlKtC2U6ZMYeLEiYUqvzAWLVrE+PHj6d27N+PHj+fOnTts2LCBCRMmaDtAOXF2dtZryx9++IHw8HAWLFigt25hPXjwgBkzZuDu7o6fn1+h92dKFi1ahIeHB+3atdMu2759O3PmzKF3794MHTqUrKwsfv/9dzp27MjKlSsZPny4dl2VSkW3bt24cOEC48ePx8nJiZ9//pm2bdty9uxZPD0986yDm5sbs2fP1lvu6OhYNAdpor788ktGjBihfXz69GkWL17M5MmTdT4bfHx88tzX+vXruXz5MmPHji2y+llZWTF06FDmz5/Pxx9/LEboC4IglEJvvfUWf/31F//73/8YMmSI3vMpKSls376dLl26UL58+QKXUxL9yuDgYGbMmEHbtm317jjbs2dPsZadl08++YTGjRuTmZnJuXPn+OWXX/jnn3+4dOkSlSpVMnq/Ozvr1q3D3d2dU6dOcf36dWrWrGnsKpUaf/31F6GhoYwaNUq77ObNm3z88ce0b9+ezz77DAcHB3bv3s3o0aM5ceIEv/32m84+vvzyS7777jtGjhxJ48aN2b59O4MGDUImkzFgwACD6rFkyZJsr5vKlClTqOMzZX369NE5V5OTk/nggw94/fXX6dOnj3a5q6trnvs6duwYM2bMYNiwYUXaZu+//z6vvfYaN27coEaNGkW2X0HQIQmCUKQ+/PBDyZC31uPHj0ugNqahSZMmUr169SSVSqVdplQqpczMzALtr1u3blK1atWKqHa6Tp8+LQHSqlWrDFp/1apVEiCdPn26WOpTVDIyMiQnJydpypQpOssvX74sRUVF6SxLS0uT6tSpI7m5ueks37hxowRImzdv1i6LjIyUypQpIw0cODDPOrRp00aqV69eIY6ieJVk/TZv3iwB0sGDB/O9bVGc/4A0bdo0nWVnzpyRAGn//v2F2rcgCIJgHCkpKZK9vb3UuXPnbJ9fv369BEh//PGHwfu8detWvvpFz8vu+8YQhfmeLC4HDx7U6wdJkiQtXrxYAqRvv/22ROthaNvcvHlTAqStW7dKzs7O0vTp04u3goWQnJxs7Cro6dmzp+Tv76+zLCoqSrp8+bLeusOHD5cAKSwsTLssPDxcMjc3lz788EPtMpVKJbVq1Upyc3OTsrKyci1/2rRpEqDXXzcVJVm/qKioAn+mzJ07VwKkW7duFbj8Nm3aSG3atNFZlpGRIZUtW1aaOnVqgfcrCHkRqRIEoQRocmeePXuW1q1bY2Njo71dffv27XTr1o1KlSphaWlJjRo1mDlzpt5tNs/nuNWkEJg3bx6//PILNWrUwNLSksaNG3P69GmdbbPLtSWTyfjoo4/Ytm0b9evXx9LSknr16rFr1y69+gcGBtKoUSOsrKyoUaMGy5Yty1f+Lrlcjkql0llfLpdjZlZ0g/7T09OZNm0aNWvWxNLSkipVqvDFF1/o5ezcu3cv/v7+lClTBjs7O2rXrq19LQIDA2ncuDEAw4cP195+82xet4I6f/48Xbt2xcHBATs7O9q3b8+JEyd01snMzGTGjBl4enpiZWVF+fLl8ff3Z+/evdp1Hj16xPDhw3Fzc8PS0pKKFSvSq1evPG8lPHLkCNHR0XTo0EFneb169XByctJZZmlpyWuvvUZ4eLjO7ZZbtmzB1dVV5xduZ2dn+vXrx/bt24ssP6rm3Lp69Sr9+vXDwcGB8uXLM2bMGNLS0nTWzcrKYubMmdrz393dncmTJ2dbl507d9KmTRvs7e1xcHCgcePGrF+/Xm+94OBg2rVrh42NDZUrV+b777/XW+fHH3+kXr162NjYULZsWRo1apTtvvLr559/pl69elhaWlKpUiU+/PBDnVu62rZtyz///MOdO3e056fmcyEjI4OvvvqKhg0b4ujoiK2tLa1ateLgwYMGld2wYUPKlSvH9u3bC30cgiAIQsmztramT58+7N+/n8jISL3n169fj729PT179iQ2NpZx48bh7e2NnZ0dDg4OdO3alQsXLuRZTnZ9wPT0dD799FOcnZ21ZYSHh+tte+fOHUaPHk3t2rWxtramfPnyvPnmmzr9mNWrV/Pmm28C0K5dO720Y9nluI2MjOTdd9/F1dUVKysrfH199UY95qfvnB+vvvoqoE5JlV37rFq1CplMxsqVK3W2+/bbb5HJZPz777/aZVevXqVv376UK1cOKysrGjVqxI4dOwpcN1CPti1btizdunWjb9++rFu3Ltv14uPj+fTTT3F3d8fS0hI3NzeGDBmik7s0LS2N6dOnU6tWLaysrKhYsSJ9+vThxo0bQM75d7PLlTxs2DDs7Oy4ceMGr732Gvb29rz11lsAHD58mDfffJOqVatq+/WffvopqampevXW9BednZ2xtramdu3afPnllwAcPHgQmUzG//73P73t1q9fj0wm4/jx4zm2XVpaGrt27dLrPzs5OVGvXj299V9//XUAQkJCtMu2b99OZmYmo0eP1i6TyWR88MEHhIeH51p+fmjafuPGjUyePJkKFSpga2tLz549uXfvnt76mzdvpmHDhlhbW+Pk5MTbb7/N/fv39dbLrX2fFR8frx3N6ujoyPDhw0lJSdFZJ7frsMI4cOAArVq1wtbWljJlytCrVy+d12D69OmMHz8eAA8PD700e6tWreLVV1/FxcUFS0tLvLy8WLJkiUFlm5ub07ZtW9F/FoqVSJUgCCUkJiaGrl27MmDAAN5++23tLR2rV6/Gzs6Ozz77DDs7Ow4cOMBXX31FYmIic+fOzXO/69evJykpiffeew+ZTMb3339Pnz59uHnzJubm5rlue+TIEbZu3cro0aOxt7dn8eLFvPHGG9y9e1d7C9358+fp0qULFStWZMaMGSiVSr7++ut8pSUYPnw47733HsuWLeO9994zeDtDqVQqevbsyZEjRxg1ahR169bl0qVLLFiwgGvXrrFt2zYArly5Qvfu3fHx8eHrr7/G0tKS69evc/ToUUCdzuLrr7/mq6++YtSoUbRq1QqAFi1aFKp+V65coVWrVjg4OPDFF19gbm7OsmXLaNu2Lf/9958239j06dOZPXs2I0aMoEmTJiQmJnLmzBnOnTunnVDsjTfe4MqVK3z88ce4u7sTGRnJ3r17uXv3bq6T1x07dgyZTEaDBg0MqvOjR4+wsbHBxsZGu+z8+fO88soryOW6v/k1adKEX375hWvXruHt7Z3rfpVKZbaTF1hbW2Nra6uzrF+/fri7uzN79mxOnDjB4sWLiYuL4/fff9euM2LECH777Tf69u3L559/zsmTJ5k9ezYhISE6nfTVq1fzzjvvUK9ePSZNmkSZMmU4f/48u3btYtCgQdr14uLi6NKlC3369KFfv35s2bKFCRMm4O3tTdeuXQF12pJPPvmEvn37aoPJFy9e5OTJkzr7yq/p06czY8YMOnTowAcffEBoaChLlizh9OnTHD16FHNzc7788ksSEhJ0UoVobptLTEzk119/ZeDAgYwcOZKkpCRWrFhB586dOXXqlEGpP1555RXt+0EQBEEofd566y1+++03Nm3axEcffaRdHhsby+7duxk4cCDW1tZcuXKFbdu28eabb+Lh4UFERATLli2jTZs2BAcHU6lSpXyVO2LECNauXcugQYNo0aIFBw4coFu3bnrrnT59mmPHjjFgwADc3Ny4ffs2S5YsoW3btgQHB2NjY0Pr1q355JNP9FIK5ZR2LDU1lbZt23L9+nU++ugjPDw82Lx5M8OGDSM+Pp4xY8borF+YvnN2NEHLnNJPDB8+nK1bt/LZZ5/RsWNHqlSpwqVLl5gxYwbvvvsur732GqDuL7Zs2ZLKlSszceJEbG1t2bRpE7179+bPP//UBgXza926dfTp0wcLCwsGDhyo7VtoBiuA+hb0Vq1aERISwjvvvMMrr7xCdHQ0O3bsIDw8HCcnJ5RKJd27d2f//v0MGDCAMWPGkJSUxN69e7l8+XKBbhPPysqic+fO+Pv7M2/ePG2/c/PmzaSkpPDBBx9Qvnx5Tp06xY8//kh4eDibN2/Wbn/x4kVatWqFubk5o0aNwt3dnRs3bvDXX38xa9Ys2rZtS5UqVVi3bp1e+61bt44aNWrQvHnzHOt39uxZMjIyeOWVVww6Hk2+2WcHRZw/fx5bW1u987dJkyba5/39/fPcd2xsrN4yMzMzvdv+Z82ahUwmY8KECURGRrJw4UI6dOhAUFAQ1tbWgLpfPHz4cBo3bszs2bOJiIhg0aJFHD16lPPnz2v3mVf7Pqtfv354eHgwe/Zszp07x6+//oqLiwtz5swB8r4OK6h9+/bRtWtXqlevzvTp00lNTeXHH3+kZcuWnDt3Dnd3d/r06cO1a9fYsGEDCxYs0L4+muvZJUuWUK9ePXr27ImZmRl//fUXo0ePRqVS8eGHH+ZZh4YNG7J9+3YSExNxcHAo1PEIQraMPeRXEF402aVKaNOmjQRIS5cu1Vs/JSVFb9l7770n2djYSGlpadplQ4cO1bk9WnPrWvny5aXY2Fjt8u3bt0uA9Ndff2mXaW5heRYgWVhYSNevX9cuu3DhggRIP/74o3ZZjx49JBsbG+n+/fvaZWFhYZKZmZlBKSEkSZImTpwoWVhYSAqFQtq6datB2+Tm+VvF16xZI8nlcunw4cM66y1dulQCpKNHj0qSJEkLFizI81ae4kiV0Lt3b8nCwkK6ceOGdtmDBw8ke3t7qXXr1tplvr6+Urdu3XLcT1xcnARIc+fONahuz3r77bel8uXLG7RuWFiYZGVlJQ0ePFhnua2trfTOO+/orf/PP/9IgLRr165c96t5H2T3995772nX05yvPXv21Nl+9OjREiBduHBBkiRJCgoKkgBpxIgROuuNGzdOAqQDBw5IkiRJ8fHxkr29vdS0aVMpNTVVZ91n03do6vf7779rl6Wnp0sVKlSQ3njjDe2yXr16FTqlwvO3gEZGRkoWFhZSp06dJKVSqV0vICBAAqSVK1dql+WUKiErK0tKT0/XWRYXFye5urrqvW7kcJvZqFGjJGtr64IfmCAIgmBUWVlZUsWKFaXmzZvrLNf0iXbv3i1Jkjot0rPfN5Kk7ltaWlpKX3/9tc6y5/tFz/crNd/Ho0eP1tnfoEGD9L5vsuv3Hj9+XO/7N7dUCc/frrxw4UIJkNauXatdlpGRITVv3lyys7OTEhMTdY7FkL5zdjQpClauXClFRUVJDx48kP755x/J3d1dkslk2r5gdv3uhw8fSuXKlZM6duwopaenSw0aNJCqVq0qJSQkaNdp37695O3trdP/V6lUUosWLSRPT0+9ehiSKkGTBmnv3r3a/bm5uUljxozRWe+rr77SplN4nqavtHLlSgmQ5s+fn+M6OdUtu/No6NChEiBNnDhRb3/ZnSezZ8+WZDKZdOfOHe2y1q1bS/b29jrLnq2PJEnSpEmTJEtLSyk+Pl67LDIyUjIzM8vzlvtff/1VAqRLly7lup4kqfuMXl5ekoeHh046uG7duknVq1fXW//x48c5Hv+zNOdTdn+1a9fWrqdp+8qVK2vPeUmSpE2bNkmAtGjRIkmS1O8NFxcXqX79+jr94r///lsCpK+++kq7zJD21dTv+b7m66+/rnPtYch1WF6yS5Xg5+cnubi4SDExMdplFy5ckORyuTRkyBDtstxSJWR3vnXu3FnvdcsuVYIkPU1Dc/LkyfwflCAYQKRKEIQSYmlpqTPRk4bml0+ApKQkoqOjadWqFSkpKVy9ejXP/fbv35+yZctqH2tGiRoyu22HDh10fh338fHBwcFBu61SqWTfvn307t1bZ+RFzZo1taMP87J48WLmz5/P0aNHGThwIAMGDNCbVMLS0pKpU6catL/sbN68mbp161KnTh2io6O1f5pb1zS3imt+Pd6+fXuBJ3rLL6VSyZ49e+jduzfVq1fXLq9YsSKDBg3iyJEjJCYmaut35coVwsLCst2XtbU1FhYWBAYGEhcXl696xMTE6JwnOUlJSeHNN9/E2tqa7777Tue51NRULC0t9baxsrLSPp8Xd3d39u7dq/eX3URbz//C/fHHHwNobynU/PvZZ5/prPf5558D8M8//wDq27KSkpKYOHGitq4az9/qaWdnx9tvv619bGFhQZMmTXTeT2XKlCE8PLxQt1U+b9++fWRkZDB27FidEc0jR47EwcFBeyy5USgUWFhYAOpR6LGxsWRlZdGoUSPOnTtnUD3Kli1Lamqq3q1tgiAIQumgUCgYMGAAx48f10k/sH79elxdXWnfvj2g7ntpvm+USiUxMTHaW5cN/c7Q0Hwff/LJJzrLs/tuf7bfm5mZSUxMDDVr1qRMmTL5LvfZ8itUqMDAgQO1y8zNzfnkk09ITk7mv//+01m/MH1ngHfeeQdnZ2cqVapEt27dePz4Mb/99huNGjXKcZsKFSrw008/sXfvXlq1akVQUBArV67Ujs6LjY3lwIED9OvXT3s9EB0dTUxMDJ07dyYsLCzb29jzsm7dOlxdXbUT08pkMvr3788ff/yhk5btzz//xNfXN9tRvZq+0p9//omTk5O2P5bdOgXxwQcf6C179jx5/Pgx0dHRtGjRAkmSOH/+PABRUVEcOnSId955h6pVq+ZYnyFDhpCens6WLVu0yzZu3EhWVpZOny87MTExAAb1oT/66COCg4MJCAjQSQdXFP1nULf/8/3nVatW6a03ZMgQ7O3ttY/79u1LxYoVte/TM2fOEBkZyejRo3X6xd26daNOnTraPqeh7avx/vvv6zxu1aoVMTExOtc5ULTXYQ8fPiQoKIhhw4ZRrlw57XIfHx86duyok4YkN8+ebwkJCURHR9OmTRtu3rxJQkJCnttrzo/s7ioUhKIgAreCUEIqV66sDao868qVK7z++us4Ojri4OCAs7OzthNhyBfF81+kmi8OQwJ7z2+r2V6zbWRkJKmpqdnOPGvIbLSpqalMmzaNESNG0KhRI23+oNdff50jR44AEBYWRkZGhjZdQEGEhYVx5coVnJ2ddf5q1aqlPQ5Qd9RbtmzJiBEjcHV1ZcCAAWzatKlYg7hRUVGkpKRQu3Ztvefq1q2LSqXS5p36+uuviY+Pp1atWnh7ezN+/HguXryoXd/S0pI5c+awc+dOXF1dad26Nd9//732tqy8SJKU6/NKpZIBAwYQHBzMli1b9G6TtLa2zjZ3rCbv7LOdnpzY2trSoUMHvb86derorevp6anzuEaNGsjlcu2F6J07d5DL5XrnYoUKFShTpgx37twBnt7CWL9+/Tzr5+bmptcZffY9ATBhwgTs7Oxo0qQJnp6efPjhh4W+zUtT1+fPEwsLC6pXr659Pi+//fYbPj4+2hzJzs7O/PPPPwZ9lsDTc6QwF2CCIAiCcWnyhGpyr4eHh3P48GEGDBiAQqEA1D/wLViwAE9PTywtLXFycsLZ2ZmLFy8a/J2hofk+fv5W+ez6PqmpqXz11VdUqVJFp9z4+Ph8l/ts+Z6ennqpnDS3pj//HVqYvjPAV199xd69ezlw4AAXL17kwYMHDB48OM/tBgwYQLdu3Th16hQjR47UBtEBrl+/jiRJTJ06Va8/O23aNIBs8xbnRqlU8scff9CuXTtu3brF9evXuX79Ok2bNiUiIoL9+/dr171x40ae/aQbN25Qu3btIp2jwszMDDc3N73ld+/e1Qbj7OzscHZ2pk2bNsDT6yNNoD2vetepU4fGjRvr5PZdt24dzZo1M+h6BvLuQ8+dO5fly5czc+ZMbeoLjaLoPwO0bt1ar/+cXZqH5/vPMpmMmjVr6vSfIfv3Z506dbTPG9q+Gnm9r4rjOiy3Y6lbty7R0dE8fvw4z/0cPXqUDh06aHPkOjs7a3PvGvK5JPrPQnETOW4FoYRk96UcHx9PmzZtcHBw4Ouvv6ZGjRpYWVlx7tw5JkyYYNAXmaYD/ry8OhiF3dYQISEhxMfH06xZM0DdOduyZQuvvvoq3bp14+DBg2zYsAEXFxdtDteCUKlUeHt7M3/+/Gyfr1KlCqB+DQ4dOsTBgwf5559/2LVrFxs3buTVV19lz549ObZHSWndujU3btxg+/bt7Nmzh19//ZUFCxawdOlSRowYAahHr/To0YNt27axe/dupk6dyuzZszlw4ECu+WvLly+f5wXJyJEj+fvvv1m3bp12tPKzKlasyMOHD/WWa5blNx9efuXUGSrKTpIh74m6desSGhrK33//za5du/jzzz/5+eef+eqrr5gxY0aR1SW/1q5dy7Bhw+jduzfjx4/HxcUFhULB7NmztcHrvMTFxWFjY2PwRYQgCIJgeho2bEidOnXYsGEDkydPZsOGDUiSpA3ognpirKlTp/LOO+8wc+ZMypUrh1wuZ+zYscX6g/bHH3/MqlWrGDt2LM2bN8fR0RGZTMaAAQNK7G6owvZ/vb299SarMkRMTAxnzpwB1BOhqlQqbbBZc+zjxo2jc+fO2W5vaJBR48CBAzx8+JA//viDP/74Q+/5devW0alTp3ztMy859cmen3RZ49mR38+u27FjR2JjY5kwYQJ16tTB1taW+/fvM2zYsAKdJ0OGDGHMmDGEh4eTnp7OiRMnCAgIyHM7Td7iuLi4bAPMoM4XO2HCBN5//32mTJmi93zFihU5ePAgkiTptE9J9Z9LSl7vK1O9Drtx4wbt27enTp06zJ8/nypVqmBhYcG///7LggULDDrfNNdYz0/4LAhFRQRuBcGIAgMDiYmJYevWrbRu3Vq7XDMrrbG5uLhgZWXF9evX9Z7LbtnzNJ2TZ2cytbW15d9//8Xf35/OnTuTlpbGN998k+0tRIaqUaMGFy5coH379nkG8eRyOe3bt6d9+/bMnz+fb7/9li+//JKDBw/SoUOHIv+l1NnZGRsbG0JDQ/Weu3r1KnK5XBtYBihXrhzDhw9n+PDhJCcn07p1a6ZPn64N3IL6eD///HM+//xzwsLC8PPz44cffmDt2rU51qNOnTqsW7eOhIQEHB0d9Z4fP348q1atYuHChTq3Gj7Lz8+Pw4cP61xoAJw8eRIbGxvtCOeiEhYWhoeHh/bx9evXUalU2knYqlWrhkqlIiwsTGfCh4iICOLj46lWrRqAdgTQ5cuX833RkxNbW1v69+9P//79ycjIoE+fPsyaNYtJkybppWMwhKauoaGhOik1MjIyuHXrls4FYk7n6JYtW6hevTpbt27VWUczUscQt27dynHyF0EQBKH0eOutt5g6dSoXL15k/fr1eHp66kxGtWXLFtq1a8eKFSt0touPj8938EHzfawZkamRXd9ny5YtDB06lB9++EG7LC0tjfj4eJ318tMfq1atGhcvXtTrn2hSjmm+Y43tww8/JCkpidmzZzNp0iQWLlyoTfek+e43NzcvUFA4O+vWrcPFxYWffvpJ77mtW7fyv//9j6VLl2JtbU2NGjW4fPlyrvurUaMGJ0+eJDMzM8dJ3DSjLJ9/PQ29cwjg0qVLXLt2jd9++40hQ4Zol+/du1dnPU2b5VVvUI92/uyzz9iwYQOpqamYm5vTv3//PLfT3BF269atbCfg3b59OyNGjKBPnz7ZtjOo+8+//vorISEheHl5aZefPHlS+3xRej7lmiRJXL9+HR8fH0C3z/n8QI3Q0FDt8/lpX0PldR2WX88ey/OuXr2Kk5OTdvLjnD5T/vrrL9LT09mxY4fOqGFNqj1D3Lp1C7lcXuTXQoKgIVIlCIIRaX5ZfPYX/oyMDH7++WdjVUmHQqGgQ4cObNu2jQcPHmiXX79+nZ07d+a5vbe3N66urgQEBOjc3lW+fHlWrVpFdHQ0qamp9OjRo1D17NevH/fv32f58uV6z6WmpmpvkcluNlZNZ0lzC5Pmy/35DmdBKRQKOnXqxPbt23VyzUVERLB+/Xr8/f21+c00ebQ07OzsqFmzprZuKSkp2tuqNGrUqIG9vX22t2A9q3nz5kiSxNmzZ/Wemzt3LvPmzWPy5Ml6My8/q2/fvkRERLB161btsujoaDZv3kyPHj0KFXzPzvMd4B9//BFAm19ZcyvawoULddbTjLzWzGbdqVMn7O3tmT17tl77FWR0+fOvk4WFBV5eXkiSRGZmZr73B+p80xYWFixevFinTitWrCAhIUFnZm5bW9tsb9vK7vPk5MmTHD9+3OB6nDt3jhYtWhTkEARBEAQTohld+9VXXxEUFKQz2hbU3xnPfwdu3ry5QHlUNd/Lixcv1ln+/PdzTuX++OOPeiMy89Mfe+2113j06BEbN27ULsvKyuLHH3/Ezs5Oe4u9MW3ZsoWNGzfy3XffMXHiRAYMGMCUKVO4du0aoB4s0bZtW5YtW5bt3U1RUVH5Ki81NZWtW7fSvXt3+vbtq/f30UcfkZSUxI4dOwB44403uHDhAv/73//09qV5vd544w2io6OzHamqWadatWooFAoOHTqk83x+rm2y689IksSiRYt01nN2dqZ169asXLmSu3fvZlsfDScnJ7p27cratWtZt24dXbp0MegHioYNG2JhYaEdKf2sQ4cOMWDAAFq3bs26dev0Rg5r9OrVC3Nzc502kCSJpUuXUrly5SLvd/3+++8kJSVpH2/ZsoWHDx9q36eNGjXCxcWFpUuX6lw/7Ny5k5CQEG2fMz/tawhDrsPyq2LFivj5+fHbb7/pfFZcvnyZPXv26KStyOkzJbvzLSEhIdv8wTk5e/Ys9erVy3ZwjCAUBTHiVhCMqEWLFpQtW5ahQ4fyySefIJPJWLNmTZGlKigK06dPZ8+ePbRs2ZIPPvgApVJJQEAA9evXJygoKNdtzczMCAgIoH///nh7e/Pee+9RrVo1QkJCWLlyJd7e3oSHh9OrVy+OHj2qDWDm1+DBg9m0aRPvv/8+Bw8epGXLliiVSq5evcqmTZvYvXs3jRo14uuvv+bQoUN069aNatWqERkZyc8//4ybmxv+/v6AOhBapkwZli5dir29Pba2tjRt2lRn5Gd2Vq5cya5du/SWjxkzhm+++Ya9e/fi7+/P6NGjMTMzY9myZaSnp/P9999r1/Xy8qJt27Y0bNiQcuXKcebMGbZs2cJHH30EwLVr12jfvj39+vXDy8sLMzMz/ve//xEREcGAAQNyrZ+/vz/ly5dn3759Or+u/+9//+OLL77A09OTunXr6o3a7dixI66uroA6cNusWTOGDx9OcHAwTk5O/PzzzyiVSoNTBCQkJOQ4Mvj5CSJu3bpFz5496dKlC8ePH2ft2rUMGjQIX19fAHx9fRk6dCi//PKLNu3IqVOn+O233+jdu7d2Ig4HBwcWLFjAiBEjaNy4MYMGDaJs2bJcuHCBlJQUfvvtN4PqrtGpUycqVKhAy5YtcXV1JSQkhICAALp166YzGUR+ODs7M2nSJGbMmEGXLl3o2bMnoaGh/PzzzzRu3FinbRo2bMjGjRv57LPPaNy4MXZ2dvTo0YPu3buzdetWXn/9dbp168atW7dYunQpXl5eJCcn51mHs2fPEhsbS69evQp0DIIgCILp8PDwoEWLFmzfvh1AL3DbvXt3vv76a4YPH06LFi24dOkS69at07nrw1B+fn4MHDiQn3/+mYSEBFq0aMH+/fuzvTure/furFmzBkdHR7y8vDh+/Dj79u3T3pL+7D4VCgVz5swhISEBS0tLXn31VVxcXPT2OWrUKJYtW8awYcM4e/Ys7u7ubNmyhaNHj7Jw4cICfzcXlcjISD744APatWun7dMFBARw8OBBhg0bxpEjR5DL5fz000/4+/vj7e3NyJEjqV69OhERERw/fpzw8HAuXLhgcJk7duwgKSmJnj17Zvt8s2bNcHZ2Zt26dfTv35/x48ezZcsW3nzzTd555x0aNmxIbGwsO3bsYOnSpfj6+jJkyBB+//13PvvsM06dOkWrVq14/Pgx+/btY/To0fTq1QtHR0fefPNNfvzxR2QyGTVq1ODvv//OV37eOnXqUKNGDcaNG8f9+/dxcHDgzz//zDbl1+LFi/H39+eVV15h1KhReHh4cPv2bf755x+965QhQ4bQt29fAGbOnGlQXaysrOjUqRP79u3j66+/1i6/c+cOPXv2RCaT0bdvXzZv3qyznY+Pj3aEq5ubG2PHjmXu3LlkZmbSuHFjtm3bxuHDh1m3bp3BKQK2bNmCnZ2d3vJn++qgvnvP39+f4cOHExERwcKFC6lZsyYjR44E1KO658yZw/Dhw2nTpg0DBw4kIiKCRYsW4e7uzqeffqrdV37aNy+GXIcVxNy5c+natSvNmzfn3XffJTU1lR9//BFHR0emT5+uXa9hw4YAfPnllwwYMABzc3N69OhBp06dsLCwoEePHrz33nskJyezfPlyXFxcsv0R5XmZmZn8999/jB49usDHIAh5kgRBKFIffvih9Pxbq02bNlK9evWyXf/o0aNSs2bNJGtra6lSpUrSF198Ie3evVsCpIMHD2rXGzp0qFStWjXt41u3bkmANHfuXL19AtK0adO0j6dNm6ZXJ0D68MMP9batVq2aNHToUJ1l+/fvlxo0aCBZWFhINWrUkH799Vfp888/l6ysrHJoBV2HDh2SOnfuLDk4OEiWlpZS/fr1pdmzZ0spKSnSzp07JblcLnXq1EnKzMw0aH/dunXTaQtJkqSMjAxpzpw5Ur169SRLS0upbNmyUsOGDaUZM2ZICQkJ2uPo1auXVKlSJcnCwkKqVKmSNHDgQOnatWs6+9q+fbvk5eUlmZmZSYC0atWqHOuyatUqCcjx7969e5IkSdK5c+ekzp07S3Z2dpKNjY3Url076dixYzr7+uabb6QmTZpIZcqUkaytraU6depIs2bNkjIyMiRJkqTo6Gjpww8/lOrUqSPZ2tpKjo6OUtOmTaVNmzYZ1G6ffPKJVLNmTZ1lmnMjp79nz0FJkqTY2Fjp3XfflcqXLy/Z2NhIbdq0kU6fPm1Q+W3atMm1rOfrFBwcLPXt21eyt7eXypYtK3300UdSamqqzj4zMzOlGTNmSB4eHpK5ublUpUoVadKkSVJaWppe+Tt27JBatGghWVtbSw4ODlKTJk2kDRs26NQvu/fp8++9ZcuWSa1bt5bKly8vWVpaSjVq1JDGjx+vPc8MsXnz5mzbNyAgQKpTp45kbm4uubq6Sh988IEUFxens05ycrI0aNAgqUyZMhKgrZtKpZK+/fZbqVq1apKlpaXUoEED6e+//9arvyTpf0ZIkiRNmDBBqlq1qqRSqQw+DkEQBMF0/fTTTxIgNWnSRO+5tLQ06fPPP5cqVqwoWVtbSy1btpSOHz8utWnTRmrTpo12PU1/89m+UHb9ytTUVOmTTz6RypcvL9na2ko9evSQ7t27p/d9ExcXJw0fPlxycnKS7OzspM6dO0tXr17Ntv+5fPlyqXr16pJCodD5zny+jpIkSREREdr9WlhYSN7e3nr9t/z0nbNz8OBBCZA2b96c63rPt0+fPn0ke3t76fbt2zrrbd++XQKkOXPmaJfduHFDGjJkiFShQgXJ3Nxcqly5stS9e3dpy5YtevV4vg/xrB49ekhWVlbS48ePc1xn2LBhkrm5uRQdHS1JkiTFxMRIH330kVS5cmXJwsJCcnNzk4YOHap9XpIkKSUlRfryyy+1/a4KFSpIffv2lW7cuKFdJyoqSnrjjTckGxsbqWzZstJ7770nXb58We88Gjp0qGRra5tt3YKDg6UOHTpIdnZ2kpOTkzRy5EjpwoUL2fbLL1++LL3++utSmTJlJCsrK6l27drS1KlT9faZnp4ulS1bVnJ0dNTrT+Zm69atkkwmk+7evatdpnkNcvp7/lxSKpXaPpqFhYVUr149ae3atQaVb2hfXVOnDRs2SJMmTZJcXFwka2trqVu3btKdO3f09rtx40apQYMGkqWlpVSuXDnprbfeksLDw/XWy6t9NfWLiorS2U5zjXTr1i1Jkgy/DstNVFRUtu27b98+qWXLlto+fo8ePaTg4GC97WfOnClVrlxZksvlOnXbsWOH5OPjI1lZWUnu7u7SnDlzpJUrV+qsI0nZf/bs3LlTAqSwsDCDj0MQ8ksmSSY0tE8QhFKjd+/eXLlyRS+PkmC6bt68SZ06ddi5c6fOTMamZvr06cyYMYOoqCiR5L+EpKen4+7uzsSJE3NNlyEIgiAIglAaZWVlUalSJXr06KGX2zk3SqUSLy8v+vXrZ/BIXWMIDAykXbt2bN68WTuyWCh+vXv3RiaTZZtmRBCKishxKwhCnlJTU3Ueh4WF8e+//9K2bVvjVEgokOrVq/Puu+/y3XffGbsqgolZtWoV5ubmvP/++8auiiAIgiAIQpHbtm0bUVFROhOeGUKhUPD111/z008/GZR6Snh5hISE8Pfff5t0QF94MYgRt4Ig5KlixYoMGzaM6tWrc+fOHZYsWUJ6ejrnz5/H09PT2NUTXjBixK0gCIIgCIJQFE6ePMnFixeZOXMmTk5OnDt3zthVKhZixK0gvLjE5GSCIOSpS5cubNiwgUePHmFpaUnz5s359ttvRdBWEARBEARBEASTtWTJEtauXYufnx+rV682dnUEQRDyTYy4FQRBEARBEIQ8HDp0iLlz53L27FkePnzI//73P3r37p3rNoGBgXz22WdcuXKFKlWqMGXKFIYNG1Yi9RUEQRAEQRBKP5HjVhAEQRAEQRDy8PjxY3x9ffnpp58MWv/WrVt069aNdu3aERQUxNixYxkxYgS7d+8u5poKgiAIgiAILwox4lYQBEEQBEEQ8kEzg3RuI24nTJjAP//8w+XLl7XLBgwYQHx8PLt27SqBWgqCIAiCIAilXanOcatSqXjw4AH29vbIZDJjV0cQBEEQBEEoApIkkZSURKVKlZDLS+cNYsePH6dDhw46yzp37szYsWNz3CY9PZ309HTtY5VKRWxsLOXLlxd9XUEQBEEQhBdEfvq6pTpw++DBA6pUqWLsagiCIAiCIAjF4N69e7i5uRm7GgXy6NEjXF1ddZa5urqSmJhIamoq1tbWetvMnj2bGTNmlFQVBUEQBEEQBCMypK9bqgO39vb2gPpAHRwcjFwb06VSqYiKisLZ2bnUjlopSaK98ke0l+EK01YqlYrg4GAAvLy8Xoq2FudW/oj2Mpxoq/wxRnslJiZSpUoVbV/vZTFp0iQ+++wz7eOEhASqVq3KnTt3RF83FyqViujoaJycnMR72gCivfJHtJfhCtNWKpWKkJAQAOrWrftStLU4t/JHtFf+iPYynDHaKjExkWrVqhnU1y3VgVvNLWMODg6iM5sLlUpFWloaDg4O4g1rANFe+SPay3CFbasWLVoUQ61Mlzi38ke0l+FEW+WPMdurNKcHqFChAhERETrLIiIicHBwyHa0LYClpSWWlpZ6y8uUKSP6urlQqVRkZGRQpkwZ8Z42gGiv/BHtZbjCtlXLli2LoVamS5xb+SPaK39EexnOGG2lKceQvq549QRBEARBEAShiDVv3pz9+/frLNu7dy/Nmzc3Uo0EQRAEQRCE0kYEbgVBEEoBlUrF/fv3uX//PiqVytjVEQRBeOkkJycTFBREUFAQALdu3SIoKIi7d+8C6jQHQ4YM0a7//vvvc/PmTb744guuXr3Kzz//zKZNm/j000+NUX1BEASTJvq6giAI2SvVqRIEQRBeFllZWfz666+AOjhgYWFh5BoJLwOlUklmZqaxq1HkVCoVmZmZpKWliVvHDFCc7WVubo5CoSjSfRaXM2fO0K5dO+1jTS7aoUOHsnr1ah4+fKgN4gJ4eHjwzz//8Omnn7Jo0SLc3Nz49ddf6dy5c4nXXRAEwdSJvq4gCEL2ROBWEAShFJDJZDg6Omr/LwjFLTk5mfDwcCRJMnZVipwkSahUKpKSksT7yQDF2V4ymQw3Nzfs7OyKdL/FoW3btrm+H1avXp3tNufPny/GWgmCILwYRF9XEAQheyJwKwiCUAqYm5szduxYY1dDeEkolUrCw8OxsbHB2dn5hbuAkiSJrKwszMzMXrhjKw7F1V6SJBEVFUV4eDienp6lZuStIAiCUPREX1cQBCF7InArCIIgCIKOzMxMJEnC2dkZa2trY1enyInAbf4UZ3s5Oztz+/ZtMjMzReBWEARBEARBEJ4jArelgFIlcfluLLHJaZSzs6J+1XIo5OJCUxAEQShe+Q3Sie8rIb9E4FwQBEEQBEEQciZm5DBxR0IeMmTxAb5Yc4Lv/hfEF2tOMGTxAY6EPDR21QRBKEFZWVn88ccf/PHHH2RlZRm7OoKgR3xfCcKL4cSdS7y+8nNO3Ln0UpQrCC+i0vh+Kmxf92X77DLma1waz6/CEK/xy1HuyB2zTfacFoFbE3Yk5CEzt5wjOilNZ3l0Uhozt5wTF8OC8BJRqVSEhoYSGhqKSqUydnUEQUdxf1/5+fnh5+eHl5cXCoVC+7h///4G72PHjh18+umn+S572LBhLFy4MN/b5VdAQADfffddsZcDcObMmXy1nSFWrlyJt7c3ZmZmeu01btw41q9fX6TlCcVDkiQWH9rAzdj7LD60ocQmJzRWuYLwIiqt76fC9HVfts8uY77GpfX8KijxGr/4xyxJEgFHNnI3MYKAIxtN8pwWqRJMlFIlsWR3cK7rLN0TTPPaFcRtqILwElAoFHTv3l37f0EoKZIkkZ6pzPF5pUri591Xct3Hkt3BNPBwyvH7ytJckest80FBQQDcvn0bPz8/7eNnaXKw5qRnz5707Nkz13oaS2pqKvPnz+fSpZL5lb9Ro0Zs3LixSPfZsGFDNm3axOzZs/We++KLL/D396d///7i88vEHb55nisRNwG4EnGTn49tpo6Le7GXezXytk65x25fpKWHb7GXKwgvomO3L5bK91Nh+rrPH3N+P7sKGqd5/rPrp6P5LVdFQkICjgmOyGSGj6l7vtyS+qzOruzScn4V1PPnVn5f44Iq7LkFRXd+me4xG/bGzSsQG1oKzmkRuDVRl+/G6o1cel5UYhqX78bi616+hGolCIKxKBQKGjZsaOxqCC+h9EwlvebsLtQ+opPS6DN3T47Pb5/QGSuL/HdJ3N3d6d+/PwcPHsTT05MffviBgQMHkpiYSFpaGu3atWPx4sXI5XJWr17Ntm3b2LZtG4GBgXz00Ue0bt2aY8eOkZWVxW+//UajRo1yLS85OZlPPvmEU6dOAfDmm28ybdo0AL755hvWrVuHpaWl+pi2b8fFxYVhw4Zx6dIlzM3NcXV1Zc8e/XbYsmULLVu2xNbWFoATJ07w4YcfolQqycrK4sMPP+SDDz4gKSmJzz77jAsXLpCWlkazZs0ICAjAwsIiX+UHBgYyduxYbQB8zZo1zJ07F4AqVarwyy+/ULlyZVavXs3atWtxdnbm0qVLWFlZsWnTJqpXr653DL6+6g6uXK5/YeDi4kKNGjXYs2cPXbt2zfN1FYxDkiR+OrpJZ9kvx7eWeD1kyPjpyEZauPuIHMiCkE+SJPHjkT+0j2Wy0vN+KmhfV5Ikvt23UmeZMT67AJafME65xjpeuUxeas6vgpAkicWHN+gsM9ZrbKxyjVm2Mco11c9MEbg1UbHJuQdt87ueIAiCILyIYmJiOHnyJDKZjLS0NP766y/s7OxQKpX06tWLTZs2MWDAAL3tQkNDWbFiBUuWLGHp0qV8+eWX7N6de4B65syZpKenc/HiRVJTU/H396dOnTp06tSJefPm8fDhQ6ytrUlJSUEul7Nz507i4+MJDlbfQRMbG5vtfgMDA2natKn28ezZsxk3bhwDBw4EIC4uDoDPP/+cVq1asXz5ciRJYuTIkSxatIgRI0YUuPzLly8zfvx4zp49S+XKlZk1axYjRoxg586dAJw+fZrz589TpUoVpkyZwpw5c1i2bFleL4ue5s2bs3//fhG4NWHHbl/kauRtveXVy7vhYGVbbOUmpj3mZky49rGEZLIjXgTB1B27fZGQiFvax5L04r+f9oedJjwhQm95QT678hOmSUx7zI1nPrs0auSz3IyMTCwszAtdbnF/VmvKfvbzWiWpXujzqyi/F41xbkHRnV8FKTs/ClquocFVWQ6vQEJaMtej72kfm+pnpgjcmqhydlZFup4gCKWbJElERUUB4OzsbFK/AAovNktzBdsndM7x+Ut3Y5my4XSe+/lmYGO8q5bLsYyCGjZsmPb9oFKpmDBhAkeOHEGSJCIjI6lfv362gdsaNWpog6XNmzdn3rx5eZa1b98+fvjhB+RyOba2tgwZMoS9e/fSt29fPD09efvtt+nUqRPdunXDzc0NX19fQkJCGD16NG3atOG1117Ldr/h4eF06dJF+7hdu3bMnDmTsLAwXn31Vfz9/QHYtm0bx48fZ/78+YA6xYJCocDBwaHA5R88eJAuXbpQuXJlAEaPHs3XX3+NUqnUto2HhwdZWVk0b96cgICAPNspOxUqVNAGkAXTI0kSPx3ZiFwmRyU9zS0pl8mxNrNg9YDpxfK9I0kSb639Uq9cwCRHvAiCKZMkifn/rdVbXlpGsRekrytJErP2/qq33FifXXKZHCszC1YZWK5KpSIyMhIXF5ds71jJT7nFeby5l106zq/8kiSJOQdW6y0vLecWFO35ld+y88MUyzW1c1pMTmai6lcth5N97kFZZwcr6udwESwIwoslMzOTJUuWsGTJEjIzM41dHeElIpPJsLIwy/HvlerOBn1fvVLdOcd9FKZTZGdnp/3//PnziYyM5OTJk1y8eJFBgwaRlpb9nSlWVk/rrFAoCjSDtabeCoWCEydOMHbsWCIjI2nWrBmHDx+mevXqBAcH06VLF44ePUr9+vW1o2efZWNjo1PPsWPH8s8//1CxYkUmT57M6NGjAXUH888//yQoKIigoCBCQ0NZtmxZocvP7piKsp0A0tLSsLa2LtC2QvHT5PB7Pnj67GiqkiwXKNZyBeFFdOz2BZ2RYxrPjmI3ZQXp6244v5vY1ES95cb67HpRy8297NJxfuXXgeunuROnP7nuy/kav5jHbMy2zi8RuDVRCrmMDzp75brO+528xMRkgvASsbGxwcbGxtjVEAQdpvR9FRcXR4UKFbCysuLRo0ds3ry5SPffoUMHVqxYgSRJPH78mDVr1tCpUyeSkpKIiIigVatWTJ06FX9/f86fP094eDgymYyePXsyb948JEni3j39i2ofHx9CQ0O1j0NDQ/Hw8GDkyJFMnjyZEydOANC7d2/mzJmjDZ7GxcVx/fr1QpXfrl07du3axYMHDwBYunQp7du3L/JJxEJCQrR5cAXTohltm9NthJrRekU9y3Je5QIsPvziz1guCEVBkiRmPZfn9XnF8T4uavnp62YplSw6tD7H54312fWilWtY2aXj/DKUJEl8s0d/JLfGy/kav1jHbMy2LggRuDVh/nUrMrXvK1hb6F48OTtYMbXvK/jXrWikmgmCUNIsLCwYP34848ePx8LCwtjVMYhSqSIw8DYbNlwiMPA2SqX+iCrhxaD5vnp+5G1Jf1+NGTOGkydPUq9ePQYPHkyHDh2KdP9Tp07F3Nwcb29vmjZtSs+ePenXrx8JCQn06dMHb29vfHx8yMzMZOjQoVy6dImWLVvi6+tLgwYNGDx4MD4+Pnr77du3r05+3YCAAOrVq0eDBg2YMmUKP/zwAwALFizA2toaPz8/fHx8aN++Pbdv3y5U+fXr12fu3Ll06dIFHx8fDh8+zPLly/PdNqtXr8bNzY3Nmzczffp03NzcOH/+PKDuHO/fv5/XX3893/sVil+mMotHSTFIOczOLCHxKCmGTGXBRlsXtFyAW7EPirxcQXgRxaQk8CAhKtd17sQ9Mun3U377uuvP7yItKyPH54312fWilWtY2fCwmMo2hlN3r2Q7klvj5XyNX6xjNmZbF4RMMpUQcgEkJibi6OhIQkICDg4Oxq5OsflqwylOXn/6Rbzqw7ZUKmd4Yuj85jZ52Yn2yh/RXoZ7mdpq69YQxozZRXj4006Pm5sDixZ1oU+fugbt42Vqr6JQlO2VlpbGrVu38PDw0LlVPi9KlcTlu7HEJqdRzk6dzscU7wyRJImsrCzMzAqXpqEodevWjenTp9O4cWNjV0VPYdtr165drF27lrVr9XMv5nSuvSx9vLyUVDs8SowmLjUpx+fL2Tjgal++xMoNibjFjD2/ALDszS9pVs071/2I74v8Ee2VP6Whvb7dt5KNQXuo6ODE993HYK54OpXNtsuB/HF+N45Wdvz17kIcre1y2VPhlFRbRSbH0nvl5zzOSOWdJr3oVLtZtuuV9GdXfsvNb3sZ67M6p7LTMtMZ//ciopLj6OHVmm9eG10sZWuUxPmVlplBv98ncCfuIW1rNOT9Fn2zXc/Uzy0oPeeXKZSrUqmIjY2lXLly2rYqzvcT5K+PJyYnKwXCY1MA9S0IEhAe8zhfgVvB9JWWYIcgGGLr1hD69t3E8z8L3r+fSN++m9iypZ/BwVuhdFHIZfi6F18H50W2ePFiQkJCjF2NYpGQkMD3339v7GoIuajg4EQFByeTKbeuqwdXI2+zMWgPM3b/wp/D5mJjISbkFYTsBD+6yaagvQDM6PI+PpU8dZ6v6VSFU3evcDMmnEWHN/BVp5HGqGaRmnvwdx5npOJdsSYft+qPXFayAXVT+8w0Ztmzuo5m1OZZ/BV8iD4+7XjFrXT38Zce38KduIc425ZlZtfROFiVbNzFFF/jl6FclUpFpMzWZH+gM70aCToyspQ8jFMHbjUTkd2JyvnXCKH0ORLykCGLD/DFmhN8978gvlhzgiGLD3AkRD8ZuvDyysrKYuvWrWzdurXAkwOVBKVSxZgxu/SCtoB22dixu0TaBEF4To0aNejevbuxq1Es+vfvT6VKlYxdDaGUGdN6IBXtnXiQGMWPR/4wdnUEwSQpVSq+2fsrEhKv1W1J06r19dYxV5gxpcO7APx5cT9B90P11jEFhvZ1j94KYk/oCeQyGVM6jijxoK2gq2k1b/p4vwrAtN3LSMvMOX2FqQt+dJPfT/8NwJcd3y3xoK0g5ER8ypm4h3EpqCQJGwsz/DzUvwbciU42cq2EonIk5CEzt5wjOkl31vPopDRmbjkngreClkql4tKlS1y6dAmVynSDnocP39VJj/A8SYJ79xI5fPhuCdZKEARBKG1sLayZ+mRk4IZzu0022CQIxrTlwj6uRNzEzsKaz9sOznG9hlXq0qt+WwC+2bvCZPI2PsuQvm5aZgbfPpmEbdArXanj4l6CNRRy8mmbt3C2K8vduEcsOVa0E8OWlExlFtN3L0MpqehUuxntajYydpUEQUsEbk3cvSdBWjcnW6o5q/MR3Y0SgdsXgVIlsWR3cK7rLN0TjFJVatNQC0VIoVDQuXNnOnfuXOSzvRelhw8NuyPA0PUE0yZJEklJ6cTEpJCUlG4yM68KgvBiaOnhS896rZGQmL57Gem5TEQkCC+b6Mfx2tHoH/n3x8m2TK7rf9p6EI5WdoRF32X9uV0lUMP8MaSv++vJ/xGeEImLXTlGt3yzhGso5MTBylY7qvv3M39z5dENI9co/1ad2kFo1B3KWNsz8dXhxq6OIOgQgVsTdy/mMQBVyttRzdkegLvRSeLi+AVw+W6s3kjb50UlpnH5bmwJ1UgwZQqFgmbNmtGsWTOTDtxWrGhfpOsJpisuLpVLlyIJDY3h1q14QkNjuHQpkri4VGNXTRCEF8i4tkMob+PIrdgH/HJ8q7GrIwgm44fAtSSlp+DlWp1+fp3yXL+sjQOftnkLgCXHNvMwMbq4q5gvefV1b8XcZ9WpHQBMeHUYthbWJV1FIRdtazaiS50WqCT1D22mOKo7Jzeiw/nlhPr75Yt2Qylv62jkGgmCLhG4NXGaEbdVnOyoVNYGM7mM1AwlUYm5B/wE0xebbNhraOh6gmAKWrWqipubAzlNPC+TQZUqDrRqVbVkKyYUqbi4VG7ciCMjQ6mzPDU1k02brvDrr2cJDLwtchkLglBojtZ2TH4ykmvVqR2ERNwyco0EwfhO3r3MvyFHkCFjSsd3URg4mU6v+m1oULk2qZnpzDnwWzHXsuhIksQ3+1aQpVLSqnoD2ns2NnaVhGxMeHUYZa3tuRZ1l5Wnthu7OgZRqlRM272UTGUWrao34LW6LY1dJUHQIwK3Ju5ezJPAbXlbzBRyKpdXJ8gWE5SVfuXsDJsd2dD1hBebJEnEx8cTHx9v0iPuFQo5ixZ1yfY5TTB34cIuKBTi66e0kiSJe/f08xgfOHCLnj3/4P33/2HkyL9p1+433N0XsXVrSKHL9PPzw8/PDy8vLxQKhfZx//79Dd7Hjh07+PTTT/Nd9rBhw1i4cGG+t8uvgIAAvvvuu2IvB+DMmTP5ajtDTJ48mTp16uDr60ujRo3YvXu39rmAgAC+/fbbIi1PeLl0qNWEjrWaopRUTCtlI7kEoahlZGVq87z28+tIvQo1DN5WLpPzZYcRmMkVHLx+msDrZ4qrmvmWW1/37+DDnLkXjJWZBRNfHY4spxECglGVs3FgwqvDAPjl+FauR98zboUMsOH8Li49vK7Oq95xhDi3BJMkrpxNmCRJhEc/SZXgpM5vW9VJky5B5Lkt7epXLYeTfe5BWWcHK+pXLVdCNRJMWWZmJosWLWLRokVkZmYauzq56tOnLlu29MPcXPcrxs3NgS1b+tGnT10j1UwoCsnJGXojbQ8cuMWECfuIjHyss/z+/UT69t1U6OBtUFAQQUFB/Pvvv9jb22sfb9y4UbtObjNQA/Ts2ZMFCxYUqh7FJTU1lfnz5/Pxxx+XSHmNGjXSabui0KpVK86fP8+FCxdYsWIF/fr14/Fj9fkwatQoVqxYQUJCQpGWKbxcJrUfjoOVLaGRt/n9zN/Gro4gGM1vZ/7mduwDyts48pF//n+E83SuwuBG3QD4bv9qUjJM4+6+nPq6CanJ/BC4FoBRzd/ArYyLsaooGKBLnRa0rv4KWSqlerIvE55UOTw+gh8Pq/tDn7Z5C1f78kaukSBkTwRuTVhscjopGVnIZTIqlrUBwP3JBGVixG3pp5DL+KCzV67rvN/JC4Vc/OonqJmbm2Nubm7sahikZ8/aOo8tLORcv/6xCNqWQpIk8fhxhvYvLi6V1NRM7V9ycjrz5h3LYVv1v2PG7CQxMU1nP8/+FXQUubu7OxMmTKBJkyYMHTqUR48e0a5dOxo2bEi9evX46KOPtDNTr169mt69ewMQGBiIn58fo0ePxtfXl3r16nHmTN6jjpKTk3nnnXeoX78+9evXZ8aMGdrnvvnmG+rWrasdDXznzh1SU1Pp378/Xl5e+Pr60qlT9jkIt2zZQsuWLbG1Vd9Vc+LECRo2bIifnx/169dnyZIlACQlJTFy5EiaNGmCj48Po0aNIiMjI9/la45fY82aNfj4+ODj40O3bt24f/++ts06dOjAoEGDaNCgAY0bN+bmzZvZHkPXrl2xtlbnG/T29kaSJKKiogCwsLCgU6dOrF+/Ps82FoSclLctwxfthgKw9Nif3Iq5b+QaCULJC4+PYPmTXJyftx2Mg5VtgfYzqlkfKjk48TApmmXH/yzKKhZKdn3dRYc3EJeaSPXybgx5EnAWTJdMJmNKxxHYWVhz6eF11p/baewqZUuSJGbs+YW0rHQaVfHiDZ9XjV0lQciRmbErIORMk9+2YlkbLMzUCdqraiYoixIjbl8E/nUrMrXvK8z/6yKP05+OFnO0seCT1+rjX7eiEWsnmBILCwsmT55s7GoY7ObNODIzVVhbmyGTyUhJyeT27QRq1RK/ZJc2KSmZ2NnNLvD2kgTh4Uk4Os7JcZ3k5EnY2loUaP8xMTGcPHkSmUxGWloaf/31F3Z2diiVSnr16sWmTZsYMGCA3nahoaGsWLGCJUuWsHTpUr788kud2/uzM3PmTNLT07l48SKpqan4+/tTp04dOnXqxLx583j48CHW1takpKQgl8vZuXMn8fHxBAcHAxAbm/1kk4GBgTRt2lT7ePbs2YwbN46BAwcCEBcXB8Dnn39Oq1atWL58OZIkMXLkSBYtWsSIESMKXP7ly5cZP348Z8+epXLlysyaNYsRI0awc6f6Quv06dOcP3+eKlWqMGXKFObMmcOyZctybadVq1ZRvXp1qlWrpl3WvHlzduzYwQcffJDrtoKQm+5erdgZcpSjty8wffcyVg6YbnBuT0Eo7SRJ4rv9q0nPyqRJ1XqFysVpY2HFxPbD+eR/c1l79l+6e7XC09m48w9k19cNuh/Knxf3AzClw7uYK0T4ojRwtS/HZ23f5us9ywk4spG2NRtSpUwFY1dLx9ZLBzh19wpWZhZM7zwKuUx8lwimS5ydJuzZ/LYaVZ+kTLgTnWzSeS4Fw/nXrcir3pV0lvVsXE0EbYVS7cqVSADq1nWmfn31LW0XL0YYs0rCC2rYsGHafGQqlYoJEybg6+tLgwYNOHPmDEFBQdluV6NGDW2wtHnz5ty4cSPPsvbt28fIkSORy+XY2toyZMgQ9u7di4ODA56enrz99tssW7aM2NhYrKys8PX1JSQkhNGjR7Nx48YcR8yHh4fj6uqqfdyuXTtmzpzJ119/zZEjRyhbtiwA27ZtY+7cufj5+dGgQQMOHz7M9evXC1X+wYMH6dKlC5UrVwZg9OjRHDhwAKVSqW0bDw8Pg9tp//79zJgxg40bN+rkiatQoQLh4eF5trEg5EYmkzG100hszK0IenCNP4Jy/7FFEF4k+8NOc/jWeczkCia3f6fQuTjb1GjIq56NyVIp+WbfClSSad3SnqnM4pu9KwDoVb8tDauIu7ZKkz7er9K4Sj3SsjKYsXu5ScUuIpJimP8k/caH/v1NLqgsCM8TgVsTdu+5/LYAlcvbopDLSEnPIiYp3VhVE4rYg9gUAKo9SYVx45H+xD+CUJpcuaK+RbpePWd8fNSB2wsXHhmzSkIB2diYk5w8Sefv3r2xHDo0jEOHhrFoUWeD9vPvv4P09qP5s7EpeAoQO7un35Hz588nMjKSkydPcvHiRQYNGkRaWva5+6ysnuYYVygUeebIzY7molmhUHDixAnGjh1LZGQkzZo14/Dhw1SvXp3g4GC6dOnC0aNHqV+/vnb07LNsbGx06jl27Fj++ecfKlasyOTJkxk9ejSgHm31559/anP8hoaGsmzZskKXn90xFaSd/vvvP4YPH85ff/1F7dq66VLS0tK0qRQEoTAqOjjxaZtBACw+9Afh8ZFGrpEgFL+UjDS+P7gagOFNeuJRvnKR7HdCu6FYm1sSdD+UbZcDi2SfRWX9uZ2ERd/F0cqOT1sPMnZ1hHySyWRM6zwSKzMLTt+7oh05bWySJPHN3hUkZ6RSv0IN3nqlq7GrJAh5EoFbE6YdcftM4NZcIadyOfUIXJHn9sVxP1YdpG9XX90Ju/ZQTOAi6MrKymLHjh3s2LGjQAGmkqYbuFWPJLx4UVxcl0YymQxbWwudPzc3R+rXd8Ha2pymTd1wcck5x55MBlWqONCpUw29/Wj+imoG37i4OCpUqICVlRWPHj1i8+bNRbJfjQ4dOrBixYoneX8fs2bNGjp16kRSUhIRERG0atWKqVOn4u/vz/nz5wkPD0cmk9GzZ0/mzZuHJEncu6c/w7KPjw+hoaHax6GhoXh4eDBy5EgmT57MiRMnAOjduzdz5szRfgbExcVx/fr1QpXfrl07du3axYMHDwBYunQp7du3R6FQ5KttDh06xODBg9m+fTu+vr56z4eEhGS7XBAKoq9vBxq61SUtK52Ze01rJJcgFIclxzYTkRRLZUcXRjR9vcj2W8HBidEt+wGw8L/1xKYYb/DIs33d8NgIfj66BVBPGlXWxsFo9RIKrkqZCtoJ9Bb8t46IpBgj1wh2XT3GoZvnMJMrmNHlfZFuRygVxFlqwjQ5bt3K614QP5suQSj9MrKURCakAtDaqyIyIDoxjbhkMaJaeEqlUnH+/HnOnz+vnWzJlGlSJdSr54Kvr/r2I5Eq4cVib28JgEIhZ/Jkf0AdpH2W5vHChV1QKIq/yzFmzBhOnjxJvXr1GDx4MB06dCjS/U+dOhVzc3O8vb1p2rQpPXv2pF+/fiQkJNCnTx+8vb3x8fEhMzOToUOHcunSJVq2bKlN3TB48GB8fHz09tu3b1+d/LoBAQHUq1ePBg0aMGXKFH744QcAFixYgLW1NX5+fvj4+NC+fXtu375dqPLr16/P3Llz6dKlCz4+Phw+fJjly5fnu23effdd0tPTGT58uHaCtEuXLmmf37VrF3379s33fgUhO3KZnGmdR2FpZs6JO5fYfuU/Y1dJEIrNtag7rDurzjs+qf1wrMwLlhM+J4Ne6UJt52okpCWz4L91Rbrv/Hi2rzvv4O+kZaXToHJtetVvY7Q6CYU36JWu+FT0JDkjlW/2rjDqD22xKYnMObAagJHN+lDTqYrR6iII+SGTSvFP1ImJiTg6OpKQkICDw4v1K1xqRha956gv4jZ/3hEHm6df0L8FhrL+8HW6NqjC2O76F4DPU6lUREZG4uLiglz8opSnkm6vu1FJjFx6CBsLM7Z+0YlRSw9xNzqZmQMa08TTpdjLLyxxfhmuMG2lVCo5evQoAC1btsz3aLiSlJWlwtb2WzIylNy8+QllylhRrtz3AMTHT8DR0SqPPaiJcyt/irK90tLSuHXrFh4eHjq3yj8rKSmd0NAYLCwUVKhgx+rVQSxYcIJHj57+qFiligMLF3ahTx/TyksnSRJZWVmYmZkV2WjfwurWrRvTp0+ncePGxq6KnsK2V3BwMO+99x6HDx/Wey6nc+1F7uPlh2iH3K0+9RcLDq3DztKGX7pNoK67p/i+MID4fs0fY7aXSlIxfMN0gh5co71nE+b3+qxYyrn4IIwh679CQmJF/69oVMWrQPspir7urdj7LAjbjkKh4I/B3+Hp/OIG116W9+KN6HD6r5lIpjKL2d0+4rW6/gXaT2Hba8Lfi9l19RieTlXZMPjbF36yu5fl/CoKxmir/PTxxKtnosJj1LfOO9pY6ARtAao52wNwJ0qMuH0RhD9Jk1CpnA0ymQzPio4AhIl0CcIzFAoFrVu3pnXr1iYdtAW4fj2WjAwlNjbmVKtWhrJlralSRf1ldOmSSJfwokhJyQTUOXDt7Mx59VUP/vprAAcODGH9+j4cPDiUW7fGmFzQ1lQtXryYiIgXc1T6vXv3WLZsmbGrIbyA3m70GvVcq5OcnsKPpzaLlAnCC2fb5UCCHlzD2tySL9oNKbZyfCp58oZvewBm7V1BprLk03IpFAoaNWvC+ogjSDIY3KjbCx20fZnUcHJjVLM+AMw58Bsxj0v+Ojfw+hl2XT2GXCZjRpf3XvigrfBiEYFbE6VJk/BsfluNak+W3Y1OEh3UF4Amv61befXrqgncijy3QmmlSZPg5eWMXK4enfc0z+2LGZh6GaWmqi/qrK3NsLY2f/Jay2ja1I2BA71p29a9RNIjvChq1KhB9+7djV2NYtG5c2e8vAo2eksQcqPJUWgmV3A8/DJ7rp0wdpUEocjEpSSy8L/1AHzQ4k0qODgVa3ljWg2grLUDN2Pv8/uZv4u1rJwsO/4nj5JiqOTgzHvN3zBKHYTiMbxJT2o5VyU+NYnvD/5WomUnpj3mm30rABjSqDv1KtQo0fIFobDEFZWJ0k5MVl5/wpfK5W2RyyA5LYtYkQe11Lsf83TELTwN3F4XgVvhGZrJkB4/fmzyP9g8OzGZhgjcvnhSU9Ujbq2tzZ9MYGYOQHJyhjGrJQjCS8bTuSrvNukFqEdyxRlxciVBKEoLD60nIS0ZT6eqDHqlS7GX52Blx7h2gwF1ADU8vmT7bNci77Dx9C4sJAUTXx2GtblliZYvFC9zhRkzOr+PQiZn19VjBF4/U2JlL/hvHVHJcVQtW4EPWrxZYuUKQlERgVsTdS9aHczLbsSthZmCSmXVAd27YoKyUk874rac+jWtUcEBuQyik9KITU4zZtUEE5KZmcm8efOYN28emZmZxq5OrrIL3Pr6isDti0SSJO2IWxsb9a1mdnbqtD6PH4vArSAIJevdpr1xL1ORuNREvj/4u7GrIwiFdv5+KNsuBwLwZcd3S+y27m51/WlcpR7pWZnM3r+qxAYLqCQV3+5ZQdfHNemeUovmVb1LpFyhZHlVqM6Qxuq7i77Zu4LEtMfFXubJO5fYeukAANM7vVfkk/sJQkkQgVsTFa4dcasfuAWo5qxeficqqcTqJBQPTeC28pPR1dYWZtq0CSLPrVAaBQdrArdPJ9d7dsStSmXaI4aFvKWnK1GpJORyGZaWuoFbMeJWEISSZq4w49NmA5DLZPwbcoRDN84Zu0qCUGCZyiy+2fsrAK97t6NB5dolVrZMJmPKk0DxkVtB7A87VSLlbrsUyMWHYSVSlmBc7zfvS7WyFYl6HMf8/9YWa1kpGWnM2LMcgP5+nWhYRcy7IJROInBrgpQqSTs5WXYjbgGqignKXgipGVnEJKnTXVQq9zQtRq1KTyYoeyACt4KahYUF06ZNY9q0aVhYmO4vxZmZSkJDowHdEbeenuWxtFTw+HEmt27FGat6QhHRTExmbW2GTKbOY2xrqz4v09OVZGYqjVY3QRBeTnWcqvHWK68BMHPvrySlpxi5RoJQMOvP7eJ69D0crewY02pgiZfvXq4Swxv3BOC7A6t5nJFarOXFpiSy4NA6lDKJ6t0amXxfVygcK3MLpnd+D4D/XTrIyTuXiq2sn45u5H5CJBXsyzOmdcm/lwShqIjArQmKTEglU6nCXCHHxdE623WqaicoE4Hb0uzBk9G2jjYWOFg/7aBo8tyKEbdCaXP9eiyZmSpsbc2pUsVRu9zMTK4dgSvSJZR+z+a3BSA+CrPIW5RNe4BNwl1Sb4bCgxtP/+KjjFhbQRBeFh+06EvVMhWITI5lwX/rjF0dQci3R4nRLDm2GYCxbQZR1sbBKPV4t2lvqpRxJSo5jp+PbirWshb8t5bEtMfUdq7GwBLI5SsY3ytudejv1wmAGXuWk5JR9OkBLzy4xrqzuwD4qtNIbC2yj6sIQmkgArcm6N6TYKxbeVsUT2Zkf1417YjbJJOfqEjIWfhzE5NpaAK310TgVihlNPltvbyckT/3+SXy3L44NPltra3N1EHZgA/hl3HU2DcLr8NzcNjwJfwy7ulfwIeFCt76+fnh5+eHl5cXCoVC+7h///752k9gYCC7du3K8flhw4axcOHCAtfTUAEBAXz33XfFXg7AmTNn8t1OeVm5ciXe3t6YmZnptde4ceNYv359kZYnCIayNrdkWudRAPx5cT+n7l4xco0EIX++P/g7qZnp+FWqRe/6bY1WDytzCya1fwdQjwAOibhVLOWcvnuFHVcOIUPGlE4jMJMriqUcwfSMaT2QivZO3E+IJODIxiLdd0ZWJtN3LUNCoodXa1p6+BXp/gWhpInArQm6F6MJ3GafJkH9nC1yGSSlZhIvJoIptZ5OTKb7Wteo4IhcBrHJ6cQkiQnKBMjKymLXrl3s2rWLrKwsY1cnR1euRAK6+W01NHluL1wQgdvSTpMqwcbGHFISISuPCfOyMtXrFVBQUBBBQUH8+++/2Nvbax9v3Ji/jn5egduSkJqayvz58/n4449LpLxGjRrlu53y0rBhQzZt2sSgQYP0nvviiy+YPn06SqVIlyEYR6MqXrzp2wGAr/f8QmpmupFrJAiGOXzzPPvDTqGQyfmy47vIZca9VG/p4Uvn2s1RSRIz9/6KUqUq0v1nKrOYtW8FAH192+Pl7FEq+rpC0bC1sOarziMB9Y8DQfdDi2zfv5zYys3Y+5S3cWR8uyFFtl9BMBYRuDVBmhG3VZxsc1zH0lxBhbLqUZp3osUEZaWVJnD7/IhbK3MFVZ3Uo6pFugQBQKVScfLkSU6ePImqiDvORUkz4vbZ/LYaz05QJpRCGWmQkUZWSgpZKSnIs9KxVighy8AfD7My1PsowiDK7t278ff3p2HDhjRp0oSDBw8CEBYWRsuWLfH19cXb25spU6YQFBTE0qVLWbduHQ0aNOCbb77Jdd/Jycm888471K9fn/r16zNjxgztc9988w1169bVjvy9c+cOqamp9O/fHy8vL3x9fenUqVO2+92yZQstW7bE1lb9HX/ixAkaNmyIn58f9evXZ8mSJQAkJSUxcuRImjRpgo+PD6NGjSIjIyPf5QcGBuLn56ctf82aNfj4+ODj40O3bt24f/8+AKtXr6ZDhw4MHDgQb29vGjVqxM2bN7M9Bl9fX+rWrYtcrt+NdHFxoUaNGuzZsyfX9hWE4jS29SBc7ctxLz6Cn44U723eglAUUjPTmb1/FQBvNexKLedqRq6R2rh2g7GzsObKoxv8eXFfke77t9N/cSv2AeVsHPmk1YBS09cVik4Ld1961muDhMT03ctIN7RPmYurkbdZdWoHAJM7vIOjdc6D4QShtDAzdgUEffc0E5PlMuIWoKqTPQ9iU7gblYyfu1NJVE0oYtoRt9m81p4VHbkdlcS1Bwk0q+Va0lUTTIxCocDf31/7f1NlSOD2xo04kpMzsLMTE0+UKt+qJ3UwA17RLMvP4NWVk9X/VqsHw3MPmhri5s2bTJ8+nd27d+Pg4MD169dp1aoVt2/fJiAggO7duzNp0iQAYmNjKVeuHO+//z7x8fEsWLAgz9E8M2fOJD09nYsXL5Kamoq/vz916tShU6dOzJs3j4cPH2JtbU1KSgpyuZydO3cSHx9PcHCwtszsBAYG0rRpU+3j2bNnM27cOAYOVLdvXJx68r7PP/+cVq1asXz5ciRJYuTIkSxatIgRI0YUuPzLly8zfvx4zp49S+XKlZk1axYjRoxg586dAJw+fZqgoCA8PDyYOHEic+bMYdmyZfl5WQBo3rw5+/fvp2vXrvneVhCKgp2lDVM7juSjrXNYd+5fOtVphk9FT2NXSxBytOLkNu4nROJqX44PWrxp7OpoudiV4yP//nx3YDWLD//Bq55NcLItU+j9hsdH8MuJrQCMazsYBys7lEplqejrCkVrXNvBHL0VxK3YByw/8T8+8i94eqcslZLpu5eRpVLS3rMJHWo1zXsjQSgFxIhbE/R0xG3ugdtqzurn70SJEbel1f0nQfrKz424BfCs9GSCskdixK2g7sC2b9+e9u3bm2xnNiNDybVrMUD2qRKcnGyoVEk9kvzy5cgSrZvw4tm1axfXr1+ndevW+Pn50bdvX+RyOXfv3qV169YsX76cL7/8kj179lCmTJl873/fvn2MHDkSuVyOra0tQ4YMYe/evTg4OODp6cnbb7/NsmXLiI2NxcrKCl9fX0JCQhg9ejQbN27E3Nw82/2Gh4fj6vr0x7h27doxc+ZMvv76a44cOULZsmUB2LZtG3PnzsXPz48GDRpw+PBhrl+/XqjyDx48SJcuXahcuTIAo0eP5sCBA9q0Bs2bN8fDw0P7/xs3buS73QAqVKhAeHh4gbYVhKLSqnoDunn5o5Ikpu1aRkZeKV0EwUhuxdzXjhD8ot0wbCysjFwjXf38OuHlWp2k9BR+CFxT6P1JksS3+1aSnpVJk6r1eK1uS6B09HWFoudobcfkDu8CsPLkdq5G3i7wvn47/TchEbdwsLJlcod3iqiGgmB8InBrYhJTMkhIUd8i4FY+51QJANWeBHbvPgn0CqVLYmoGiU9mZq9UTv+11kxQFvYgQUxAJ5QKYWExZGWpsLe3oEqV7GdBfprn9lFJVk0oCpM3wOQN3H17Kee6zOf+0F/Uy9751rDt3/lWvf7bU4ukOpIk0bFjR22+26CgIO7fv4+npydvvPEGR48epXbt2trRt4Ulk6kn21MoFJw4cYKxY8cSGRlJs2bNOHz4MNWrVyc4OJguXbpw9OhR6tevrx09+ywbGxvS0p7mLh87diz//PMPFStWZPLkyYwePVp7fH/++af22EJDQ1m2bFmhy8/umDSsrJ4GCxQKRYFzDKalpWFtLWZvFozvi3ZDKWfjyM2YcH49uc3Y1REEPZIkMWvfSrJUSlp5NKC9Z2NjV0mPQi5nascRyGUy/g05yok7lwq1v33XTnL09gXMFWZ82eFdve8i4eXToVYTOtZqilJSMW3XUjKV+e9/3I59wNJjWwAY33ZIkYwMFwRTYdTArVKpZOrUqXh4eGBtbU2NGjWYOXPmSx2k0kxM5uxghbVF7pksqjqrR67diRKB29LowZM0CeXtLbN9rau7OiCXyYh7nE5MkphY42UnSRIZGRlkZGSY7GekJk2Cl5dzjp1wHx/1SFyR57YUsrACCyseZ8pRmVli7WinXmZmYMoLMwv1+uaWRVKdzp07s2/fPi5evKhddurUKUCd49bV1ZUhQ4bw/fffc+LECQAcHBxISDDsLoYOHTqwYsUKJEni8ePHrFmzhk6dOpGUlERERAStWrVi6tSp+Pv7c/78ecLDw5HJZPTs2ZN58+YhSRL37t3T26+Pjw+hoU8n4AgNDcXDw4ORI0cyefJkbV179+7NnDlztMHTuLg4rl+/Xqjy27Vrx65du3jw4AEAS5cuLZaRTSEhIfj6+hbpPgWhIMpY2zOp/XBAfSv6tag7Rq6RIOj6N+Qop+9dwdLMnInth5lsENOrQnX6+3UGYNa+FQXORZqcnsKcg78B8E6TXriXq6R9rjT0dYXiM6n9cByt7LgaeZvfz/ydr21Vkoppu5eRocykpbsvPeq1LqZaCoJxGDVwO2fOHJYsWUJAQAAhISHMmTOH77//nh9//NGY1TKqcE1+2zzSJGjWkQEJKRnEPxaBvdLmaZqE7EdWW5krtOkwrj2ML6lqCSYqMzOT2bNnM3v2bDIzTfN2z+DgnPPbajydoEykSiiNJEkiNVUdSLS2Nm6a/Jo1a7J+/Xree+897WRZCxcuBNQTgHl7e9OgQQP69+/P0qVLAXj99dcJCgoyaHKyqVOnYm5ujre3N02bNqVnz57069ePhIQE+vTpg7e3Nz4+PmRmZjJ06FAuXbqknRCtQYMGDB48GB8fH7399u3bl927d2sfBwQEUK9ePRo0aMCUKVP44YcfAFiwYAHW1tb4+fnh4+ND+/btuX37dqHKr1+/PnPnzqVLly74+Phw+PBhli9fnu+2X716NW5ubmzevJnp06fj5ubG+fPnAfU5sn//fl5//fV871cQikPHWk151bMxWSol03apcx8KgilITHvMvCepB0Y264NbGdOe0+JD/34425blbtwjbWqH/Pr56GaikuOoUsaVd5v20nmuNPR1heJT3rYM49sNAWDpsT+5FXPf4G03nt9D0P1QbMytmNJxhMn+ACIIBWXUq65jx47Rq1cvunXrBoC7uzsbNmzQjph5GWnz2+YxMRmoA3sVytrwMC6Fu9HJlLEtmlFMQskIj809cAvqdAm3IpMIe5hAi9oVSqpqglAgTycm089vq+Hrqz6PL16MQJIk0bEqZTIylKhUEjIZWFk96ULYOICZOeSWP9LMXL1eIbm7uxMfH6993KFDBzp06KC33qRJk7QTkz3Lw8OD8+fPI0lStmkAVq9erf2/nZ0dK1eu1FvHzc1NOyr2WV27djVoMi5vb29cXFw4ffo0jRs3zvHHajs7OwICArJ9Lj/lt23blqCgIO3jwYMHM3jwYL31hg0bxrBhw7SPu3fvnmOKiefXfdbu3btp0qQJ1aqZxozogiCTyZjc/h1O3w0mOOIma878w/AmPY1dLUEg4MhGYlMScC9XiaGNCp/Sp7jZW9owvt0Qvvh7Eb+e3EbXui2pVraiwduHRNxiw3n1rKaTO7yDpaF37Agvje5erdgZcpSjty8wfc8vrBowDbks97GG9xMiWXR4AwBjWg+kkmPOA0gEobQyauC2RYsW/PLLL1y7do1atWpx4cIFjhw5wvz5841ZLaN6OjFZ7vltNao62fEwLoU7Ucn4VCtfnFUTiph2xG0uuYw9Kzqy50I4YQ/FBGUvO3Nzc20gKqdJj4ztyhX1KFovr5w7TLVrl8fcXE5iYjp37yZQrVqZEqqdUBRSUtTBWWtr86dB9zLO8NFPkJKoXS8i8jExMSmUKWNFpYr26qBtGdGR1li8eDEhISHGrkaxSEhI4Pvvvzd2NQRBh7NdWca1Hcy03UtZcmwz7Wo20rlFWxBK2uWHN9gUtBdQBzEtzEyzb/e8TrWbse1yIMduX+DbfStZ2neyQT/CK1UqZu79FZUk0aVOC1q466fTKQ19XaF4yWQypnYaSZ9V4wi6H8of5/cw6JUuOa4vSRJf71lOamY6r7jVoZ9fxxKsrSCUHKMGbidOnEhiYiJ16tRBoVCgVCqZNWsWb731Vrbrp6enk57+NCVAYqL6IlGlUqFSqUqkzsVNk+O2cjlbg46pipMtJ8PgTlRSjuurVCokSXph2qi4lVR73deMuC1rk2NZNSuoR6iFPUxAqVSa5OhEcX4ZrrBtZWam/siWJMnkcn9lZCgJC4sFoG7d8jkeo0Ihw8vLmQsXIjh//mGOk5iBOLfyqyjbS7Ov58+11FRN4NZM9xx0dFL/PWFpk0ZKVhwqSzMqVnwSsDWxc1ZTf2O8l6pXr0716tVN7n2cG0Pbq1+/fgat9+x+Nefts+eueN8LRa1X/TbsCj3G8dsXmbHnF1b0/yrPkVzCi+PEnUvM2b+aCe2H0ayat1HrolSpmLVvBRISr9X1p2nV+katT37IZDImdxhOn1XjOXHnEruuHqNr3ZZ5brflwj6uPLqBnYU149rq3/Wh2beFhRiF+7Kr6ODEp20GMWvfShYf3kCbGq9Q2TH7u/m2X/6PE3cuYWlmzrROo8RnuvDCMmrgdtOmTaxbt47169dTr149goKCGDt2LJUqVWLo0KF668+ePZsZM2boLY+KitKZobm0ylSqeBiXAoC1lEpkZN45IMtaqC+Mrt+PzXF9lUpFQkICkiQhl4sPs7yURHtJkkT4kyC9lZSW42tnJ1Mhl0H84wyu3rpPeTvT68yI88twL3JbXb0aS1aWCnt7Cyws0oiMzDnvtqenAxcuRHD8+C2aNSub43ovcnsVh6Jsr8zMTFQqFVlZWTopBR4/Vk9GYmkpzzbVgIalpbr8tLQs0tIyMDMzrddPkiSUSnWeS1P8QczUFGd7ZWVloVKpiImJ0RlhlZSUVKTlCIJMJmNqxxG8sXo858KvsjloH/0bdDJ2tYQSIEkSiw9t4GbsfRYf2kDTt+sb9bN/U9AegiNuYm9pw7i2bxutHgVVpUwFRjZ7nZ+ObmLuwd9p6eGHg1XOdxBGP45n8ZNb2T9uNQBnu5z7foIA0Ne3A7uuHudseAhf71me7cjuqOQ4bY7oD1q8Ke6iEF5oRg3cjh8/nokTJzJgwABAnfftzp07zJ49O9vA7aRJk/jss8+0jxMTE6lSpQrOzs44OBQ+d56x3YlKQiWBtYWCWu6VDepQ1M+yhP9u8ygxHReX7H+JUqlUyGQynJ2dRfDDACXRXrHJ6aRlqoOyXjXcsDDLeUZvd2d7bkYmEZdpTt0cXmNjEueX4QrTVkqlkv/++w+ANm3aFPks8IV18ODTiclcXXOfXKNJk2ps2RLGzZvJOX5ugTi38qso2ystLY2kpCTMzMy0I73Vy9XBOzs7S53lzzMzU+fATUvLIj1depoP18SIWzHzpzjay8zMDLlcTvny5bGystIuf/b/glBUKju6MKbVQL47sJqFh9bTqnoDkQ/xJXDkVhBXIm4CcCXiJsduX6Slh/6t+iUhKjmOgCMbAfjYfwDlbcsYpR6FNaxxD/4JOcLt2AcEHNnI5A7v5LjuvIO/k5yRSj3X6rzpm/Ot7EqlksDAQECdn93U+rpCyZHL5EzrPIo3f/uCE3cusf3yf/T2bqt9XpIkZu1bSVL6Y7xcqzO4UTfjVVYQSoBRr6RSUlL0Li4VCkWOt8dZWlpiaak/AZdcLn8hLurvx6pH21ZxsjP4i6qaiz0AcY8zSE7LwsEm+xGZMpnshWmnklDc7aUZWe3iaI2VRe4Xwp6VHLkZmcT1R4n41zV8AoCSJM4vwxW0rbKysjh69CgArVu3Nrm2DgmJBtQTk+VVNz8/9QRlly5F5rmuOLfyp6jaSy6XI5PJtH8ASqWK9HR14FYnx20O7OwsSEvLIjk5gzJlTCsI9+zEeGLEbd6Ks70059jz5614zwvFpX+DTuwKPU7Q/VBm7v2Vn9+YKD4HXjApGWlcehjG+fvXOH//KqfuXtZ5/qtdS5jWaRQN3Opgb2lTonX7IXCNNojZ11d/cs3SwsLMnC87vMvITTPZFLSXHvVa412xpt56x29fZOfVY8hlMqZ0HIEil892pVLJkSNHAGjVqpUI3L7kqpWtyOgW/VhwaB3zAtfQ0sOX8jaOAOwLO8nB66cxkyuY3vk9zOTiXBFebEYN3Pbo0YNZs2ZRtWpV6tWrx/nz55k/fz7vvJPzL3YvsntPJquqUt7O4G2sLcxwdbQmIiGVu9HJ1K9arriqJxQhbX5bA15rz4pl2B0kJih72cnlcpo2bar9v6m5cuXpiNu8+PioR+SGhcWSkpKJjY0Y9VgapKaqUyOYm8sxN9ftICfevUtqdLTOsrS4VJIeJqO8a4aDyhOHqlVLrK6CIAg5kcvkzOj8Hm/+NoFjty/wd/BhnO3KGiX/qSnlXS3NHiVGc/7BNYLuhxJ0P5RrUXdQ5ZJnO/pxPB//73tkyKjlXJVX3OryilsdXnGrg1MxjoA9cecSO68eQ0beQczSoEnVenT3asXfwYf5Zu+vrHt7FnKe/giSnpXBt/tWAjCgQWe8KlTPdX+m3tcVSt7bjV5jT+hxrkTcZNa+lfTz6cA3e38lMUN9Lf1Ok17Udqlm5FoKQvEzauD2xx9/ZOrUqYwePZrIyEgqVarEe++9x1dffWXMahnNvWh1ztMqToYHbgGqOdsRkZDKnagkEbgtJcKfBOkrl8v7V37PiupfFsMeJuiMehJeLmZmZnTpkvOsqsZ25Yo6T3O9enmn83B1tcPFxZbIyMdcuRJJ48aVi7t6QhF4OjGZbqA98e5dVtSujTKXXPPHrKx4NzS0wMFbPz8/ADIyMggNDcXbWx3gqF27Nhs3bjR4P4GBgaSlpdG5c+dsnx82bBh+fn6MHTu2QPU0VEBAAMnJyUycOLFYywE4c+YMc+fOzVc75WXy5Mls3boVS0tLzM3NmTVrlrZNAwICSExMZPLkyUVWnin56aefmDt3Lo8ePcLX15cff/yRJk2a5Lj+woULWbJkCXfv3sXJyYm+ffsye/ZskQrCyNzLVeL9Fn1ZfHgDcw6sppKDc4nnPzW1vKulRZZKSVjUXc4/CdJeeHCNR0kxeutVtHfCt5InFx5cIyI5Vi+Qa6EwI0OZRWjUHUKj7rDh/C4AqpapoA3ivuJWBzfH3NM/GSojK1MbxOzn1zHPIGZp8Vmbt/nvxjmuRt5m4/ndDGzwtK+68uR27sY/wtm2LB+27Jfnvky9ryuUPDO5ghld3mfAmkkcvH6asKg73E9SDxbxKFeZkc1eN3INBaFkGDVwa29vz8KFC1m4cKExq2Ey7j2ZrKpK+ZyTu2enqrM9p65HcfdJ4FcwfQ+ejLh1K5f3a13d1R6FXEZCSgZRiWm4OFoXd/UEIV/S07O4fj0WMGzELahH3e7bd5OLFyNE4LaU0Iy4fX6EdGp0dK5BWwBlWhqp0dEFDtwGBQUBcPv2bfz8/LSP8yswMJD4+PgcA7clITU1lfnz53Pp0qUSKa9Ro0ZFGrQF9S2sU6dOxdramgsXLtC6dWsePHiAra0to0aNom7dunz44Yc4OjoWabnGtnHjRj777DOWLl1K06ZNWbhwIZ07dyY0NDTbfN3r169n4sSJrFy5khYtWnDt2jWGDRuGTCZj/vz5RjgC4VlDG3dn77UThETcIjTqDlCy+U+P3b5oMnlXTVlSegoXH4Rx4cmI2ksPr5OSqfudo5DJqe3ijl/lWvhWqkWDyrVxtS/P0VsX2BV6PNv9ZiizmN3tYxQyOefuX+V8+FWuRd3lbvwj7sY/YtvlQACc7crSoHJtPB0q01rWmFouVQs0c/2q0zu4E/eQ8jaOfOTfP9/bm6ryto6MbT2QmXt/JeDIJtrXVP+QdSfuIStObQfgi1eHYlfCKSmEF4enc1VGNO3N0uN/Ep7wdELvvr7tsTATd+0JLwfTnC3kJSRJEuHRT1Il5HPEbdUn69+JEoHb0iL8SeC2kgGBWwszBe7O9tyISOTag3gRuBVMzrVrMSiVEo6OllSqZG/QNr6+TwO3QumQGB2PMjUTM5U5GY8fa5dnpqYatH1maioZjx8jk8sxty6az7Hdu3czc+ZMUlNTUSgUzJkzh3bt2hEWFsawYcNITk5GpVLRq1cv+vbty9KlS7WTn/Tq1Yvp06fnuO/k5GQ++eQTTp06BcCbb77JtGnTAPjmm29Yt26dNu/+9u3bcXFxYdiwYVy6dAlzc3NcXV3Zs2eP3n63bNlCy5YtsbVVf/6fOHGCDz/8EKVSSVZWFh9++CEffPABSUlJfPbZZ1y4cIG0tDSaNWtGQEAAFhYW+So/MDCQsWPHaoPda9asYe7cuQBUqVKFX375hcqVK7N69WrWrl2Ls7Mzly9fxtLSkk2bNlG9uv6osK5du2r/7+3tjSRJREVFYWtri4WFBZ06dWL9+vV88MEH+XxFTdv8+fMZOXIkw4cPB2Dp0qX8888/rFy5MtvR08eOHaNly5YMGjQIAHd3dwYOHMjJkydLtN5C9szkCqZ3eo/+a3Rfu7Hb5uJqXz7n0a8534H/zCq5ryRJEhHJsTrLpuz8iaGNulPBwQlX+/JUsC+Ps13ZFyp3Y16pISRJ4kFiFEH3n6Q9eBBKWNQ9vfa0s7DGp1It/CrXwq9ybbwr1MTGwkpvXz8d2YgMWbavhwwZa8/8w7q3Z9G5TnMAEtMeE3Q/VBvIvfzoBlHJcewJPcEe4KfTf+JgZYtfpdq84laHhm51qevqgbki50vqE3cu8c3eX3mYqE4nNK7dYBys8jdIx9T18XmV7Zf/4+LDMCb++yPRSfHYWFmRqcyipbsvHWs1NXYVhVLu3aa9WXVqB+lK9d1fMuDf4CO89UpXcaeC8FIQgVsTEZucTkpGFnKZjIpl8/eLZDVnTeA2qTiqJhQxlSTx4MlEdG4G5jP2rOTIjYhEwh4mmOwEZULxysjIYPbs2QBMmjQJC4vsJyI0hqf5bV0M7jxp8txeuCACt6WBJEnsaugOwOEC7uMPf38A3Nq0YcCTWaML4+bNm0yfPp3du3fj4ODA9evXadWqFbdv3yYgIIDu3bszadIkAGJjYylXrhzvv/8+8fHxLFiwgKysrFz3P3PmTNLT07l48SKpqan4+/tTp04dOnXqxLx583j48CHW1tbaiVZ37txJfHw8wcHB2jKzExgYqM3hBzB79mzGjRvHwIEDAYiLiwPg888/p1WrVixfvhxJkhg5ciSLFi1ixIgRBS7/8uXLjB8/nrNnz1K5cmVmzZrFiBEj2LlzJwCnT58mKCgIDw8PJk6cyJw5c1i2bFmu7bRq1SqqV69OtWpPc8w1b96cHTt2vFCB24yMDM6ePas9p0Cdg7FDhw4cP579iL4WLVqwdu1aTp06RZMmTbh58yb//vsvgwcPzrGc9PR00tPTtY8TExMBUKlUOU7eK6jbR5KkfLdR9OM4vWUZyizuxZf8d1NsSiILDq3XWSaXyXCyLYurXTlc7ctpA7qu9uVwtVP/v7xtmXznSj1++yKz961iUofhNHf3KcrDyNHzqSEaD/IiS6XkWtQdgp6Mpr3wIIyobF6Tyo7O+FWqjW+lWvhVqkX18m56x/z8a5+RlcnDpJgcg+gSEo+SYkjPzNCO2rOzsMbfww9/Dz8A0jIzuPzoOmfDQzh16xIhMXdITHvMoZvnOHTzHABWZhZ4V6xJg8rq1Ao+FWtibW6lPeZFhzZoz6fGVbzoXKv5C/lentzhHQatmcz5+6HqBYlgITdjwqvDkCQJKZecwxoZGRnMmTMHgAkTJphUX7e4FPSz62Vz6u5lbdAW1L+fXYm4ydFbQbRwF3cq5EScX4YzRlvlpywRuDURmvy2FcvaYGGWv1/WqzqpR7jFJqeTlJqJvbW4ZcCURSWkkqlUYSaX4eJoWI47z4qO7Dp/T0xQJpgkTX5bLy8ng7fRBG4vXowQuZtLgYwMpbGroGfXrl1cv36d1q1ba5fJ5XLu3r1L69atGT9+PMnJybRp04YOHfI/c/e+ffv44YcfkMvl2NraMmTIEPbu3Uvfvn3x9PTk7bffplOnTnTr1g03Nzd8fX0JCQlh9OjRtGnThtdeey3b/YaHh+vk8GvXrh0zZ84kLCyMV199Ff8nAe5t27Zx/Phx7S31mlHFDg4OBS7/4MGDdOnShcqV1elJRo8ezddff41SqX59mzdvjoeHh/b/P/74Y65ttH//fmbMmMHevXt13sMVKlQgPDzc0KYuFaKjo1Eqlbi66ua7dHV15erVq9luM2jQIKKjo/H390eSJLKysnj//fdzzf87e/ZsZsyYobc8KiqKtDxSkrzMVCoVCQnquQAMndRIkiQW/bceuUymk/9Uhgw3B2fGNu1v+HdTPr7DJEli4YmNhCdG6gQVZYCdhQ1VHV2JTkkgJjWBLJWSyORYIpNjufQo+/3JZXLKWzvgbFsWZ5syONmUwdm2DM42ZXC2KYuTjSNlre21t/dLksSCwHXcS4xgQeA6qnd1LbLvYJWkIkulJFOpJFOVRZYqi0xlFpkqJRciwnRSQ7yxahwPkmJIV2bo7EMhk1OznBv1nD3wcqmOl5O7diZ59QFAzHOTYeZkUeexJKTlfEdiGSt74mP1A8XPqmrphJtHS9qWq4+tvR234h9yOfIGlyJvcCXqFonpjzl9L5jT94J16l/fpQbWZpYEPzlmgJaVvImKijKo7qVNWaxpXsWbo/cuape1rtYAywwZkZGRuWz5VGbm08BcVFQU5uYv/jVtQT67XjY5fVbLZTIW/beeGtYVxHVEDsT5ZThjtFVSkuEDL0Xg1kQUNL8tgI2lGc4OVkQlpnE3Ool6VcQEZaZMkyahYlkbg0dI1BITlL30zM3NGTdunPb/puTZEbeGqlvXCTMzOXFxady/n4Sbm0NxVU8oAqmpWbQ6FIaVlYK6Xrqvc2RQkHY0bW7eOBBI5SaNkBVRZ0iSJDp27Mj69ev1nvP09KRFixbs3buXgIAAFi5cyL///luo8jSfuwqFghMnTnDs2DECAwNp1qwZGzZsoFWrVgQHB3PgwAH27dvHF198QVBQEGXLltXZj42NjU4AbuzYsfTq1Yt9+/YxefJk6tevz88//4wkSfz555/UqlVLry75Kd+QY9J4dsIshUKR66jk//77j+HDh/PXX39Ru3ZtnefS0tKwLqJ0GKVZYGAg3377LT///DNNmzbl+vXrjBkzhpkzZzJ16tRst5k0aRKfffaZ9nFiYiJVqlTB2dkZBwfxOZkTlUqFTCbD2dnZ4AuuY7cvcC3mnt5yCYl7iZFY2dsUy0iuY7cvcC9Rf0SvBCRlpDC6VT9auPuiklTEPE4gMjmWR0kxRCTFEJEUy6Nk9b8RSTFEJcehlFREpcQTlRKfY5lmcgUuduoRu3KZjLBY9XGHxd5j/umNuNiXUwdYlZnqoKsyiwxlJlmqLDKUWU8fK599rA7MZmRlkvkkQJulMvxHvlvxDwFwsLTFt1ItfCvXwrdiLepVqI61uWW+2jQnLhjeL8nNs+eXW6XKtPJqpF4uqbgV+4Dz90M5Fx7C+fuhPEqKITTmLqExd3X2IQP23j7NkBY9X8h+vCRJxKQn6iy7/zgaZ2dng49XkiTt55+Njc0L2U7PK8hn18smp89qlSRxLeYeN1IfiVG3ORDnl+GM0Vb5mahWBG5NxL0C5rfVqOps/yRwmywCtyZOMzFZZQPTJAC4u9hjJpeRmJpJREIqFcqIBP8vG5lMps2JaWqeBm4Nm5gMwNLSjDp1nLh8OZKLFyNE4NbEpaZmorC2wb6cNRbPnYeG5qvNkMz0ti2Mzp07M2PGDC5evIiPj/pWX80t6WFhYdSoUYMhQ4bQpEkTWrRoAYCDgwN37twxaP8dOnRgxYoVtGnThpSUFNasWcOECRNISkoiKSmJVq1a0apVK65cucL58+fx8PCgbNmy9OzZky5durBt2zbu3bunF7j18fEhNDRU+zg0NJTatWszcuRIqlSpoh2N2bt3b22qAjMzM+Li4oiJicHV1TVf5T+rXbt2zJo1iwcPHlCpUiWWLl1K+/btUSjyd6fPoUOHGDx4MNu3b8fXV/9iKSQkJNvlpZmTkxMKhYKICN2AW0REBBUqVMh2m6lTpzJ48GBGjBgBqPMBP378mFGjRvHll19me2FgaWmpzV38LLlcLi668iCTyQxuJ0mS+Pno5lzzn/58dDMtPfyKNHiUn3LN5Ga4OpTH1aE83nhmuz+lSkX04/gnQd0YHj350wZ5k2KIfhxHlkrJg8QoHiTqj/bcc+1EkR3f88zkCswVZsiAlMx0veendhxJH592BZrsq6Rld37JkePpXBVP56r08+sIwIOEKM6Gh7Dz6lGO3rqgXVdza/eJu5dfyEnojt66wNXI2zrLQiJv5ft47e0NmyvhRZKfz66XjbE+q18k4vwyXEm3VX7KEYFbExGuGXFbwMBtNWc7zt6IEhOUlQLhMU8Ct+UMD75amClwd7Hn+iN1nlsRuBVMRVpaFtevq3Np5mfELajTJVy+HMmFC4947bXsL0oF05CSor590cam4KO9U1NzzymbXzVr1mT9+vW89957pKSkkJGRQYMGDVi/fj1btmxh7dq1WFhYoFKpWLp0KQCvv/46a9asoUGDBnlOTjZ16lQ++eQTvL3VE+i8+eab9OvXj/DwcPr27cvjx4+RyWR4enoydOhQjh07xqRJk7S3xA8ePFgbUH5W3759eeedd/jmm28ACAgI4MCBA1hYWKBQKPjhhx8AWLBgARMnTsTPzw+5XI6ZmRnff/89VlZW+So/8Jl8wvXr12fu3LnaVA1VqlRh+fLl+W77d999l/T0dO0kXaCe9EzTVrt27WLmzJn53q8ps7CwoGHDhuzfv5/evXsD6tEZ+/fv56OPPsp2G03+4WdpguSG5HsUik+mMotHBuQ/zVRmFems5UVdrkIuf5L7thzkENzNVGZpg7v/3TjHylPb9dbpWKsp7uUqYa4ww0Jh/uRfM8w0j+VmWJiZYy5XYG725PEz65krzDDXe2yGXCZHkiTeWvslIZG3UUlP8/nJZXK2XtzPGz6vGtZ4pUQlR2cqOjix4dwu5DK53jH/dGQjLdx9Xqggk2YiuJfleIWSY6zPakEwNSJwayLuPQnmuRUgVQJAtScB37tigjKTpxlxa+jEZBqeFR3VgdsHCbQSE5S9dJRKJUePHgWgZcuW+R4hV1xCQ6NRqSTKlLGiYsX8ndM+Pi6sXw8XLxqW+0wwHk3Q1dpav9tg7eSEwsoKZS75N+UWligtCz+q2t3dnfj4eO3jDh06ZJu/dtKkSTqTSGl4eHhw/vx5bXDzeatXr9b+387OjpUrV+qt4+bmxokT+iPUunbtSteuXfM8Bm9vb1xcXDh9+jSNGzfOMY+snZ0dAQEB2T6Xn/Lbtm2rkzJh8ODB2U6ONWzYMIYNG6Z93L17d7p3755t+WFhYdkuBwgODiYrK0ubq/dF8tlnnzF06FAaNWpEkyZNWLhwIY8fP9YGsIcMGULlypW1E0n26NGD+fPn06BBA22qhKlTp9KjRw+T+Qx/WVmYmbP+7VnEpebcby5n41DkgQBjlGuuMKOigxMV7Mvz/YHfsg2uPUiIYm6PscUSXDt2+6I2t+2zVJKKKxE3OXb74gs3AvVlO+aiOl5T7esKxvP8Z6ZKpdJOOKv5YbQ4PqsFwdSIwK0JSMvIIjIhFYAq+QzmaVR1Vt9WcidajLg1dZoct5XyMeIWoFalMuw8f4+wR2KCspeRUqnk4MGDADRr1sxkOrPPpknI7wXfsxOUCaZLqVSRlqYOcmY34tahalXeDQ0lNYfJYjIzldyOAqmMK0qlCoVC3Kq1ePFiQkJCjF2NYnHv3j2WLVtm7GoUi/79+xMVFcVXX33Fo0eP8PPzY9euXdoJy+7evaszwnbKlCnIZDKmTJnC/fv3cXZ2pkePHsyaNctYhyA8o4KDExUcDJ9Us7SXa4xgomYkZm63Ob9oIzJftmMuyuM11b6uYFzPfmaqVCoiZba4uLiIW/+Fl4oI3JoAza3zjjYWONhYFGgfVZ+MuI1OTONxeia2luJXJ1OUpVTxKE4dpHcrl/8RtwDXHogJyl5GcrmcBg0aaP9vKq5cUY+WzU9+Ww1N4DY0NJq0tCysrMRXkinSBG3NzOSYmWV/7jlUrYpD1ao57iP2YgQZGUoeP87EwaFoJp0pzWrUqEGNGjWMXY1i0blzZ2NXoVh99NFHOaZGeDYtBYCZmRnTpk1j2rRpJVAzQciZsYKJL+Ntzi/bMRfl8ZpqX1cQBMHYxFWyCbhXyPy2AHZW5jjZWxGdlMbdqGTqupXNeyOhxD2KT0ElSViaKyhvn7/gRTVnO8wVcpLTMomIT6VCWZHn9mViZmZGz549jV0NPU9H3OZ/5uZKlewpX96amJhUgoOjeOUVkQLEFD2bJqGgF/R2dhbExqaSnJwhAreCIAglzFjBRGOlpDCml+2Yi/JWdlPt6wqCIBibCNyagHvRhctvq1HV2U4duI0WgVtTdT9WMzGZbb4DIJoJysIeJnDtYYII3AomITj4aaqE/JLJZPj4uHLw4G0uXowQgVsTVRQTkz0buBUEQRBKljHzRBorNYQxvWzHLG5lFwRBKF4icGsCtCNuC5jfVqOqkx3nbkZzR0xQZrLux2gCtwULunpWdCTsYQJhDxNo7SWCXIJxpaVlceNGHFCwEbeATuBWME2pqerArbV14QK3AMnJGSLViyAIghGI4JogCIIglE4icGsC7kVrUiUUbsRtNc0EZVFigjJTFf7MiNuC0Oa5fRhfVFUSSomMjAzmzZsHwLhx47CwKFg+7KJ09Wo0KpVE2bJWuLoW7JwWE5SZNkmStKkSbGwK3mWwtjZDLpehUqn3V5jRu4IgCIIgvHhMsa8rCIJgCsRPrEamVEna2+cLO+K2mrN6+7vRInBrqrSpEgqYFqPWk8Dt9YfqCcqEl0tmZiaZmZnGrobW04nJXAo8gtLXVx24vXAhQpzTJigzU0VWlgoAK6uCB1tlMpnOqFtBEARBEITnmVpfVxAEwRSIEbdGFpWQSkaWCnOFHNcyhctZqpncLDIhlZT0LGwsxctrap6mSihY4Laai/2TCcqyeBiXQqUC7kcofczNzRkzZoz2/6bg6cRk+c9vq+Hl5YxcLiM6OoVHj5KpWNG+qKonFIH09KcTk8nlhUtvYGdnQWJiOsnJGbi45P+za+vWrcyaNQulUklaWhqVKlVi3759RXqb79KlS0lKSmL8+PFFtk+ZTEZcXBxlypQpsn3mh5OTE2fOnMHd3d0o5QuCIAiCIUyxrysIgmAKRGTPyDT5bSuXs0VRyItiB2sLytlZEpuczr2YZGpXKlMENRSKSnqmkqjENADcCji62lwhx8PVnmsP1HluReD25SGTyYwW+MlJUQRura3NqVWrPFevRnPxYoQI3JoYTZqEwuS31bCzU+/j8eP8j7h9+PAho0aN4uzZs1SrVg2Ac+fOFXmu3Pfff79I91daZWVlYWYmuoiCIAhCyTHFvq4gCIIpEKkSjKyo8ttqVH2SLkFMUGZ6HjxJk2BnZYZDIYIgmjy3YQ8TiqReglBQz6ZKKAyR59Z0PTviNiMjg4yMDJ2UFkqlkoyMDLKysnS2y25dKysFWVmZpKSkk5GhzFc9IiIiUCgUlCtXTrvslVde0QZuw8LC6NatG40bN8bHx4eAgAAAUlNT6d+/P15eXvj6+tKpUyft+m3atMHPzw9vb2+mTJkCwPTp0xk7dqz22MaPH0/9+vWpX78+H3/8MRkZ6qDzsGHDeO+992jfvj21atWiT58+2ueyM2/ePBo0aECtWrVYt26ddvnu3bt55ZVX8PHxoU2bNgQHBwMQGBiIn5+fdr3Lly9rR8zevn2bMmXKMG3aNBo2bEjNmjX5999/tevu2LGDunXr4uPjwxdffKFTj3HjxtG4cWP8/Pxo3bo1oaGh2udkMhnTpk2jcePGTJo0CW9vb44dO6Z9/tdff2XAgAG5vEqCIAiCIAiCIBQ1MZzCyO7FFE1+W41qTvYE3YrhrpigzORo89uWsyvUKLFaFR35BxG4fdkolUpOnz4NQOPGjVEoFEatT0pKJjdvxgGFG3EL6jy3mzZd4eLFyKKomlCE0tKyABk2NubMnj0bUAf/bG3VPzYePXqUgwcP0qBBA3r27Kndbt68eWRmZjJmzBjt6Jlz586ye/duKlWqQa1ab2BhYW1wPXx8fPD396datWq0adOGFi1aMGjQICpXroxSqWTgwIGsXbuWOnXqkJKSQrNmzWjatCnh4eHEx8drA6KxsbEABAQE8Nprr/Hll18ik8m0y5/1yy+/cPr0ac6ePYtCoaBnz54sWLCACRMmABAUFMTBgwextLSkdevW/PnnnwwcODDb+stkMs6fP8/Nmzdp1KgRLVu2xMbGhkGDBhEYGIi3tzfr1q2jb9++XLlyJc/2SEhIwMfHhxkzZrBr1y7GjBnDa6+9RmRkJMOHD+fw4cN4eXnxyy+/EBMTo91uwoQJ2olf/vjjD8aMGcOuXbu0zysUCu3nTK1atQgICKBFixYALFmyRBsQFwRBEISiZmp9XUEQBFMhRtwa2dMRt0UTuNWOuBUTlJmcp4HbwuUyfnbErZjM6eWhVCrZvXs3u3fvRqnM32jF4nD1ajSSBOXLWxcoX+mzNCNuL1x4VBRVE4qIJEmkp6vPtaJIlfCs/E5QJpfL+fPPPzl27BhdunTh6NH/s3ff4W3V1+PH31ree29nD8fOICETyPwyCjSjrIQSoIUykgLNt79S2kJL+bJKR2ihQIEk0BJWCAHasjIhi4RMJ3F2HO+9t6R7f3/IchLiOLIt6UryeT2Pn8eWr+49/khRro7OPWcLI0aM4Pjx4xw5coSDBw9yyy23MHr0aCZPnkx9fT2HDh1i1KhR5OTkcP/99/Puu+929My74oorWLZsGb/+9a/54osvOr00c+3atdxxxx34+/tjNBq5++67+fLLLzt+P3fuXIKCgjAYDIwfP54TJ05cMP677roLgAEDBnDFFVfw1Vdf8c0335CVlUVWVhYAt956K0VFRRQWFl50PQICApg3bx4AkyZN6jj29u3bGTlyJBkZGQD8+Mc/Pmcq95dffsmkSZPIzMzk97//PXv37j1nvz/60Y86vv/hD3/Ihg0bKC0tZfPmzeh0Oi6//PKLxiaEEEL0hKed6wohhKeQiluN2XvcOitxmx4jrRI8VUfitpfV1emxtgFlja0WiqqbejzoTHgXvV7fkeBx5jCmnjq7TUJv+4zaE7c5ORW0tVnx85MKC09gNisAGI16TCY9jzzyCHDuwJApU6YwceLE856TP//5z8/b9tJLL6Vfv2GcPl3X7cSt3bBhwxg2bBj33HMPV199NR9//DFXXXUVUVFR5yUh7Q4dOsT69etZu3Ytv/jFL9i7dy8/+MEPGD9+PBs2bOCFF15g6dKl57Qb6Mx3n+cBAQEd3xsMhvPaRXRnX99lNBrPedPa0tJyzu/9/f079mEwGC74Bvfs4+Tl5bF48WJ27tzJwIED2b9/P1dcccU524eEnPn/KTAwkDvuuINXXnmFnJwc7rvvPsf+OCGEEKIHPO1cVwghPIW8ImqorrmNmvYhLSnRzkm+pcfaBvuU1jTT0ub4m0jhegWVzqm4NRr0DIgPA+BYkbRL6CuMRiPz5s1j3rx5HjE06NCh3g8ms0tNDSMiIgCLReHw4Ype7084h70PbWCgEZ1Oh5+fH35+fuckAw0GA35+fuc9Jy+0bWRkCAaDkaYmM4qiOBxLYWEhW7Zs6fi5urqaU6dOMXDgQIYOHUpYWBjLly/v+P3x48epqqqioKAAnU7H97//ff74xz+iqir5+fkcO3aM+Ph4Fi5cyB/+8Ae2b99+3jFnzZrFm2++2dHD97XXXuvokdtd9thyc3P5+uuvufzyy5k4cSLZ2dkcOHAAsLUuSE5OJjk5mQEDBnD69GnKy23/zv75z386dJxJkyaxf/9+Dh8+DMCyZcs6eu/W1tZiMplITExEVVWH2h4sWrSIf/zjH6xfv/6CbSCEEEIIZ/C0c10hhPAU8oqoIXsiLyYsgEA/5zwUYUF+RAT7UdPYRn5lY8dl9UJ7RVVNAKQ4oZ/xkKRwjhTVcKyklmmZSb3enxDddfCg8xK3Op2OkSPj+eqr0+zfX9pRgSu0ZTZb8fNzbpsEPz8DJpMes1mhsdFMaKi/Q/ezWCz8/ve/59SpUwQFBWGxWLj99tuZPXs2AP/+97956KGH+Mtf/oLVaiUmJoaVK1eSnZ3NI488gqqqWCwWbrvtNkaOHMlTTz3Fv/71L/z9/VEUhZdffvm8Y/7kJz/hxIkTXHLJJQBMmzatY3BZd1mtVsaMGUNjYyN//etfOwaNvfXWWyxcuBCLxUJkZCTvv/8+Op2OpKQkfvGLXzB+/Hji4+O55pprHDpObGwsy5YtY+7cufj5+XH11VcTHR0NQFZWFrfccgsjRowgOjqaOXPmXHR/KSkpjBkzhsGDBxMU1LsPHYUQQgghhBDdp1O9uElmXV0d4eHh1NbWEhYWpnU43fb53nz+/Ml+xvSP4ZkfTnDafv/fm9vYf7qK/zd7FLNGpqAoCmVlZcTFxcllJw5wxXo1tpiZ99wXAKz+xZUE+/cuEWJ/7oxMj+K5hZOcEWKPyfPLcb60VgMH/pWTJ6tZv34h06f37/X+fvrT//LCCzv5+c8n8dxztqpGX1ovd3DmerW0tLB9ezYhIfGkp0cTG+u8liwnTlRRXd1CcnIoiYmhTttvd9gTuUajsdetPnxZY2MjQ4cO5auvviI1NdUl69XS0sKpU6fo37//Oe0nvP0cz1lkHRwj/190j6xX98h6OU7WqntkvbpH1qt7ZL0cp8VadeccTx49DZ0ZTObcHqX2dgmny2VAmaew97eNDPbvddIWzgwoO15Sh+K9n72Ibmhra+O5557jueee67j0WStNTWZOnaoGbD1uncFeZbt/f5lT9id6R1XVjlYJQUHOHUwWEmIbltXTPrfCPV5++WWGDRvG/fffT//+vf9wRgghhOiKJ53rCiGEJ5FWCRrKb2+VkOqES+fPlh5r21+eDCjzGPbEbVIv+9vapceG4GfU09Rqoaiq0SntF4Tna2pq0joEAHJyylFViIkJIi7OOR88nUncljplf6J3KiqaUBTbh0IBAc49VbAnbhsbzaiqKhWvHuree+/l3nvvBWyJfCGEEMLVPOVcVwghPIkkbjVU0FFx69ykW1pMe8VthVTceorC9iS9s4bQGfR6BsaHkVNYw7HiWknc9gEmk6ljqrvJ5NwKyO5yZn9bu8zMOHQ6KClpoKys0WkJYdEzR45UAraetAaDcy/OCQw0odPpsFgUWlosTu2hK4QQQgjv5EnnukII4UmkVYJGzFaFomrbJ4quqrgtqW6i1Wx16r5Fz9grbpOjnPdYD2pvl3C0uNZp+xSeS6fTERcXR1xcnOYVigcP2toZODNxGxzsx6BBUYBU3XqCw4crUFUICDA4fd96vY7gYNsbssZGs9P3L7yLVPMKIYQAzzrXFUIITyIVtxoprmpEUVUC/QxEOzhV21ERwf6EB/lR29RGfkUDA+K1Gf4izijoSNw6byr3kKT2PreSuBVudqbi1jn9be1Gjozn2LEq9u8vZdasAU7dt+ie3bvLiImJwGJpoLm52elvoAICoKHBQm1tAyEh7v8MWYaTdY+r1ktVVcrLy9HpdFJdJYQQQgghRCckcauRs/vbuuJNY1pMCNl5VeRJ4lZzqqpSVGVvleC8itvBCfbErW1AmV6SDz7NarWyd+9eAEaPHo3B4PxKSEe5olUC2BK3H3yQIxW3HmDXrhJ27jzN669Hkpub6/T9NzebqahopLbWQFub+/+PUlUVRVHQ6/WSuHWAK9dLp9ORkpKi6WuaEEII7XnSua4QQngSSdxqJN9F/W3t0mJtidvT5fVAokuOIRxT29RGQ4sFgMRI51XcpsWG4G/U09RmobCy0WXPJeEZrFYr//73vwHIysrS7GS2oaGN3NwawDUVtyCtErTW1mYlJ6ccs1khLi6VhATnvW7ZVVc3M2/e6wBs2/ZjIiMDnX6MriiKQmVlJdHR0ej10jXqYly5XiaTSd6cCyGE8JhzXSGE8DSSuNVIfqUtceusYVXfld6exDtdLgPKtGbvbxsXHoi/yXknIAa9ngEJYeQU2AaUSeLWt+n1eoYOHdrxvVYOH64AIC4umJgY5yb0Ro2yJW4PHizHbLZiMEglpBaOHKnAbFYID/cnPT3SJRWpiYkBBAYGcvhwBd9+W8b11w91+jG6oigKJpOJgIAASdw6QNZLCCGEq3nKua4QQngaeUXUSH5Fe6sEFyXb0mNtl57mVUjiVmv2xG2SE/vb2g1JjADgmPS59XlGo5FbbrmFW265BaNRu8/cXDGYzC49PYLQUD/a2qwcPVrp9P0Lx+zbZ6t4Hjky3qVtBKZMSQVg69Z8lx1DCCGEEN7BU851hRDC00jiVgOqqnZU3KY6sefp2dJibfstrm6kzWJ1yTGEYwrb+xmnRDm/unpwoq3P7VFJ3Ao3sfe3zchwfuJWr9eRlSXtErRmX3t76wpXmTzZlrjdskUSt0IIIYQQQgjRGUncaqCqoZWmVgt6nWuqMAEig/0JCTChqGcSh0Ib9orbZBcmbk+U1GJVVKfvX4jvctVgMruRI219cyVxqx13JW7tFbc7dxbR1iYfMAohhBBCCCHEd0niVgP2atuEyCD8jK5puq7T6Uhvr7o9Le0SNFXQnjhPdkE/49SYEPxNBprbrBRWyuPsy8xmM0uXLmXp0qWYzWbN4jjTKsG5g8nsRo1KAM5cri/cz12J2yFDoomODqSlxcKePcUuPZYQQgghPJunnOsKIYSnkcStBjr627qoTYJdR59bGVCmGUVVKapuAlxTcWvQ6xiUEAZIn1tfp6oqtbW11NbWoqraVFc3NLRx+rTteea6iltplaCl8vJGiosb0OkgM9M1yXk7nU7X0S5B+twKIYQQfZsnnOsKIYQnksStBgrs/W1dNJjMLq19/zKgTDuV9S20mq3odToSIlzTFkP63PYNRqORu+66i7vuukuzgQ2HDtnaJMTHBxMd7Zrnsz1ZWFhYT2Vlk0uOIS7MnjAfODCKkBA/lx9P+twKIYQQAjzjXFcIITyRJG41kF9hH0zm/ArMs6VJqwTN2fvbJkYGYTS45p+bPXErFbe+Ta/Xk5ycTHJyMnq9Ni/drm6TABAW5k///hEAZGeXuew4onPuapNgZ+9zu2VLvlTXCCGEEH2YJ5zrCiGEJ5JXRA3kt/c8dXXFbb/2VglFVU2YrYpLjyU6Zx8Ml+yiIXRwJnF7vKROBpQJl3L1YDI7e59baZfgfvv325Ll9iFxrjZuXBImk56SkgZyc2vcckwhhBBCCCGE8BaSuHWzljYLZbXNgOt73EaF+BPsb0RRVUprW116LNE5e8Vtsgsf65ToEAJMBlrN1o42HML3KIrC/v372b9/P4qizQcx7krc2pOG9iSicJ99+0qAM8lzVwsMNHHJJYmAtEsQQggh+jJPONcVQghPJIlbNytor8AMD/IjLMi1/QN1Ol1Hu4TC6maXHkt0zh0Vtwa9joHtA8qOFkm7BF9lsVj48MMP+fDDD7FYLJrEYO9x68pWCXDmMv3sbKm4dSeLRelIzrurVQKcaZcgA8qEEEKIvssTznWFEMITSeLWzfLbKyJTXNzf1i69vV1CYU2LW44nztVRcRvl2urqIUkRABwvkcStr9LpdAwYMIABAwag0+ncfvz6+lby8mzPr4wMV1fc2pKGBw6UY5U2L25z9GglbW1WQkL86Ncvwm3HlQFlQgghhND6XFcIITyVjGt0s/wK9/S3tUtvP06RVNy6nVVRKK5uAlxbcQswWCpufZ7JZOK2227T7Pj2atuEhBCiogJdeqwBAyIJCjLR1GTm1Kk6EhPdc9l+X2fvKZyVFYde7743TPbEbXZ2KXV1rYSF+bvt2EIIIYTwDFqf6wohhKeSils3s1fcurq/rV2aveK2Wipu3a2stgWLomIy6IkNd22ia3B7xe2J0jqs0hNKuIC7+tsCGAx6srJs7RgOHap0+fGEjb2/rTvbJAAkJobSv38Eqgrbtxe49dhCCCGEEEII4ckkcetm+RXtidsY97RKSGuvuC2tbcEilxy7lX1QWFJUEHoXX+6TEh1MoJ9tQJm9qlsIZzp40DYozB2JWziTPJTErfvYh8GNGuXexC3AlClpgPS5FUIIIYQQQoizSeLWjayK2tHz1F0Vt7FhAQT6GbCqZ/qtCvewr3dKlOuT9HqdjkEJ4QAcK5Z2Cb7IbDbz97//nb///e+YzWa3H/9Mxa1rB5PZ2RO3OTlVbjmeONMqwd0VtwCTJ6cA0udWON9vf/tbTp8+rXUYQgghLkLrc10hhPBUkrh1o/LaZtosCiaDnvgI1/Y8tdPpdB1Vt3nt1b7CPToGk7kpST840Za4PVpc45bjCfdSVZXy8nLKy8tRVdXtx3dnqwSQilt3q6pqpqCgDoDMTPck589mr7jdvr1ABtIJp/roo48YOHAgM2fOZOXKlbS2tmodkhBCiE5ofa4rhBCeShK3bmTvb5scFYzBjYNfJHGrjcLK9sStiweT2dkTt1Jx65uMRiO33347t99+O0aje+dK1ta2dCT13F1xW1DQQE2N9Oh2NXu1bb9+EYSHB7j9+CNGxBIW5k9DQxvZ2WVuP77wXXv37mXnzp2MGDGCBx98kISEBO677z527typdWhCCCHOouW5rhBCeDJJ3LqRu/vb2qXFtiduyyVx605aVdyeLJEBZb5Ir9fTr18/+vXrh17v3pfuQ4ds1bZJSaFERLgnqRcREUBamu05LYk817MnbrXobwu2gXQTJ9rbJeRpEoPwXWPGjOGvf/0rRUVFvP766xQUFDBlyhRGjhzJ888/T22tfOAphBBa0/JcVwghPJm8IrpRfqV7+9vapceEAlJx605tFitltc2A+ypuk6ODCfIz0mpRJEkvnMrdbRLssrJs1b3Z2aVuPW5fpGV/W7spU1IB2Lq1QLMYhG9TVRWz2UxbWxuqqhIZGckLL7xAamoq7777rtbhCSGEEEIIcR5J3LrRmYpb9yZu7RW3BZWNUonpJiXVTSgqBPkZiQz2d8sx9TodgxLDADgq7RJ8jqIoHD58mMOHD6O4+d+xveLW3YnbkSNtidv9+6Xi1tU8IXE7ebItcSsVt8LZdu3axeLFi0lMTORnP/sZY8aMIScnh02bNnHs2DGefPJJHnjgAa3DFEKIPk3Lc10hhPBkmiduCwsL+eEPf0h0dDSBgYFkZWXx7bffah2WS9h73Lo7cRsbFoC/UY9FUSmqanLrsfuqgvY2CUlRQeh07utnLH1ufZfFYuHdd9/l3XffxWKxuPXYZypu3Tu0yp5EtCcVhWtYrQoHDtiS41ombidMSEav13H6dC2FhXWaxSF8S1ZWFhMnTuTUqVO8/vrr5Ofn88wzzzBo0KCObebPn095ebmGUQohhNDyXFcIITyZpl2/q6urmTJlCtOnT+fTTz8lNjaWY8eOERkZqWVYLlHX3EZNYxsAKdHu7XGr1+lIigzgVHkTp8vr3Z447ovs/W1T3NwWQxK3vkun05GamtrxvTsdPGhL6mVkuLvi1pZEzM4uQ1FU9G4c6tiXHD9eRXOzhaAgEwMHavf/b2ioPyNHxrN3bwlbt+Zz440jNItF+I6bbrqJH/3oRyQnJ19wm5iYGKnuEkIIjWl5riuEEJ5M08Tts88+S2pqKsuXL++4rX///hpG5DoF7f1tY8ICCPRz/7InRwRyqrxJ+ty6SWHlmYpbdxqSGAHAydI6LFYFo0HzonrhJCaTiR/96EduP25NTQuFhfWA+xO3gwZFERBgoKnJzMmT1QwaFOXW4/cV9ormzMw4DBq/ZkyZkiqJW+FUjz76qNYhCCGEcIBW57pCCOHpNH2H9vHHHzNu3DhuvPFG4uLiGDNmDK+++qqWIblMR39bN1dg2iVF2ibBn5ahVW7RUXEb5d7q6sSoIIL8jbRZFHmshVPY+9smJ4cSERHg1mMbjXqGDLFVgEq7BNc509/Wva0wOnOmz22+xpEIX/GDH/yAZ5999rzb//CHP3DjjTdqEJEQQgghhBCO07Ti9uTJk7z00kssWbKEX/3qV+zcuZMHHngAPz8/br/99vO2b21tpbW1tePnujpbDzxFUTz+Ere8ClvFWkp0sNtjVRSFpAh74rbe49dKa4qioKpqr9bJXnGbGBnk9vUenBDGvtNVHC2qpn+c6z8ocMZ69RXeuFbZ2bakXkZGrCavXcOHR7F/fwV79xYzZ85Qtx7f2/T0+bVvn+0xzsqK0/y5OWmS7XL2PXtKaGhoJSjI5JLjeOO/RS1psV7OOtZXX33F7373u/Nuv+aaa/jTn/7klGMIIYQQQgjhKpombhVFYdy4cTz11FMAjBkzhgMHDvDyyy93mrh9+umnefzxx8+7vby8nJaWFpfH2xsniqoAiPBTKCtz74R0RVEINdj66xZUNlBcUopBekVekKIo1NbWoqoqen33i9JbzFYqG2wfMPhZmygra3N2iF1KCjexD9h/spQxSf4uP15v16sv6c1aWSwWPv74YwC+//3vYzS65+X7229PA9C/f7Amr10DBtjajezcme/243ubnj6/9uwpAiA11U/zNQ4IUElMDKa4uJEvvjjI5MlJLjmOvG51jxbrVV9f75T9NDQ04Ofnd97tJpOpowBACCGE9sxmMytWrADgjjvuwGRyzYe3QgjhbTRN3CYmJpKRkXHObcOHD+eDDz7odPtHHnmEJUuWdPxcV1dHamoqsbGxhIWFuTTW3iqrPwzA8H4JxMXFuPXYiqKgAv7GQlotCopfCIluvoTfmyiKgk6nIzY2tkdvUE+U2N4IhgWZGJDmmqRDV0YNtPLp/lIKa9uIi3P9pc+9Xa++pDdr1dbW1jH1PCYmptNEhCucOmWrHh83Lt0tz6ezKYrCJZekAHs5erTW7cf3Nj15ftXWtlBQYGurcsUVQ4mMDHRliA6ZMiWNVatyyMlpYM4c1zzm8rrVPVqsV0CAc1qzZGVl8e677/LYY4+dc/s777xz3jmoEEII7aiqSlFRUcf3QgghbDRN3E6ZMoUjR46cc9vRo0dJT0/vdHt/f3/8/c+vINTr9R79xstsVSiubgIgPTZMk1gNej2pMSEcL6kjv7KR1JhQt8fgTXQ6XY+fV0Xtj3VyVLAmj/WQpAgATpbWo6i4ZUBZb9arr+npWvn5+TF//vyO79211vYet1lZ8Zo8vsOH2waSnTxZTWOjmdBQ11eRe7PuPr8OHqwAIDU1jOhoz/hA77LLbInbbdsKXPqck9et7nH3ejnrOI8++ijz5s3jxIkTzJgxA4B169bx9ttv8/777zvlGEIIIXrPaDR2nOu668oyIYTwBpq+W/nZz37G9u3beeqppzh+/DgrV67kH//4B4sWLdIyLKcrrmpEUVUC/QxEa5h0SIux9TuVoVWudWYwmVaD6III9jditiqcLnfOpaZCe3q9niFDhjBkyBC3JU6qq5spLra9XmRkxLrlmN8VHR1IUpLtg6bsbGmV4GxnBpPFaxzJGfYBZVu35qMoUnEjeuf6669nzZo1HD9+nPvvv5///d//paCggLVr1zJnzpxu7+/FF1+kX79+BAQEMGHCBHbs2NHl9jU1NSxatIjExET8/f0ZMmQI//3vf3v41wghhO/S4lxXCCG8gaaviJdeeikffvghb7/9NpmZmTzxxBMsXbqUW2+9VcuwnC6/fVBVanQIOp12vWXTY22JxDxJ5rmUPXGbFBWkyfF1Oh2Dk8IBOFpcq0kMwjfYq21TU8MIC9PuQyd7UtGeZBTOs29fCeBZidvRoxMIDDRSXd3CkSMVWocjfMC1117Lli1baGxspKKigvXr1zN16tRu7+fdd99lyZIl/Pa3v2X37t2MGjWKq6666oK9odva2vif//kfcnNzWbVqFUeOHOHVV18lOTm5t3+SEEIIIYToIzT/KOu6664jOzublpYWcnJyuPvuu7UOyenyK2wVa6kx2lRg2tkrbvMqpOLWlToqbqO1e7wHJ9gSt8ckceszFEXhxIkTnDhxwm2T3Q8etCVuR4zQtrfsyJG240vi1vn277clnEaN8pzErclkYPx4W2Jry5Z8jaMR4ow///nP3H333dx5551kZGTw8ssvExQUxLJlyzrdftmyZVRVVbFmzRqmTJlCv379mDp1KqNGjXJz5EII4fm0ONcVQghvIM1j3CC/0pYoTdG4f+DZiVuromLQa1f968sK2yuskzWquIUzfW6PFUni1ldYLBb+9a9/AbZBje4YTnbwoC2pl5Hh3oGK35WVJYlbV1AUlexsz2uVADBlSiqbNp1m69Z87rrrEq3DEV7MarXyl7/8hffee4+8vDza2trO+X1VVZVD+2lra2PXrl088sgjHbfp9XpmzZrFtm3bOr3Pxx9/zKRJk1i0aBEfffQRsbGxLFiwgIcffhiDwdDpfVpbW2ltbe34ua7ONvBUURRJZHRBURRUVZU1cpCsV/fIejmuN2vV1tbWca778MMPu20Qr5bkudU9sl7dI+vlOC3WqjvHksStG+RXtLdK0LjiNj4iCD+jnjaLQmlNE0lRnjGIxpfUNbdR12wG0HR9ByfaKm5PldVjtiqY3DCgTLiWTqcjPj6+43t38JyK2zOtEhRFRS8fOjnFqVO2gW/+/gYGD47WOpxz2PvcSsWt6K3HH3+c1157jf/93//lN7/5Db/+9a/Jzc1lzZo1PPbYYw7vp6KiAqvV2vE6bBcfH8/hw4c7vc/JkydZv349t956K//97387+uyazWZ++9vfdnqfp59+mscff/y828vLy2lpaXE43r5GURRqa2tRVVV6YzpA1qt7ZL0c15u1slgsREfbzkcqKir6xIAyeW51j6xX98h6OU6Ltaqvd7yFqe+/GmpMVdWOittUDS+dBzDodaRGh3CitI68igZJ3LpAUXubhOhQfwL9tPvnlRARSEiAiYYWM7ll9R2JXOG9TCYT9957r1uPeSZxq81gMruhQ6Px8zNQX9/G6dM19O8fqWk8vmLfPlu17YgRcRiNnnUyN2mSLXF79GglFRVNxMRodwWD8G5vvfUWr776Ktdeey2/+93vmD9/PgMHDmTkyJFs376dBx54wGXHVhSFuLg4/vGPf2AwGBg7diyFhYU899xzF0zcPvLIIyxZsqTj57q6OlJTU4mNjSUsLMxlsXo7RVHQ6XTExsbKm1MHyHp1j6yX43q7Vvfff78LovJc8tzqHlmv7pH1cpwWaxUQEODwtpK4dbGqhlaaWi3oddoNqzpbWqwtcXu6vIGJQzzr0lhfUNDRJkHbpLhOp2NwYjh7TlVwrLhWErei26qqmikpsX3olJGhbeLWZDKQkRHL3r0l7N9fKolbJ7G3nvCk/rZ2UVGBZGTEcuhQOVu35vP97w/VOiThpUpKSsjKygIgJCSE2lpbC6HrrruORx991OH9xMTEYDAYKC09t2VLaWkpCQkJnd4nMTERk8l0TluE4cOHU1JSQltbW6eXAfv7++Pvf/4wSL1eL2+6LkKn08k6dYOsV/fIejlO1qp7ZL26R9are2S9HOfuterOceTRczF7tW1CZBB+xs77mbmTvc/t6XLHy7KF4+yDybRO3AIMSZQBZaLn7P1t09LCCQ09P4ngbme3SxDOYV9LT+tvazd5cgoAW7bkaRyJ8GYpKSkUFxcDMHDgQL744gsAdu7c2WmC9EL8/PwYO3Ys69at67hNURTWrVvHpEmTOr3PlClTOH78+Dk9zI4ePUpiYmKf6N0ohBBCCCF6TxK3LtbR31bjNgl2/WJDAduAMuF8HYPJNB5EB2f63Eri1jeYzWZWrFjBihUrMJvNLj+ep7RJsBs50j6grEzjSHyHpydup0xJA2Dr1gKNIxHebO7cuR3J1p/+9Kc8+uijDB48mIULF/KjH/2oW/tasmQJr776Km+88QY5OTncd999NDY2cueddwKwcOHCc4aX3XfffVRVVfHggw9y9OhR/vOf//DUU0+xaNEi5/2BQgjhI9x9riuEEN5CWiW4WIG9v63Gg8ns0mJtceRVNKCoKno3DTnqK+wVtylR2j/eg5PaB5SV1tFmsXpExbfoOVVVOX36dMf3rmavuPWUxO2oUbZLkfftK9E4Et9QX9/KiRPVgOcmbu0DynbuLKS11YK/v5yyiO575plnOr6/+eabSU9PZ+vWrQwePJjrr7++W/u6+eabKS8v57HHHqOkpITRo0fz2WefdQwsy8vLO+eyt9TUVD7//HN+9rOfMXLkSJKTk3nwwQd5+OGHnfPHCSGED3H3ua4QQngLeRfkYvkV9sFk2ldgAiRGBmEy6Gk1WymrbSYhQvu+u75CVdWzWiVov67x4YGEBpqobzZzurxB+tx6OaPRyA033NDxvaudqbiNc/mxHGFPLh4/XkVjYxvBwXKZcW8cOGBLzCclhXrs4K/Bg6OIiQmioqKJPXtKmDgxReuQhJcxm83cc889PProo/Tv3x+AiRMnMnHixB7vc/HixSxevLjT323cuPG82yZNmsT27dt7fDwhhOgr3H2uK4QQ3kJaJbhYfvul855ScWvQ60lpTyJLn1vnqm5spbnNil5n62msNZ1O19Hn9mhRjbbBiF7T6/WMGDGCESNGuKVh+qFDntUqIS4umPj4YFT1TFJZ9Jynt0kA22uYvepW+tyKnjCZTHzwwQdahyGEEMIB7j7XFUIIbyGviC7U0mahrLYZ8JwetwDp9j635dLn1pns/W3jwgM9pi3BIHviVvrcim6orGyitNT2fB4+3DMStyADypzpTOLWMyqqL2TKFFviVvrcip6aM2cOa9as0ToMIYQQQgghekSuQXChgvZEXniQH2FBnnNZb1p79e9pGVDmVB1tEjwoSW+vuD0uiVuvpygKBQW25FVKSopLKxHsFa3p6eGEhHjOa9fIkfF8+eVJ6XPrBPv2eX7FLXBOxa2qquikL7vopsGDB/P73/+eLVu2MHbsWIKDz21d9cADD2gUmRBCiLO581xXCCG8iSRuXSi/fTBZiof0t7WzDyiTVgnOZU/Ue0J/Wzt7X9tTZfUyoMzLWSwWli9fDsAjjzyCn5/rEqpnBpN5VjXmqFH2itsyjSPxbqqqdlTc2oe+eapx45Lw8zNQWtrIyZPVDBwYpXVIwsu8/vrrREREsGvXLnbt2nXO73Q6nSRuhRDCQ7jzXFcIIbyJJG5dKL/Cs/rb2p3dKkEqmJynqL3iNiXKcxL1ceGBhAf5UdvUxqmyeoYmRWgdkughnU5HVFRUx/eudGYwmee0SYBzWyXIa1fPnT5dS319GyaTnqFDo7UOp0sBAUbGjk1k27YCtm7Nl8St6LZTp05pHYIQQggHuPNcVwghvIkkbl3IXnHrSf1tAZIigzDqdbSYrZTXtRAXHqh1SD6hoD1xm+RBiVudTsegxHB2nSjnaFGtJG69mMlk4qc//albjuWpidthw2IwGvXU1LRQUFBHamq41iF5JXu1bUZGLCaT51fhT56cyrZtBWzZks9tt43SOhwhhBBCuIA7z3WFEMKbSOLWhfLbe8imxnhOIg/AaNCTHB3M6fIGTpfXS+LWCRRVpaiqCYAUD0vUD2lP3EqfW+EoT22V4O9vZNiwGA4cKGPfvlJJ3PbQmcFknt3f1m7KlFT+9KdtbN2ar3Uowgv96Ec/6vL3y5Ytc1MkQgghhBBCdJ90/HYRRVU7hlV5WsUtQFqMrV3C6XIZUOYM5bXNmK0KRr2OuPAArcM5h73P7VFJ3AoHlJc3Ul5u+xBi+PAYjaM535k+t6UaR+K9vGUwmZ19QNmBA2XU1LRoHI3wNtXV1ed8lZWVsX79elavXk1NTY3W4QkhhBBCCNElqbh1kbLaZtosCiaDnvgIzxlWZdcvNoSvcyCvQgaUOYO9TUJiZBAGD5uAak/cni6vp9Vsxd8LLo0W57NYLLz33nsA3HTTTRiNrnn5trdJ6N8/guBgzxsKMXJkPG+9lS2J2144M5jMOxK38fEhDBwYyYkT1XzzTQFXXTVI65CEF/nwww/Pu01RFO677z4GDhyoQURCCCE6465zXSGE8DaelWHyIfY2CclRwRj0ntdcPe2sAWWi9+yDyZI9sLo6NiyA8CA/rIrKqbI6rcMRPaQoCseOHePYsWMoiuKy43hqmwS7sweUie5rajJz7Fgl4D0Vt3Cm6nbLFmmXIHpPr9ezZMkS/vKXv2gdihBCiHbuOtcVQghvIx9juUh+ZXubBA/rb2uXFmNLMJ6uaPDI6exWReVAXhVVDS1EhQSQmRblkQlwu4L2xzs5yvOqq3U6HUOSwtl5vJxjxbUMS47UOiTRAwaDgdmzZ3d87yqHDnnmYDI7e7LxyJFKmpvNBAaaNI7Iuxw8WIaqQlxcMPHxnvdB04VMmZLKP/+5X/rcCqc5ceIEFotF6zCEEEK0c9e5rhBCeBtJ3LpIx2AyD6zABEiOtlUCN7VaqKhvITbMcwaUbc4p5qXPD1FRf6aXYUxoAPddlcFlwxM1jOzC7BW3njaYzG5wgi1xe7RI+tx6K4PBwOjRo11+HHurBE9N3CYmhhATE0RFRROHDpUzdmyS1iF5FW/rb2tnr7jdvr0Ai0XBaJQLhoRjlixZcs7PqqpSXFzMf/7zH26//XaNohJCCPFd7jrXFUIIb9Ojdz75+fkUFBR0/Lxjxw4eeugh/vGPfzgtMG9XUNmeuI3xzESeyaAnOcpWDexJ7RI25xTzxKrd5yRtASrqW3hi1W425xRrFFnX7D1ukzyw4hZgcJKtz+0xGVAmLsKeuM3I8MzErU6nk3YJveBt/W3tRoyIIzzcn8ZGszzuolv27Nlzztf+/fsB+NOf/sTSpUu1DU4IIYQQQoiL6FHF7YIFC/jJT37CbbfdRklJCf/zP//DiBEjeOuttygpKeGxxx5zdpxeJ7/C3irBMxO3YGuXkFfRwOmKBsYO1D5JY1VUXvr8UJfbvPzFISYNTfCotgkWq0JJdTMAKVGe+XifGVDWIAPKvJSiKJSV2frPxsXFoXfBELyyskYqKprQ6WD4cO1fEy5k5Mg41q8/JQm8HrCvmbdV3Or1OiZNSuWzz46zdWs+l1zimVdfCM+zYcMGrUMQQgjhAHec6wohhDfq0avhgQMHGD9+PADvvfcemZmZbN26lbfeeosVK1Y4Mz6vVN9sprqxFYCUaM/scQuQFtve57a8XuNIbA7kVZ1Xaftd5XUtHMirclNEjimpaUJRVfxNBqJD/bUOp1MxoQFEBvujqConS2VAmTeyWCy88sorvPLKKy7ry2gfTNa/fyRBQZ7bO9aedLRf9i8co6qq1yZuASZPTgFkQJnonlOnTnHs2LHzbj927Bi5ubnuD0gIIUSn3HGuK4QQ3qhHiVuz2Yy/vy1BtXbtWr7//e8DMGzYMIqLPfNSdneyt0mICQsg0M9z2winx4YCntMqoaqh66Rtd7dzl8Iq+2CyYI8b8man0+kYnBgGwFFpl+CVdDodoaGhhIaGuux55un9be1GjUoAbNWjqqpqHI33KCioo7q6BaNRz/DhMVqH021TpqQByIAy0S133HEHW7duPe/2b775hjvuuMP9AQkhhOiUO851hRDCG/UoqzhixAhefvllrr32Wr788kueeOIJAIqKioiOjnZqgN4ov9KzB5PZpbe3ccirqEdVVc3/g4wKCXDqdu5SWGlP3Hpmf1u7wYkR7DheLn1uvZTJZDpvyI6z2StuPT1xm5ERi16vo7KymeLiBpKSQrUOySvYq22HDYvB399zP1S8kPHjkzEYdOTl1VJQUEdKSpjWIQkvsGfPHqZMmXLe7RMnTmTx4sUaRCSEEKIz7jjXFUIIb9Sjittnn32WV155hWnTpjF//nxGjRoFwMcff9zRQqEvs/e39eQ2CQDJ0cHoddDQYqGqoVXrcMhMiyIy2K/LbWLDAshMi3JTRI4pOKvi1pPZ+9weK5LErejcmYrbOI0j6VpAgJGhQ20fEkqfW8d5c5sEgJAQv45qa6m6FY7S6XTU15/fEqq2thar1apBREIIIYQQQjiuR4nbadOmUVFRQUVFBcuWLeu4/Sc/+Qkvv/yy04LzVvkV7RW3HjyYDMDPaCAp0pZsPO0B7RIMeh2xYYFdbnPvlRkeNZgMzmqV4OGJ+iFJtsRtXkU9LWZ5syrOpaqq17RKgLP73JZoHIn32L/fVlE9cqRnJ+a7cqbPbZ7GkQhvccUVV/D000+fk6S1Wq08/fTTXHbZZRpGJoQQQgghxMX1KHHb3NxMa2srkZGRAJw+fZqlS5dy5MgR4uK89w2hs3hLqwSA9Ngz7RK0ti+3kqPFtejgvMrbQD8Dj95wCZcN97xJ4mdaJXh24jY6NICoEH8UFU6USNWtt7FYLLz//vu8//77LhnYUFraSFVVM3q9jmHDPL//qT1xa09GiouzJ7m9teIWzu5zW6BxJMJbPPvss6xfv56hQ4dy5513cueddzJ06FC++uornnvuOa3DE0II0c7V57pCCOGtepS4nT17Nm+++SYANTU1TJgwgT/96U/MmTOHl156yakBehuLVaG4ugmA1BjPTuQBpLUPKNO64lZRVf7x5SEArhuXzlsPzeIPt03khkn9AQgwGZg0NEHLEDvVarZSXmcblpbiBYl6e7uE49Ln1usoisKhQ4c4dOgQiqI4ff+HDtmqbQcMiCQw0OT0/TvbqFH2xK20SnBES4uFI0cqgTPD3bzR5MmpAOzZU0xjY5vG0QhvkJGRwf79+7npppsoKyujvr6ehQsXcvjwYTIzM7UOTwghRDtXn+sKIYS36tF0kt27d/OXv/wFgFWrVhEfH8+ePXv44IMPeOyxx7jvvvucGqQ3KapuwqqoBJgMxIR61hCtzqS1t3M4Xa5txe26/YUcL6kjyN/ID68YjEGvY1S/aDJSI/lsTwHVjW1k51Uyup9nVQIWtbdJCAkwEuYFya7BieF8c6yMo5K49ToGg4Frrrmm43tn85bBZHb2qtHDhytobbV45bAtdzp0qBxFUYmODiQx0fM/ZLqQtLRwUlLCKCioY8eOQqZP7691SMILJCUl8dRTT2kdhhBCiC64+lxXCCG8VY8qbpuamggNtVVqfvHFF8ybNw+9Xs/EiRM5ffq0UwP0NgVn9bfV6TyrF2tn0s+quFVVVZMYWtosrNhwBID5lw0iIti/43cmg57LhtuqwzYdLNYkvq509LeN8o7Hu2NAmSRuvY7BYGD8+PGMHz/eRYlbW8VtRoZ3JG5TUsKIiAjAYlE4fLhC63A83tmDybzhtaorU6bYqm5lQJlwxPLly3n//ffPu/3999/njTfe0CAiIYQQnXH1ua4QQnirHiVuBw0axJo1a8jPz+fzzz/nyiuvBKCsrIywsDCnBuhtzvS39fw2CQAp0cHoddDQYqZGo8tOV20/RUV9C/HhgcwZ3++8308bkQTA1znFWKyeddnMmcRtkMaROMaeuM2vaKClTXpHiTO8aTAZ2CbFnxlQJu0SLsYX+tva2dslbNkiiVtxcU8//TQxMedfrRMXFydVuEIIIYQQwuP1KHH72GOP8fOf/5x+/foxfvx4Jk2aBNiqb8eMGePUAL1NfoUtkZca4x2XovqbDCRE2pKOpzUYUFZZ38J7W08A8KOZw/Aznv/p6sj0aCKD/alvNrP7pGdV1nUkbr2gvy3YBpRFh7YPKCut0zocTVgVlX25lWw4UMi+3EqsijaV5t2lqiqVlZVUVlY6vTpeVdWzWiV4z4BJ6XPrOPsQN/uaeTN7xe22bQUoXvLvV2gnLy+P/v3Pb6mRnp5OXl6eBhEJIYTojCvPdYUQwpv1qCngDTfcwGWXXUZxcTGjRo3quH3mzJnMnTvXacF5ozMVt96RyANIiwmlqKqJ0+UNbu8h+8bGI7SarQxPjmBqRmKn2xj0Oq7ISOSjnblsPFjE+MGek1gqqPSuiluAwQnhVNaXcbSolhGpUVqH41abc4p56fNDVNS3dNwWExrAfVdlcNnwzp9/nsJsNvPCCy8A8Mgjj+Dn5+e0fZeUNFBd3YJer2PYMM/qI90Ve/WoJG67pqqqT1XcjhwZT1CQiZqaFnJyyr3qwwbhfnFxcezfv59+/fqdc/u+ffuIjo7WJighhBDnceW5rhBCeLMeVdwCJCQkMGbMGIqKiigoKABg/PjxDBs2zGnBeRtVVck/q8ett0iPtcWa5+YBZSdKavlir+2585MrM7rsuzh1hC2ptu1IKa1mq1vic4S94jbFixL1g5MigL7X53ZzTjFPrNp9TtIWoKK+hSdW7WZzjuf1UP4uf39//P39L75hN9nbJAwcGElAgPcM+ZLErWNKShqorGxGr9d5TQ/jrphMBsaPt7XQWbp0Oxs35mL1sDY6wnPMnz+fBx54gA0bNmC1WrFaraxfv54HH3yQW265RevwhBBCnMVV57pCCOHNepS4VRSF3//+94SHh5Oenk56ejoRERE88cQTKErfffNU3dhKY6sFvQ6SvKgCM709yZzXnnR2B1VV+ceXOajA1IxEMlIiu9x+eEokceGBNLVZ2Hm8zD1BXkTjWX2BvenxHpxo60PdlxK3VkXlpc8PdbnNy18c8ui2CX5+fvzyl7/kl7/8pdMrELyxTQLY+vHqdFBa2khpqftev7yNvQfwkCHRBAaaNI6m91avzmHXLtsHLa+9tofp09+gX7/nWb06R+PIhCd64oknmDBhAjNnziQwMJDAwECuvPJKZsyYwZNPPql1eEIIIdq58lxXCCG8WY8St7/+9a954YUXeOaZZ9izZw979uzhqaee4m9/+xuPPvqos2P0Gvb+tvERQZ32avVUabGhAJwud1/i45tjZezNrcRk0POjGRev0tbrdB2tFDYeLHJ1eA6xV9tGBvsT7O89yZCzB5Q195EBZQfyqs6rtP2u8roWDuRVuSkiz+Jtg8nsgoP9GDzYdqmzVN1emH1tfKFNwurVOdxww3vU1587TLOwsI4bbnhPkrfiPH5+frz77rscOXKEt956i9WrV3PixAmWLVsmVV1CCCGEEMLj9Shx+8Ybb/Daa69x3333MXLkSEaOHMn999/Pq6++yooVK5wcovfo6G/rRW0SwBavDqhtaqOmsdXlx7NYFV5ba3tzPWd8v47haBczbYTt0thvjpXR1Kp9wtGeuPWmaluAqJAAYkIDUIHjJX1jQFlVQ9dJ2+5u52u8NXEL0i7BEfa18fbBZFarwoMPfkZn80rstz300GfSNkF0avDgwdx4441cd911REZG8tJLLzFu3DitwxJCCCGEEKJLPUrcVlVVddrLdtiwYVRV9c2KNeBMf9voYI0j6Z4Ak6EjeeqOdgn/3Z1HfmUj4UF+zL9skMP3G5gQRkpUMG0Whe1HtU/SFFba+9t61+MNZ6pu+0q7hKiQAMc29NxOCVgsFtasWcOaNWuwWJz3wYWqqhw6ZE/celerBICRI20x79/vGS1UPJGvVNx+/XUeBQUX/rBJVSE/v46vv85zY1TCm2zYsIHbbruNxMTEjhYKQgghPIOrznWFEMLb9ShxO2rUqI6Jj2d74YUXGDlyZK+D8lb57Yk8b6u4BUhrj9nV7RIaWsz8c9NRAG6bOpjgAMdbDOh0Oqa2V916QrsEe8VtcpT3Pd4diduiGm0DcZPMtChiQi+evH3uo7288OkBj6y8VRSFffv2sW/fPqf2Ei8ubqCmpgWDQcfQod43Yd2ejNy3r0TjSDxTW5uVnJwKwPsTt8XFjg3QdHQ70TcUFhby5JNPMmjQIG688UZWrlzJsmXLKCws5MUXX9Q6PCGEEO1cda4rhBDerkfjw//whz9w7bXXsnbtWiZNmgTAtm3byM/P57///a9TA/QmBR0Vt96XyEuLCeGbY2WcLnftG953Nh+nrtlManQw37skrdv3nzYikbe+PsauE+XUNbcRFqhd4/qCjsStd7VKABiS1Lcqbg16HfddlcETq3ZfcJv+8aGcKq3nk29P88W+AuaM78eNkwYS6iHDnAwGA7Nmzer43lnsg8kGDYrC379H/yVoyp6MPHSoHLPZisnkPf3F3SEnpxyLRSEiIoDU1DCtw+mVxMRQp24nfNsHH3zA66+/zldffcU111zDn/70J6655hqCg4PJyspCp9NpHaIQQoizuOpcVwghvF2PKm6nTp3K0aNHmTt3LjU1NdTU1DBv3jwOHjzIP//5T2fH6BVazFZKa5sB76y4TW8fUObKVgkl1U2s2ZELwN3/MxyDvvtPv7TYUAbEh2FRVLYc1q7CTlVViqrsrRK87/G2V9wWVDZ6RL9gd7hseCI/mjH0vNtjwwJ49IZLePknV/DsbRMYlhxBq9nKu1tOcMcL63l3y3FaPGCIm8FgYMqUKUyZMsXJiVtbm4SMDO/rbwvQr18EoaF+mM0KR45Uah2Oxzm7TYK3J6ouvzyNlJQwLvRn6HSQmhrG5Zd3/0NB4XtuvvlmxowZQ3FxMe+//z6zZ8+WKeVCCOHBXHWuK4QQ3q5HiVuApKQknnzyST744AM++OAD/u///o/q6mpef/11Z8bnNQrbB5OFBZoID/K+NwbpsbbkY54LWyW8vv4wZqvCmP4xjB/U816a00YkAtq2S6htaqOhxZbMS3RwuJoniQj2JzbMNqDsREnfqLoF2wcsAFlpUfxy7mj+cNtE3vjpDC4bbntOje4Xw9I7J/O7m8bRLzaUhhYLy9Yf4c4XN/LxzlzMPjj0yF5x642DycDWQkUGlF3YmcSt9/Uv/i6DQc/zz18NcMHk7dKlV2Mw9PjURviQH//4x7z44otcffXVvPzyy1RXV2sdkhBCCCGEEN0m726cJL/Ce/vbwpm4qxtbqWtqc/r+D+ZX8dWhYnTA3bOG96rya2qGrc/t/txKzXqR2vvbxoUH4u+ll2bbq26P9pF2CQA7jtmSlFeNTmV6ZjKj+kVj0J/7XNTpdEwaGs/ff3I5v5g9ioSIQKoaWnnxs4Pc9feNrN1fgFVx/xQzVVWpq6ujrq4OVXXe8e0Vt944mMxO+txemH1om7f3t7WbN284q1bdRHLyuW0fgoJMrFp1E/PmDdcoMuFpXnnlFYqLi/nJT37C22+/TWJiIrNnz0ZVVemdKIQQHshV57pCCOHtJHHrJPmV3tvfFiDQz0h8eCAAp53cLkFVVf7xZQ5gS5gNTOhdn8WEyCCGJ0egqPD1oWJnhNht9sRtkhf2t7XrGFDWRxK3FXUtHC+pQwdcOuji1aUGvY6ZI1N47f5pLL5mBFEh/pTUNPPcR/u47x9fsfVwiVtPKs1mM3/5y1/4y1/+gtlsdso+VVU9K3HrnRW3wFkVt2UaR+J57MlsX0ncgi15m5v7IBs23M4jj0wBIDIygLlzh2kcmfA0gYGB3H777WzatIns7GxGjBhBfHw8U6ZMYcGCBaxevVrrEIUQQrRzxbmuEEL4AkncOkl+e7IzJSZY40h67ky7BOcOKNt0sJjDhTUEmAwsnDbEKfucOsJWdbvxoDaJ24LK9v62Ud77eHckbov6RuJ2x3FbUm9YcgQRwf4O389k0HP9uH4sXzSNH80YRkiAidPlDTz+/i4eWr6VvacqXBXyefR6Pfoe9Ia+kMLCeurqWjEYdAwZEu20/brbqFHSKqEzpaUNlJY2otNBZqb3VlR3xmDQM21aP37zm6n4+RkoLKzn2LEqrcMSHmzw4ME89dRT5Ofn869//Yumpibmz5+vdVhCCCHO4uxzXSGE8AXdGiE+b968Ln9fU1PTm1i8Wn57Is9bK27BNvhrx/Fypw4oa7NYWbb+MAA3TR5IdGiAU/Z7RUYir3xxiEMF1ZTWNBEf4d7KV/tgsmQfSNwWVDXS2Gom2N+kcUSu9U17m4Txg3uWwArwM3LzlIFcOzaN97ee4MMduRwurOHhf33DmP4x3DljKEOTIpwY8bn8/Px49NFHnbpPe3/bwYOj8ffv1n8HHsWelCwqqqeioomYGO+thHem7Gzb4ztoUBTBwd7Xe90RQUEmJk9OZePGXNatO+nVH0AI99Dr9Vx//fVcf/31lJVJlb4QQngKV5zrCiGEL+jWx1nh4eFdfqWnp7Nw4UJXxeqxFFWlwN4qwUt73AKktcee68SK2w+/yaW0tpmY0AB+MGmA0/YbHRpAVnoUAF9p0C7BXnGbHO29iduIYH/i2ttjHC+u0zga12o1W9nTXhk7YXDvLhkPCTBx54xhrFg8jdmX9sOo17HnVAUPvL6F37/3LaedXLHuSr7QJgEgNNSfAQMiAam6PduZwWS+0yahM7Nm9Qdg7dpTGkcivE1cnG9VogshhBBCCN/TrRKr5cuXuyoOr1ZW20ybRcFk0JMQEah1OD2WHhsKQF65cypuaxpbeWfzcQDumD6UACcP8Zqemcz+01VsPFjEjZMHOnXfXVFUlaLqJgBSorw3UQ+2qtuy2maOFdcyqp/vVqrtP11Jq9lKTFgAA+JDnbLPqJAA7r96BPMm9udfm46xLruALUdK2Xa0lJlZKfxw6mASzqoEtyoq2acrOVVYRf9mA1npMecNRnO3Q4d8I3ELtuTkyZPV7N9fyowZ/bUOxyPs29c3ErczZw7gN7/ZwIYNp7BaFQwGucRSCCGEEEII4Ru899pYD2Lvb5sUFYTBi3vy2CtuqxpaqW82ExrYu0vn/7npKE1tFgYlhDFzZLIzQjzHlGEJvPDpAY6X1JFf0eC2aufK+hZazVb0Oh3xXpyoB1vidsvhEnYcLyM61J+okAAy06I0Tyg6W0ebhEFx6HTO/dsSIoL4+exR3Dh5AG9sOMKWI6V8ub+ADQcKuXZsOvMvG8TB/Cpe+vwQFfUt7fc6RUxoAPddlcFlwxMdOo7FYuHzzz8H4KqrrsJo7P3L95mKW++vOhs1Kp41aw5Lxe1Z7Gth7wHsq8aNSyIszJ/q6hb27Clh3LgkrUMSQgghRDe54lxXCCF8gfdmGT2IL/S3BQjyNxIbZutBm1fRu8u9T5fX89/deQDcc2UGeicnywDCg/y4ZEAMAJvc2C6hsL2/bWJkEEYvr+xqs1gB2JdbyTMf7uUX/9zOwr+uZ3OONkPfXEFVVXa0J24n9LC/rSPSY0N57KZxPP+jKYzpH4NFUfloZy4//Ot6nli1+6ykrU1FfQtPrNrt8ForisK3337Lt99+i6IovY5XVVWfq7gFaZVgZzZbOx5fX6+4NRptg8oA1q07qW0wPshqVdi4MZcPPzzOxo25WK29f/0RQgghvsvZ57pCCOErPCbr9Mwzz6DT6XjooYe0DqXb7BW33tzf1i6tvV3C6V62S3htbQ6KCpOHxjMy3XWX4E/NsFVWbTxQiKqqLjvO2Qrt/W2jvHsA0uacYlZ+ffy827ubUPR0p8sbKK1txs+oZ3T/GJcfb1hyBM/8cALP/nACQxLDsVwkyfHyF4ewKhd/7hoMBqZOncrUqVMxGHrfdqSgoI66ulaMRj2DB3t/mwx7cvLgwXIsFjnZP3q0krY2K6GhfqSnR2gdjstJn1vXWL06h379nmfmzH9y//3rmDnzn/Tr9zyrV+doHZoQQggf4+xzXSGE8BUekbjduXMnr7zyCiNHjtQ6lB7pGEzmxYOq7NJjbcnnvIqeJ253nSxnx/FyDHodP545zFmhdWrysHhMBj35lY2cLHXPUCh7xW2yF1dYWxWVlz4/1OU2jiYUPZ29TcLoftFO77PcldH9Yxx6/pfXtXAgr+qi2xkMBqZNm8a0adOccjJrb5MweHAUfn7ef3I8YEAkwcEmWlosHDtWqXU4mrP3t83KikfvY61POjNzpm345ebNebS0WDSOxjesXp3DDTe8R0HBucMrCwvruOGG9zw6eRsZGUlUVJRDX0IIITyDs891hRDCV2jeOKahoYFbb72VV199lf/7v//TOpweya9ob5XgAxW36e1/Q155z5KgVkXl1S9tb+auH5dOiouTm8H+JsYPjmPL4RI2HSxiYEKYS48HvlFxeyCv6rxL97/LnlD09qFl3xyzJbDGD3b/5eLVja0ObVfV0PVj4QoHD9oS2r7Q3xZAr9eRlRXP9u0F7N9fyvDh3t/+oTfsLSNGjvSNx/dihg+PITExhOLiBrZuzZcBdb1ktSo8+OBndHYhi6qCTgcPPfQZs2cP9chhcEuXLtU6BCGEEEIIIZxC88TtokWLuPbaa5k1a9ZFE7etra20tp5JhNTV2apAFEXRrA9OfbO5IzmTFBnkkf14FEVBVVWHYrNXDZ8ub+jR3/L5nnxOldUTEmBiwWUD3bIeUzMS2HK4hI0Hi7h92uBeD5+62HrZK2499fF2RGV9s8PbXexv7M7zy93qmtrIKagG4NKBMW6PMTLYz+HtLhabqqodr3/+/v69fp4fOGBL3GZkuH9dHNXd51ZWVhzbtxewb18JN96Y4eLoPM/Z63V2xa2nPr7ONmNGf956K5u1a08wbVp6l9t68uuWJ9i0Kfe8StuzqSrk59exaVNuR39hZ+vNY3P77bc7MRIhhBDu4OxzXSGE8BWaJm7feecddu/ezc6dOx3a/umnn+bxxx8/7/by8nJaWtxfsQZwvNTWUiAy2ERDbRW96wzrGoqiUFtbi6qq6PVdV8YEqLZLTCvqW8gtKCaoG5dQN7dZWbHhMADXj46nub6GZjd0L+gXriPApKe0tpntB3MZGNe7lhVdrZdVUSmqbgLAX2mmrKysV8fSis7sWOJWZ77439id55e7bTtehaJCSlQgtNZTVuaedhp2cf4qkcEmqhvNF9wmKthEnL/loutsNptZtmwZAD/60Y8wmUy9im3fPlsP45QUP499Hnf3udW/fyAA336b77F/kyudvV72xzc11dRn1uLSS6N56y34/PNjPPBAZpfbevLrlifIySlwaLsjR4rIyHDN1Sf19c57vT5x4gTLly/nxIkTPP/888TFxfHpp5+SlpbGiBEjnHYcIYQQPWc2m3n22WcBeOSRR/Dzc6wAQgghfJ1midv8/HwefPBBvvzySwICAhy6zyOPPMKSJUs6fq6rqyM1NZXY2FjCwlx/iXxn9hW3AZAeG0ZcnGdekqooCjqdjtjYWIfeoEaHHqayvpVmXQD94iIdPs6bG49S22whKTKI+dNGYHLj5ZOThpay4UAR+4qamZTZu0tku1qvoupGrIqKyaBn2IAU9F76SXB0TCwxX+V12S4hNiyAy0YOwHCR/pjdfX650+GtRQBMGZao2b/PRVer/N8Hey74+/uvziQh4eJtHNra2jq+j42N7dXJrKqqHDtWA8CkSYOIi/PMtgLdfW5NnjwI2MLhwzUe+3rsSvb10uuDKS62XRlw+eVDCQvz1zgy95gzx5+HHtrI3r3l+PmFERFx4XMLT37d0lJJSQPLl+/lb3/b4dD2Q4cmuezfmqPnhhezadMmrrnmGqZMmcJXX33Fk08+SVxcHPv27eP1119n1apVTjmOEEIIIYQQrqBZ4nbXrl2UlZVxySWXdNxmtVr56quveOGFF2htbT2vKbm/vz/+/ue/AdXr9Zq98SqoslVfpsaEePSbP9ubecfWKT02lMr6VgoqmxiR6lh/07LaZj74xjbN+8czh+Fvcu9Ta9qIJDYcKOLrnBLuuXLERZONF3Oh9SqutlWqJkUFYfTipvl6Pdx3VQZPrNp9wW3uvTIDk9Gxv7E7zy93sSoK356wDeCaMCRes9guz0jiUZ2Olz4/dE6iPDYsgHuvzOCy4YkO7cff35/f/OY3gO01rzeXj+Xl1dLQ0IbJpGfo0BiPety+qzvPrVGjEgDbJdy1ta1ERga6OjyPo9PpOHCgAoD+/SOIiOg7a5CeHsmQIdEcPVrJ11/nMXt218MBPfF1SwuKorJu3UleeWUXH310BIvF1qJAp6PTHrf236WkhDF1aj+XrZ+z9vvLX/6S//u//2PJkiWEhoZ23D5jxgxeeOGFbu/vxRdf5LnnnqOkpIRRo0bxt7/9jfHjx1/0fu+88w7z589n9uzZrFmzptvHFUIIX2cymc451xVCCGGjWeJ25syZZGdnn3PbnXfeybBhw3j44Ye9ZpJkfoWtOYIvDCazS4sJYffJCnK7MaBsxYYjtFkUMtOimDIswYXRdW7swFhCAoxUNbS6dKCWvb9tSlTv2jF4gsuGJ/LoDZecl1CMCvFn0dUjHE4oeqpDBTU0tFgICzQxLNnxynFXuGx4IpOGJpB9uoJTheX0T44lKz2mWx8w6HQ6p70u2geTDRkSjcnkHa+1joiICCA9PZzTp2vJzi7jiiu67nPqq7Kzbf1t7YnsvmTWrP4cPVrJ2rUnL5q47evKyhpZvnwPr766mxMnqjtunzQphXvuGYufn4Fbb10NnJvAtX9mtHTp1R45mOy7srOzWbly5Xm3x8XFUVFR0a19vfvuuyxZsoSXX36ZCRMmsHTpUq666iqOHDnSZeVxbm4uP//5z7n88su7Hb8QQvQVzjzXFUIIX6LZGXdoaCiZmZnnfAUHBxMdHU1mZte96TxJfmV74jbadxK36bG2ipS8csc69h4tqmFddiEA9/zPcE0ayZsMei4bZks0bjxY5LLj2BO3yT7yeF82PJE3H5jBH26bSP842+N+zSVpXp+0BfjmqC15demguF5XYDuDQa9jZHo0kwZFMTI9WtOYDh60VSKPGOF77QRGjrS1ndi/v1TjSLSzf78tMT9ypO89vhczc+YAANatO6VxJJ5JVVU2bDjFLbesIiXlz/zyl+s4caKasDB/Fi26lP3772Xr1h9z++2jmT8/i1WrbiI5+dxWVCkpYaxadRPz5g3X6K/onoiICIqLi8+7fc+ePSQnJ3drX3/+85+5++67ufPOO8nIyODll18mKCioo/94Z6xWK7feeiuPP/44AwYM6Hb8QgghhBCib/P8UgkPZrEqFFfbWyV4fwWmXXqsLSmZV3HxxK2qqvzjyxwAZmYlMyQpwpWhdWlaZhIAm3OKsVhdMym8sLI9cRvlmmEsWjDodYzqF80PJtreUG46UIR6oetjvcg3x2zJq/GDfSN5ZbVa+eKLL/jiiy+wWq292teZxK1n9rbtDXvidt++Ek2Ob7UqbNyYy9tvZ7NxYy5WF70WdcVecWtfi75k+vR+6HSQk1NBYWGd1uF4jMrKJv70p60MG/YiM2a8ybvvHsRsVhg/PpnXX/8+RUVLeOGF75GVde5zZt684eTmPsi6dbfx97/PZN262zh16kGvSdoC3HLLLTz88MOUlJSg0+lQFIUtW7bw85//nIULFzq8n7a2Nnbt2sWsWbM6btPr9cyaNYtt27Zd8H6///3viYuL48c//nGv/g4hhPB1zjzXFUIIX6JZq4TObNy4UesQuqWougmrohJgMhAT6pwhGp7A3vahrLaZplYLQf4XfppsPVJKdl4VfkY9d0wf6q4QOzUyPZrIYH+qG1vZc6qCSwc5P2HnaxW3Z5syLIG//TebgqpGjhXXapqE762S6ibyKhrQ63SMG+gbyUmr1dqRHJg2bVqvLiWzt0rIyPCNtTnbmYrbMrcfe/XqHB588DMKCs4kDFNSwnj++avdluiyWBQOHLAl5vti4jYyMpCxY5P49tsi1q8/xW23jdI6JM2oqsrmzXm88souVq06RGur7U1wSIgft96axT33jGXMmItfXWEw6Jk2rR8ZGUHExcV5Xd/Bp556ikWLFpGamorVaiUjIwOr1cqCBQs6eik6oqKiAqvVSnz8uf+u4uPjOXz4cKf32bx5M6+//jp79+51+Ditra20trZ2/FxXZ3s9URQFRXH/B0HeQlEUVFWVNXKQrFf3yHo5rjdrZTabO851r7jiCk2u4nQ3eW51j6xX98h6OU6LterOsTwqcettCs7qb+tL/7GEBfoRFeJPVUMreRUNDEuO6HQ7s1XhtXW2atsfTBxAXLi2Q3AMeh2XZyTw8c7TbDxY5PTEbZvFSlmtbTiZL1Xc2gX5G5k4JJ5Nh4pZf6DIqxO33xy3Je0y0yIJCTBpHI1zGAwGJk2a1PF9TymKyqFDvltxO2qULaly4EAZVqvith6cq1fncMMN7503zKmwsI4bbnjPbZeWnzpVS0uLhaAgEwMHRrn8eJ5o1qz+fPttEWvX9s3EbXV1M2++uY9XXtlFTs6ZHq6XXJLIPfeMZf78TEJDzx/06qv8/Px49dVXeeyxx8jOzqahoYExY8YwePBglx63vr6e2267jVdffZWYmBiH7/f000/z+OOPn3d7eXk5LS0tndxDgO3NT21tLaqqet2HC1qQ9eoeWS/H9WatrFYrI0eOBKCysrJP9LuV51b3yHp1j6yX47RYq/p6x2dKSeK2F870t/WdNgl2abEh7Ynb+gsmbj/59jRFVU1EBvtz0+SB7g3wAqaNSOLjnafZeriUtmut+Bmd9x9+SXUTigpBfkYig33zTe+MrGQ2HSpm08Ei7p413CN6w/aEr7VJAFuy9sorr+z1fvLyamlsNGMy6Rk0yPcSe4MGRREQYKSpyczJk9UMHuyaQYVns1oVHnzw0/OStmAb6qTTwUMPfcbs2UNdnkjOyakCICsrDr2X/vvtrZkzB/DMM1tYt+4kqqr6zAerVqvC11/nUVxcT2JiKJdfntbxfFJVle3bC3j55V28995BWlosAAQFmViwIJN77hnHuHFJWoavmQ0bNjB9+nRSU1NJTU0953evvPIK99xzj0P7iYmJwWAwUFp6bv/s0tJSEhLOHwR44sQJcnNzuf766ztus1dWGI1Gjhw5wsCB5587PfLIIyxZsqTj57q6OlJTU4mNjSUsLOy87YWNoijodDpiY2PlzakDZL26R9bLcb1dq9mzZ7sgKs8lz63ukfXqHlkvx2mxVgEBjl+1L4nbXsivsF02b28t4EvSY0LZe6ryggPK6prbeOurYwAsnDaky3YK7jQ8JZK48EDKapvZcazMqUO2CtrbJCRFBflMIuC7xg6MJTTQRFVDK/tyK7lkgONVQp6iuc3C/txKACa4oF2Gt7O3SRg6NAaTyfcqGQwGPZmZcXz7bRH79pU6PXGrqiqFhfVkZ5eSnV1GdnYZ27blU1Bw4U9MVRXy8+v4+us8pk3r59R4vuvQIdtzvy+2SbCbMiUVf38DhYX1HD1aydCh3vc69l0XasPx1FMzqKtr5ZVXdpGdfaY9yMiR8dxzz1huvTWL8HDfaeXUE1dffTUPPPAATz31FCaT7QqMiooK7rzzTjZv3uxw4tbPz4+xY8eybt065syZA9hO8tetW8fixYvP237YsGFkZ2efc9tvfvMb6uvref75589LItv5+/vj73/+h8N6vV7edF2ETqeTdeoGWa/ukfVynKxV98h6dY+sV/fIejnO3WvVneN4RrbNS52puPW9xG1a+4Cy0+WdJyNWfn2chhYz/eNCuWp0528+tKDX6Ziakcj7206y8WCxUxO39sFkKT74eNuZDHquyEjkP7vyWH+g0CsTt3tOVWC2KiRGBvnUhypn99zR6/U9/vDAlweT2WVmxvLtt0WsXJlNTEzQOZWJ3VFb29KenLUlaQ8csCVqa2p6drnyb36znp/9bCJXXz2I4GC/Hu3jYiRxC4GBJqZMSWP9+lOsXXvS6xO3F2rDUVBQx8KFazp+Dgw0cvPNmdxzz1gmTEj22Q8Yu2vDhg0sXLiQL7/8kpUrV3Lq1Cl+/OMfM3To0G71ngVYsmQJt99+O+PGjWP8+PEsXbqUxsZG7rzzTgAWLlxIcnIyTz/9NAEBAWRmZp5z/4iICIDzbhdCCOG8c10hhPA1krjtIVVVyT+rx62vSY8NBeB0xfkVt4WVjXy8MxeAu//H8y6nnzoiife3nWTHsdKLDlfrjsKzKm592YzMZP6zK48tOSX89JpM/L2sKtPeJmHC4DifOuEzm808/fTTgO1SWj+/niX+fD1xu3p1DmvW2AYFffjhYT788PBFB4S1tVk5fLjinCra7OxS8vPrOt3eYNAxdGgMWVlxZGXZqrp/85sNF41ty5Z8tmzJJyDAyNVXD2Lu3GFcf/0QIiOd1x/80CFbqwR7r9++aubM/qxff4p1606xaNF4rcPpMVsbjs86bcNhZzTq+eMf/4fbbx9NRETfrq7tzOTJk9m7dy/33nsvl1xyCYqi8MQTT/CLX/yi2/9H3HzzzZSXl/PYY49RUlLC6NGj+eyzzzoGluXl5UlFixBC9JCzznWFEMLXSOK2h6obW2lstaDX+WYiL709GV1a00xLm4UAvzNPldfX5WBVVC4dFMvYAZ6X/BmUEEZyVDCFVY1sP1rKjKxkp+zXnrhNifK9nsZny0g9027im2NlXJHhvKplV1NVlR32/rbSJqFTZwaT+d76XGxA2Hvv3cjYsYkdidkDB8rJzi7lyJFKLJbOp3qmpoaRlRVPVlYcmZm2RO2wYTH4n/WBkNWq8PLLuygsrOs0wabTQWxsMLfemsWaNYc5daqGNWsOs2bNYYxGPdOn92Pu3GHMmTOMxMTQHv/9NTUtFBbaPmzLyurbidtZswbw61+vZ8OGXLcOqXO2r7/OO6c9QmcsFoVRoxIkaduFo0eP8u2335KSkkJRURFHjhyhqamJ4ODu/3++ePHiTlsjAGzcuLHL+65YsaLbxxNCCCGEEH2bJG57yN7fNj4iyKkDsDxFWJAfEcF+1DS2kV/ZyODEcAD2n65ky5FS9Dodd89y/YT0ntDpdEwbkcRbXx9j48Eipyduk31wGN3Z9Dod00ck8e7WE6zPLvSqxO3xkjqqGloJMBnISvetwVsmk4mHH3644/ueUBT1rMSt533o0htdVSbab7vppvcvWLkYHu7fkaC1fcWTmRnnUDLMYNDz/PNXc8MN76HTcc4x7AV9L710LfPmDedPf7qS/ftLWb06h9WrD3PgQBlffnmSL788yaJF/2XSpFTmzh3GvHnDGTAgsltrYO9xmpYW3ueTeGPHJhIe7k9NTQu7dxdz6aXO+X/A3YqLHZs26+h2fdEzzzzDb3/7W37yk5/w3HPPcfz4cW677TZGjhzJv/71LyZNmqR1iEIIIXDOua4QQvgiSdz2UEd/Wx9sk2CXFhNCTWMVuWX1DE4MR1FV/vFlDgDXXJLa0U7BE00dkchbXx9j14ly6prbCAvs3aU2zW0WKutbAUjy8YpbgBlZyby79QQ7j5c5Zf3cxd4mYeyAGJ/7QEWn03Vr8mRnTp+uoanJjJ+fgYEDfSux7Uhloqra2hyMGBF3ToI2KyuOlJSwXrXWmDdvOKtW3dTpAKmlS8+0adDpdIwalcCoUQk8/vh0jh2r5MMPD7N6dQ7ffFPI1q35bN2az//7f18yalQ88+YNZ+7cYWRmdt36w2pV+OCDQwAkJYV4dZWpMxgMeqZP78+aNYdZu/ak1yZuHa3A7k2ltq97/vnnWbNmDddccw1g6y+7Y8cOfvWrXzFt2jRaW1s1jlAIIQQ451xXCCF8kSRue6ijv60PV1+mx4ay/3QVee1/6/rsQo4V1xLkZ2Th1CEaR9e19NhQ+seFcqqsnq2HS7h6TFqv9lfUXm0bHuTnNUnM3ugXd2b9NueU8L1Lerd+7vLNsVIAxg/2vTYAzmDvbztsWAxGo28l9RytOFy+fDa33TbKJTHMmzec2bOH8vXXeRQX15OYGHrRwWiDB0fzi19M4Re/mEJhYR1r1hxm9erDbNqUy759pezbV8pvf7uRQYOimDdvGHPnDmf8+GT0Z/UWX70655yE8fbthfTr93yXfX37gpkzbYnbdetO8cgjl2sdTo9cfnkaKSlhF/xQQqezfThw+eXe8RqthezsbGJizh1QZzKZeO6557juuus0ikoIIYQQQgjH+NY7dzfKr7Ql8ny54jY1xpaU3n2ynJ3Hy1i2zjbw55bLBhIR7K9laA6ZNiIJgI0Hi3u9r4LKvjGY7Gz2FhPrsws1jsQx1Q2tHC2qBeBSH+xva7Va2bhxIxs3bsRqtfZoHwcP2iqSMzJ8q00COF5xmJoa7tI4DAY906b1Y/78LKZN69etqtfk5DAWLRrPunULKS39OcuXz+b664fg72/g+PEq/vCHrUya9DqpqX9h8eL/sn79Kd5//yA33PDeeYk9e1/f1atznP0neo1ZswYAsHlzHs3NZo2j6Rl7G47O2Auwly69uk9XV1/Md5O2Z5s6daobIxFCCNEVZ5zrCiGEL5KK2x4q6Ki49c3E7eacYt766jhg6xv6m7d3AraK07kT+msZmsOmjUhi+YYj7MutoKqhhaiQnl96c2YwmW8+3p2ZNiKJZesOk51XRVltM3HhgVqH1KUdx21JySGJ4USH+t5lVlarlU2bNgG2KekGQ/dbQdgrbn2tvy2cqUzsakCYN1UmRkcHcccdo7njjtHU17fy6afH+fDDw/z730cpKqrnxRd38uKLO8/rqWunqra/+aGHPmP27KF9MrE3dGg0SUmhFBXVs3VrPjNnDtA6pB657rohhIT40dDQds7t323DIc6YN28eK1asICwsjHnz5nW57erVq90UlRBCiK4441xXCCF8Ud97J+cELWYrpbXNgG9W3G7OKeaJVbupbWo773e1TW3saO8j6ukSIoMYlhyBosLXOSW92pc9cduXKm7jwgM7BnxtOFCkcTQXZ+9vO8FH2yTo9XrGjRvHuHHj0Ot79tLty4nbsysTv9sK1tsrE0ND/bnpphG8/fYPKC//f/z73/P58Y/HEBbmf8Fha2BL3ubn1/H113nuC9aD6HS6jqrbtWtPahxNz3355QkaGtqIiwti7drbWLlyHhs23M6pUw9K0vYCwsPDO3pCh4WFER4efsEvIYQQnsEZ57pCCOGLpOK2BwrbB5OFBZoID/KtfqdWReWlzw91uc3LXxxi0tAEDPqeD/Jxl6kjkjhcWMOmg0XMvrRfj/fTUXHroxXWFzI9M5n9p6vYcKCQm6cM1DqcCzJbFXaftCUlfbW/rdFo5Nprr+3x/RVFJSfHnrj1zTVydECYNwsIMHLttUO49tohTJvWj9tu+/Ci93G0/68vmjmzP2++uY91605pHUqPrVx5AID587O8tmrY3ZYvX97x/YoVK7QLRAghhMN6e64rhBC+Sj7K6oH8Ct/tb3sgr4qK+pYutymva+FAXpWbIuqdqRmJ6ICD+dWUtVdJ90Rhe4/b5D5UcQtw+fBETAY9p8rqyS3z3ORP9ukqmtusRIX4MyhRKqg6c+pUNc3NFvz9DQwcGKl1OC4zb95wcnMfZMOG232+MjElJcyh7Rzt/+uLZs60tfbZtauY6uqe/x+glcbGNj76yNZffv78TI2j8S6KovDss88yZcoULr30Un75y1/S3Ox9zwEhhBBCCNG3SeK2B/Irfbe/bVVD10nb7m6ntejQgI7L/Tcd7Nnl/nXNbdS1D7ZJigp2WmzeIDTQxKWDbJfVe/KQsm+OlQIwflAc+u9eJy+AM20Shg2L8cp2Ad3RmwFh3sTe1/dCT3mdDlJTvaevryskJ4cxbFgMiqKycWOu1uF02yefHKWx0cyAAZGMH5+sdThe5cknn+RXv/oVISEhJCcn8/zzz7No0SKtwxJCCCGEEKJbfPPdrIvltw8mS4nxvSSeowO8ejPoy92mjUgCYGMPE7dF7W0SokP9CfTre91FpmfakgUbDhahdNVQUyOqqnb0t/XVNgkAbW1tPPHEEzzxxBO0tZ3ff/piDh3y7TYJfZEv9/V1JnvVrTe2S1i5MhuABQsyO3q2Cse8+eab/P3vf+fzzz9nzZo1fPLJJ7z11lsoiqJ1aEIIITrR23NdIYTwVX373VwP5bdfNu+LFbeZaVHEhHadlI0NCyAzLcpNEfXeZcMT0et0HC+po6C9Wro7CjraJPheot4REwbHEeRnpKy2mYP51VqHc56CykaKq5swGfSM6R+jdTgupShKj5IOVqvSkbQKDDRitUriwlfY+/omJ5/bNiElJYxVq27yyRYR3eWtA8oqK5v49NPjACxYkKVxNN4nLy+P733vex0/z5o1C51OR1GR5w/bFEKIvqqn57pCCOHL+l75YC8pqtqR/PPFHrcGvY77rsrgiVW7L7jNvVdmeMVgMrvwID8uGRDDtyfK2XSwmFuvGNyt+9sHk/XVxK2/ycCU4Ql8ua+A9dmFZHlY0t5ebTsyPYogf999STOZTPzsZz/r+N5Rq1fnnDOs6/XX9/D55yd4/nnfGNYlbMnb2bOHsmlTLkeOFDF0aBJTp/pui4jumjatH3q9jiNHKikoqHO4N7DWPvggB4tFYfToBIYPj9U6HK9jsVgICDj3g2iTyYTZbNYoIiGEEF3p6bmuEEL4Ot/NcrhIWW0zbRYFk0FPQkSg1uG4xGXDE3n0hkt46fND5wwqiw0L4N4rM7hseKKG0fXMtBFJfHuinI0Hi1hw+aBuXXLaMZgsum8mbgFmZCbz5b4Cvs4p5v6rR2DyoIRQR39bH26TAKDT6QgL617CafXqHG644T2+2+GisLCOG254TyoyfYi9r29GRhBxcXHo9Z7zb1RrEREBjBuXxI4dhaxbd5Lbbx+tdUgOsbdJkKFkPaOqKnfccQf+/v4dt7W0tHDvvfcSHHzm//PVq1drEZ4QQojv6Mm5rhBC9AWSuO0me3/bpKggDD78xviy4YlMGprAgbwqqhpaiAqxtUfwpkrbs00eGo/JoCevooFTZfUMiHf8pMBecZsS5XsV1o4a1S+aqBB/qhpa+fZ4OZOGxmsdEgANLeaO9g3jB/l24ra7rFaFBx/87LykLYCq2nqgPvTQZ8yePVQqM4XPmzmzf3vi9pRXJG4LCur46qvTANxyiyRue+L2228/77Yf/vCHGkQihBBCCCFEz0nithusypkhSKEBJqyK6rWJTEcY9DpG9YvWOgynCA4wMX5QLFuOlLLxYJHDiVtVVc9qlRDkyhA9mkGvY9qIJFZ/c4r1Bwo9JnG760Q5VkUlLSaEJB9vZWG1Wtm+fTsAEydOxGAwdLn911/ndbRH6IyqQn5+HV9/nce0af2cGaoQHmfWrAE8/fRm1q49ieqBQxa/6913D6CqcPnlaaSlhWsdjldavny51iEIIYTohu6e6wohRF8hZVYO2pxTzMK/rueTb20VMAfyq1n41/VszinWODLhqKkjkgDYdLDI4Tfu1Y2tNLdZ0esgIbLvJm4BZmQlA7D9aCmNrZ7RI9D+QYqvt0kA28ns2rVrWbt2LVar9aLbFxfXO7RfR7cTwptNnpxKQICR4uIGDh+u0Dqci1q58gAgQ8mEEEL0Hd091xVCiL5CErcO2JxTzBOrdp/T7xWgor6FJ1btluStl5gwJJ4Ak4GSmmaOFNU4dB97f9u48ED8jH37U99BCWGkRAfTZlHYerhU63CwKirfnigHYEIfSNzq9XpGjRrFqFGjHOpfmpgY6tB+Hd1OCG8WEGBkypRUANatO6VxNF07fLiC3buLMRr13HBDhtbhCCGEEG7R3XNdIYToK+QV8SKsispLnx/qcpuXvziEVfH8Sy/7ugCToeMS/40HHUu2d7RJiO67/W3tdDodMzJtVbcbDhRqHA0cKaqhtqmNkAAjGSmRWofjckajkTlz5jBnzhyMxot3ubn88jRSUsK40Bw+nQ5SU8O4/PI0J0cqhGeaNWsAAGvXntQ4kq69/bZtKNlVVw0kJqZvX+khhBCi7+juua4QQvQVkri9iAN5VedV2n5XeV0LB/Kq3BSR6I1pZ7VLcCTZXlAp/W3PNj3Ttn57TlVQ1dD1vwtX++aorep37IBYjDJc6zwGg57nn78a4Lzkrf3npUuvlsFkos+YObM/ABs35mKxKBpH0zlVVXn7bVubhPnzZSiZEEIIIYQQfZ28Y78IR5NTWiexhGMuGRBDSICRqoZWDuZfPNlur7hN8fHBV45KigpmeHIEigqbHKxadpUdx/tOm4SemjdvOKtW3URy8rnD+FJSwli16ibmzRuuUWRCuN8llyQSERFAbW0ru3Z5ZoujXbuKOXasisBAI7NnD9M6HCGEEEIIIYTGJHF7EVEhAU7dTmjLz2hgyrAEADYcKLro9vbEbZIkbjvYq27Xa9guoay2mZOldeh1MG5Q30jctrW18cwzz/DMM8/Q1tbm8P3mzRtObu6DbNhwOytXzmPDhts5depBSdqKPsdg0DN9ej8A1q/3zD63K1fa2iTMnj2MkBA/jaMRQggh3Ken57pCCOHrJHF7EZlpUcSEdp2UjQ0LIDMtyk0Rid6aNsLWp3VzTjEW64Uvl1VUlaKqJgBSpMdth6kjktDrdBwtqu0Y3uZuO46XATAsOZLwoL6T3GhtbaW1tbXb9zMY9Eyb1o/587OYNq2ftEcQfZa9z60nDiizWhXeecfWJmHBAmmTIIQQou/p6bmuEEL4Mnn3fhEGvY77rup6qvO9V2Zg0F9gApDwOKP6RRER7Edds5k9pyouuF15XQtmq4JRryMuXCqq7SKC/blkQAygXdXtjmO2xG1fapNgMplYvHgxixcvxmQyaR2OEF7J3ud2y5Z8mprMGkdzrk2bTlNc3EBkZABXXTVI63CEEEIIt5JzXSGE6Jwkbh1w2fBEHr3hkvMqb2PDAnj0hku4bHiiRpGJnjDo9Vze/ph11afVXk2aGBmEQS//VM4246x2Cap68SFvztRitnYk3PtS4lan0xEdHU10dDS6704bE0I4ZMiQaFJSwmhrs7JzZ6nW4ZzD3ibhhhsy8PMzaByNEEII4V5yriuEEJ0zah2At7hseCKThiZwIK+KqoYWokJs7RGk0tY7TRuRxCffnmbLkRIesGTiZzz/TXJRe3/bZGmTcJ7JwxLw/+8BiqqaOFpUS6QbPxTfl1tBm0UhLjyQfnGh7juwEMLr6XQ6Zs7szxtv7GPz5kJuvPESrUMCoLXVwgcf5ACwYEGWxtEIIYQQQgghPIWUEXaDQa9jVL9opmcmM6pftCRtvVhGaiSxYQE0tVrYeby8020K7InbqCB3huYVAv2MTBoSD8CGgxcf8uZM37S3SRg/KLZPfRpvtVrZsWMHO3bswGq1ah2OEF7L3i7h66+1G7D4XZ99dpyamhaSk0O5/PI0rcMRQggh3E7OdYUQonOSuBV9kl6nY+oI2+X+Gy+QeJTBZF2bkWVbv02HirEq7mmXoKrqWf1t491yTE9htVr59NNP+fTTT+VkVohemDnTNqBs//5yqqqaNY7GZuVK21CyW27JlOGBQggh+iQ51xVCiM7JuwPRZ01rT9x+c7SU5jbLeb8vbK+4TZKK206NHRBLeJAfNY1tHCqqd8sxT5XVU17Xgr9Rz6h+0W45pqfQ6/VkZGSQkZGBXnouC9FjSUmhDB8eg6rCxo25WodDfX0rH398BJA2CUIIIfouOdcVQojOySui6LMGJYSRFBVEq0Vh25Fzh9RYFJWSGlslVkqUVNx2xmjQc0WGbcjbtuOVbjmmvU3C6P4x+Jv61vAeo9HIjTfeyI033ojRKO3JhegNe7uEdetOaRwJrFlzmJYWC0OGRDNmTILW4QghhBCakHNdIYTonCRuRZ+l0+k6qm43faddQkVdK4qq4m8yEB3qr0V4XmF6pm39duXW0GJ2/SVNZ9okxLn8WEII3zVjhi1xu3699olbe5uEBQsy+1TfbiGEEEIIIcTFSeJW9Gn2xO23J8qpbzZ33F5S2wJAclSwvJHuQkZKJPHhgbSYlY5qWFepbWojp6AagPGSuBVC9MK0aeno9TqOHq0iP79WszjKyxv58ssTAMyfL20ShBBCCCGEEOeSxK3o09JjQ+kfF4pFUdl6pKTj9pK6VgCSpb9tl86uWt5woPMhb86y83gZKjAgPozYsECXHssTmc1m/vznP/PnP/8Zs9l88TsIIS4oPDyA0aNjAW3bJbz//iGsVpVx45IYMqRv9e0WQgghzibnukII0TlJ3Io+b2onicezK25F16Zn2vrcfnuinLqmNpcdp6+3SVBVlfr6eurr61FVVetwhPB6l1+eDMDatSc1i2HlymzA1iZBCCGE6MvkXFcIIToniVvR59krRvflVlDdYKu0La1tr7iNlsTtxaTHhpIWHYhVUfkqp9glx7BYFb49UQ703cSt0Wjknnvu4Z577pGBDUI4gT1xu27dKU3eIObm1rBlSz46Hdx8syRuhRBC9G1yriuEEJ2TxK3o8xIjgxiaFIGiwtftiUepuO2eSYOiAFifXeiS/R/Mr6ax1UJ4kB9DkiJccgxPp9frSUhIICEhAb1eXrqF6K2xY+MJDDRSUtJATk6F24//zju2oWTTpvUjKSnU7ccXQgghPImc6wohROfkFVEIYNoI2+X+Gw8W0Wq2UtVo66uUEh2iZVheY+LAKHTYEqylNU1O3/+O47Y2CZcOisWgl2FxQojeCwgwMmVKGqBNu4S337YlbhcskKFkQgghhBBCiM5J4lYI4IqMpI7E477TlQCEBBgJCzRpG5iXiAr2Y2S6rerWFUPKvjlaCsCEwfFO37e3sFqt7N27l71792K1WrUORwifMHNmP8D9A8oOHChj//5STCY9P/jBcLceWwghhPBEcq4rhBCdk8StEEBMWABZ7YnH19cdBiAy2B9F+uI7bHrm+UPenKGoqpH8ykYMeh1jB8Q4dd/exGq18tFHH/HRRx/JyawQTjJz5gAANm7MxWJR3Hbct9+2DSX73vcGExkZ6LbjCiGEEJ5KznWFEKJzkrgVop19EFleRSMA+ZWNLPzreja7aOCWr5kyLAGTQU9ueT0nS+uctl97m4TMtCiCA/puBbRer2fw4MEMHjxY+n4J4SSjR8cTGRlAXV0r337r/KsFOqOqKitXSpsEIYQQ4mxyriuEEJ2TV0QhgM05xXy6O/+82yvqW3hi1W5J3jogJMDE+MFxgHOHlH1zzJa4ndC+777KaDSyYMECFixYIJN2hXASg0HPjBn9Aff1ud2+vYDc3BpCQvy47rohbjmmEEII4enkXFcIIToniVvR51kVlZc+P9TlNi9/cQir9E24qBnt7RI2HixCUXu/Xk2tFvbn2noO9/XErRDCNWbOtCVu3dXnduVKW5uEOXOGERTUd68iEEIIIYQQQlycJG5Fn3cgr4qK+pYutymva+FAXpWbIvJe4wfHEexvdNp67TlVgUVRSYoKIiU6xAkRCiHEuWbNsvW53bo1n6Yms0uPZbEovPee7YPCBQsyXXosIYQQQgghhPeTxK3o86oauk7adne7vszPaOCy4QmAc9olfHOsFIAJg+N7vS9vZzab+dvf/sbf/vY3zGbXJpeE6EsGDYoiNTWMtjYrmzfnufRY69efoqyskZiYoI6EsRBCCCHkXFcIIS5EEreiz4sKCSBWbWCQWnHBr1i1gaiQAK1D9QozMpMB+DqnmDZLzyfCKqrKjmPlgLRJANtAo6qqKqqqqlCd0IZCCGGj0+k6kqiu7nNrb5Nw000ZmEwGlx5LCCGE8CZyriuEEJ2Trt+iz8sMt7JMeR8/LpxkbMOAIXy6G6PyXlnp0USH+lNZ38q3x8uZPCyhR/s5VlxLdWMrQX5GMtOinByl9zEajdx5550d3wshnGfmzP4sX77XpX1um5vNrF6dA8D8+VkuO44QQgjhjeRcVwghOqdpxe3TTz/NpZdeSmhoKHFxccyZM4cjR45oGZLogwzN9V0mbQH8sGJorndTRN7NoNcxbYRtSNn6Az1vl7DjWBkAlwyIwWSQiwP0ej1paWmkpaWh18t6COFMM2bYBpTt2VNMZWWTS47xn/8co76+jbS0cCZPTnXJMYQQQghvJee6QgjROU1fETdt2sSiRYvYvn07X375JWazmSuvvJLGxkYtwxJC9JK9XcL2o2U0tvSsR9U37YnbCUOkTYIQwrUSE0MZMSIWVYUNG3Jdcgx7m4T58zPR63UuOYYQQgghhBDCt2iauP3ss8+44447GDFiBKNGjWLFihXk5eWxa9cuLcMSQvTSwIQw0mJCMFsVthwp6fb9K+tbOFZcC8ClAyVxC6AoCgcPHuTgwYMoiqJ1OEL4nJkzbVW369Y5v89tTU0L//3vMQAWLJA2CUIIIcR3ybmuEEJ0zqOax9TW2hI1UVGd97NsbW2ltbW14+e6ujrA9iIvL+4XpigKqqrKGnVGVaGyyKFPMBRVBVnD81zo+TVtRCJvbjrG+uxCZmUld2ufO46VAjA0KZzwIJPPPHd782+xra2NVatWAfDwww/j5+fn7PA8jrx2dY+sl+M6W6sZM/rz17/uYO3aU05fww8+OERrq5URI2IZMSLG6x4jLZ5b3rZGQgghesdisXSc6z7yyCN94itY8jsAAFUGSURBVFxXCCEc4TGJW0VReOihh5gyZQqZmZmdbvP000/z+OOPn3d7eXk5LS0trg7RaymKQm1tLaqqSr8gO6uZgBO7Cc7egKn8tEN3qaqsxGIIcXFg3udCz6+RCf4A7M2t5GhuIRFBJof3+dWBAgBGJAZTVlbm3IA11Jt/ixaLhcTERAAqKir6xNAGee3qHlkvx3W2VhkZQRgMOo4fr2LXrhOkpoY67XhvvrkbgOuu60d5ebnT9usuWjy36uulr7wQQvQlOp2O9PT0ju+FEELYeMw7/0WLFnHgwAE2b958wW0eeeQRlixZ0vFzXV0dqampxMbGEhYW5o4wvZKiKOh0OmJjY+XNfEMN7PoC3befo2usAUDVG9EploveNXrHGtSb/h+ERLg0RG9zoedXXBxkpBRwqKCGg6VtzJ3QXnVbWw5NF35D3uYXzKEi2++nj+pHXFy4S+N3p97+W7zrrrtcEJXnkteu7pH1clxnaxUXB+PHJ7NtWwH79tUzduxApxyruLiezZuLALjrrgnExUU6Zb/upMVzKyAgwC3H6a4XX3yR5557jpKSEkaNGsXf/vY3xo8f3+m2r776Km+++SYHDhwAYOzYsTz11FMX3F4IIfoyk8nEHXfcoXUYQgjhcTwicbt48WL+/e9/89VXX5GSknLB7fz9/fH39z/vdr1eL29SL0Kn0/XtdWqshc9XwMHNYG1P0oZGwaVXo0sZAm/+7qK70FUVo/Pzh766hl240PNremYyhwpq2HCwmB9MGgg15fDiT8Fy4YFlfnojodxAcFg0g5MifO4T9z7/b7GbZL26R9bLcZ2t1cyZ/dm2rYANG3K5665LnHKcVatyUBSViRNTGDQo2in71IK7n1ue+Bx+9913WbJkCS+//DITJkxg6dKlXHXVVRw5coS4uPP7sW/cuJH58+czefJkAgICePbZZ7nyyis5ePAgycndayEkhBBCCCH6Jk3PilVVZfHixXz44YesX7+e/v37axmO8GX+QXBijy1pmzIUfrAEHnoFrrgRopLAeJHL+A1G+N7dEBBs+1lVobbC9XF7uSsyEtHrdBwrriW/ogGa6rpM2gLoFQvhtDB+UJzPJW2FEJ5t1qwBgG1AmaqqTtnn22/bqi0XLOi8DZTwHn/+85+5++67ufPOO8nIyODll18mKCiIZcuWdbr9W2+9xf3338/o0aMZNmwYr732GoqisG7dOjdHLoQQQgghvJWmFbeLFi1i5cqVfPTRR4SGhlJSYps+Hx4eTmBgoJahCW/WWAe7v4Tje+D2x0FvsCVmr70HwmMgefC520fEwuIXbUlFbEPIqqqqiIqKQm9PHAaF2baz27MO/vsqzLwVJlxrO4Y4T0SwP+MGxrDjeDnrDxRy+xDHX3LGDz6/eqkvM5vNvP766wD8+Mc/xmRyvGewEMIxEyemEBhopLS0kYMHy8nM7N3r0IkTVXzzTSF6vY6bbhrhpCiFFtra2ti1axePPPJIx216vZ5Zs2axbds2h/bR1NSE2Wy+4BBeIYToy+RcVwghOqdp4vall14CYNq0aefcvnz5culvI7qvJBe++Q9kfwWWNtttx3bD0Ett32dMuvB9I2LPJGYVxTaELC7uwm0Rju2yHePz5XBwC8xeDLGpTvtTfMn0zGR2HC9nw4EiFg5JxZEaWqNez5j+MS6PzZuoqkppaWnH90II5/P3N3L55el88cUJ1q072evErb3adubM/sTHy3BLb1ZRUYHVaiU+Pv6c2+Pj4zl8+LBD+3j44YdJSkpi1qxZF9ymtbWV1tbWjp/r6to/VFYUFEXpQeR9g6IoqKoqa+QgWa/ukfVyXG/Wymq1dpzrWq1WDAbfL4yR51b3yHp1j6yX47RYq+4cS9PErSQfRK8pVjiy05awzT1w5vbEATDhOhg42jXHvekXtqreL96AgqPw8hKYehNMmWtrqyA6TB4aT4DJQHF1E7llDTjSEGVIUjiBfrKOZzMajfzwhz/s+F4I4RqzZvXniy9OsHbtKR58cGKP96OqKm+9lQ3AggVZzgpPeKlnnnmGd955h40bN3Y5eO3pp5/m8ccfP+/28vJyWlpaXBmiV1MUhdraWlRV9cj+yJ5G1qt7ZL0c15u1UhSFa6+9FoCqqqo+sdby3OoeWa/ukfVynBZrVV9/4YHt3yXv/sX5aso72gZ06rttA7Q8duExePdZ2/c6va2qdsK1kDoMXNkfVaeDsVfCoEvg3y/bKnDXr4RD22DOTyFB+jXbBfgZmTw0nq+y82ne/LFD9xmR5n1T111Nr9czcKBzptwL31GXl0dzha3ftqIoVFVVoUZFdZxwBMbEEJaWpmWIXmfmTFuf202bcjGbrZhMPav42bevlMOHK/D3NzB37jBnhig0EBMTg8Fg6KgGsystLSUhIaHL+/7xj3/kmWeeYe3atYwcObLLbR955BGWLFnS8XNdXR2pqanExsYSFhbW8z/AxymKgk6nIzY2Vt6cOkDWq3tkvRzX27W62Oupr5HnVvfIenWPrJfjtFirrj7I/y5J3Ipz1ZTDC4u6HiBlNNl6wjo7eevIsQ1GuOpHMP4a288pQ2HAKEgaCJdeY+th607hMbDg17b2DJ++ZmvXYG696N36mhlZyRRm72VYxR6Hts9Mlf5/QlxMXV4erw8dirWLKjxDQAA/PnJEkrfdMHp0AlFRgVRVNbNzZxGTJ/esDc7KlbZq2+uuG0J4uOMnZsIz+fn5MXbsWNatW8ecOXMAOgaNLV68+IL3+8Mf/sCTTz7J559/zrhx4y56HH9/f/z9/c+7Xa/Xy5uui9DpdLJO3SDr1T2yXo6TteoeWa/ukfXqHlkvx7l7rbpzHHn0xLma6rpOnILt911Vxbry2FYLfLECWppsP+t0sPB3MOs29ydt7XQ6GDkVFv0N5j5gq/a1a6jRJiYPc8mAGEqCU/iYDIe2jwmVJMd3KYrC0aNHOXr0qPQpEgA0V1R0mbQFsLa0dFTkCsfo9TpmzLBdNbFu3cke7UNRVN55x9a+R9ok+I4lS5bw6quv8sYbb5CTk8N9991HY2Mjd955JwALFy48Z3jZs88+y6OPPsqyZcvo168fJSUllJSU0NDQoNWfIIQQHkvOdYUQonOSuBW9o1htydYLfSnWs7ZVbInXc76sZ74c7XmcMgRaPPBNT0gEjJp25ueKQnj+XvhsGbT1wb50NWXwryegohCDXs/UEYms0o/Eouu60N+qM9haYohzWCwW3n77bd5++20sFovW4Qjh02bNsiVu16491aP7b9mSR35+HWFh/nzve4OdGZrQ0M0338wf//hHHnvsMUaPHs3evXv57LPPOgaW5eXlUVxc3LH9Sy+9RFtbGzfccAOJiYkdX3/84x+1+hOEEMJjybmuEEJ0TloliN45thvefurCv7/2Hrj0atv3uQfgzd9eeNsJ1zl2zCvvgIjeTfp2iyM7bW0Ttn8CR3bA9ffDgK572/kEVYV9G22tI1qb4N9tcMcTzMhM5uOdp7nHdBN/v3UU/sYzfSOtqsqh1/9CllJEW0QSgWHSKuG7dDodSUlJHd8LIVzH3ud227Z8GhvbCA7269b97W0S5s0bTkCAnGr5ksWLF1+wNcLGjRvP+Tk3N9f1AQkhhI+Qc10hhOicvJsQwlWmzIH4dPjkJagutSWtL/kfuPJ2CAjWOjrXaKyDf78EOdttP6cOg+/fD8Cw5AgSI4MoqIatdcFMz0zuuNvh/CqeYiqv8QHB1fnwzX9g0ve1+As8lslk4u6779Y6DCH6hIEDI0lPD+f06Vq+/jqPq68e5PB929qsvPfeIQAWLMh0VYhCCCGET5FzXSGE6JwkbkXvDBoDv3zrrBu+0+7AeFaVUnoGPPzPszb9zrYVhfDNv50eoqYGjYH7n4e1b8LOz2D3l7Yq5evvhSEXH1LiVY7ugk/+Do01oDfC9FtsyWu9rbJWp9MxfUQSKzcfZ/2BonMSt98cLaNKF8xXKVdyTcG/Yf1KGDYBIuO1+VuEEH2aTqdj5sz+LFu2l3XrTnYrcfvllyeoqmomPj6Y6dP7uzBKIc6wWq2YzReZE+DDFEXBbDbT0tIiA1gcoNV6mUwmDAbDxTcUQgghRAdJ3IreMRhtX45uGxhy4d8bTc6JydP4B9paRoy4DD5+EaqKofiULXFbU971oLegMIiIdV+sPeR/Ohv9p3+3/RCbCvMegsQB5203PSuZlZuPs+tEObVNbYQH2RL73xwrs+1n/FVgzLW11fjkJbjtt7bhb0II4WYzZw5oT9x2r8/typW2oWQ33zwCo1ESSMK1VFWlpKSEmpoarUPRlKqqKIpCfX29XGLtAC3XKyIigoSEBHmchBBCCAdJ4lYId+k3Au77i63ydsK1tqTtC4tsQ9wuxGiCxS96fPK2NSUDNXkIurRhMONWMHXeDzItJoRBCWEcL6njq0NFXD+uH6U1TeSW16PXwbjBcZB8H7z0Mzi5D/ZtgNEz3PzXONnZyXlVxVhVBdaGMwlpB5PzZrOZf/7TVrF+2223YTL56AcdwmG1p09rHYJPmznTVi27Z08JFRVNxMQEXfQ+jY1tfPTRYQAWLMhyaXxCAB1J27i4OIKCgvpsMkxVVSwWC0ajsc+uQXdosV6qqtLU1ERZme3D+sTERLccV3gPOdcVQojOSeJWnCsozJYsvFgyMSjMt47tLiZ/mDzb9n1TXdd/K9h+31TneYlbixm+/QzGXW1rhWAwoN7xe3Qm/4vedUZWMsdL6lifbUvc7jhuO4HPSI0iLNAPApNg2s3w7RcQFuPqv8S1vpOc1wPn/UUOJudVVSU/P7/je9G3WVpa2PzrX190O73RSGCMl/870kh8fAiZmXEcOFDGhg2nuPHGERe9zyefHKWx0cyAAZGMH5980e2F6A2r1dqRtI2OjtY6HE1J4rZ7tFqvwMBAAMrKyoiLi5O2CeIccq4rhBCdk8StOKO1Gdb9Cxb+vuu2Ba66fD8i1pbA8oHWAT6tLA9WPw8lJ6GhxlZhC2Bw7FPxaSOSePXLHA4VVFNS3dTRJmH8oLgzG036Poz/HvgFODl4N3Nict5oNHLzzTd3fC/6to3/+79U5eTgHxXFdStXEhQbi6IoVFVVERUVxdF332XnH/8IOh3NlZWEpaVpHbJXmjWrPwcOlLF27UmHErcrV2YDMH9+piSPhMvZe9oGBV28GlwIT2F/vprNZkncinPIua4QQnROXhGFjaraeooe+BrK8+GeP2nTWzQiVhKznkpRbMPj1v4LrGYIDIUkxwf22EWHBjCqfzR7T1WyYuMRdp+oAODSgWc97t/tnaxYO4ac9VV6vZ5hw4ZpHYbwAHkbNrD377ae0tetXEn/q64CbMNmdO1VTAljx1J97BjHP/qIT266iYW7d+MXGqpl2F5p5swBLF36jUN9bisrm/j00+OAtEkQ7iUfEghvIs9XcSFyriuEEJ2TqRnCZs86W9JWp4fv/UQGQnmigqNQkmtLoLpbTTm8+Vv4fLktaTt4LNy/FDIm9Wh3qdG2IXUbDhRhbb8U6tF3drI5p/jcDRUFdvwX/v4QtDT14g8QwnekXHEFlz35JBN//euOpO136XQ6rlq2jNDUVCIGDcLa1ubmKH3D1KnpGAw6TpyoJje3psttP/ggB4tFYdSoeDIy5ANIIXrjjjvuYM6cOU7b34oVK4iIiHDa/oQQQggh3EUqbgWUnob/vmr7fuatkCafdHqkdW/Bqf22dhH9R8KA9q/IeNce9/geeP+P0Npk69F71Z0w9soeJ/c35xTzybfnD1WqqG/hiVW7efSGS7hsePvACqsZtn0C1SWw7p9w7T29+Uu8mqIo5OXlAZCWloZeL5+79VV6g4GJv/rVRbcLjIpi/pYthCYno5PnS4+EhvozYUIKW7fms27dSX7840suuO3bbx8ApNpWCEfccccdvPHGGwCYTCbS0tJYuHAhv/rVrzAajTz//PPS41KIPkbOdYUQonPyatjXtbXAqj+BpQ0GjoHJc7SOSHRGVSEgGEwBtn6oBzfDJ3+H5++FpffCZ8tcd+zoJFAVSBkC9/4Fxl3V46StVVF56fNDXW7z8heHsCrtb9ZM/nD9fbbvd34GeTk9Oq4vsFgsvPHGG7zxxhtYLBatwxEaOLJqFebm5m7dJyw19ZykbWttrbPD8nmzZvUHYO3aC7dLKCioY9OmXABuuSXTHWEJ4XTbT2czd9n/sv10tluOd/XVV1NcXMyxY8f43//9X373u9/x3HPPARAeHt7nK2Tb5EoJ0cfIua4QQnROErd93aev2XrahkTC3AdAPtn0TDod3PwLePhNuPNJmHozpA239X2tKYWKgnO3/2oVHN1lGzh3ITXlUHSi869D22y/B1tF751P2b6iE3v1ZxzIq6KivqXLbcrrWjiQV3XmhgEjYcxM2/cfv3jxYV8+SqfTERsbS2xsrPSH64NOfPIJn9x4I29NmIC5qfttQ9oaG/n0zjtZOXlyj+7fl82cOQCA9etPXbAC8N13D6CqcNllaaSlhbszPCGcQlVV/vrV25ysKuSvX73tlmpXf39/EhISSE9P57777mPWrFl8/PHHwLmtEsrLy0lISOCpp57quO/WrVvx8/Nj3bp1ALS2tvLwww+TkpJCcHAwEyZMYOPGjd2K5+GHH2bIkCEEBQUxYMAAHn300Y4BcHaffPIJl156KQEBAcTExDB37tyO39ljSE1Nxd/fn0GDBvH6668DnbdqWLNmzTn/n//ud79j9OjRvPbaa/Tv35+AANuA1s8++4zLLruMiIgIoqOjue666zhx4sQ5+yooKGD+/PlERUURHBzMuHHj+Oabb8jNzUWv1/Ptt9+es/3SpUsZNGgQihbtt4S4ADnXFUKIzkmrhL6stdmWpEMHP/gZhERoHVHfEhQGRlPXiUijybbd2T+nZ9i+pt9iewxPH7JVptrVVcL6t2zf6w22StkBo6B/lu17g9GWlH1hUdfH1hvhgb/bhsUl9u/d39quqqHrpO0Ft7vyDji2GyoK4av3YcYCp8TjcoXHnLYrk8nE/fff77T9Ce9Rl5/Pp3fcAUD6zJmYejBB3tzYSO5nn9FYUsL6Bx7gqtdec3KUvmvixBSCgkyUlTVy4EAZWVnnt6dZudLeJkGqbYW2VFWl2dza7fttP53NwdKTABwsPcmG498yMd3xth+BJv9eJ1oCAwOprKw87/bY2FiWLVvGnDlzuPLKKxk6dCi33XYbixcvZuZM2we7ixcv5tChQ7z99tskJyfz4YcfcvXVV5Odnc3gwYMdOn5oaCgrVqwgKSmJ7Oxs7r77bkJDQ/nFL34BwH/+8x/mzp3Lr3/9a958803a2tr473//23H/hQsXsm3bNv76178yatQoTp06RUVFRbfW4Pjx43zwwQesXr0ag8E2lLWxsZElS5YwcuRIGhoaeOyxx5g7dy579+5Fr9fT0NDA1KlTSU5O5uOPPyYhIYHdu3ejKAr9+vVj1qxZLF++nHHjxnUcZ8WKFdx2221yKbrwKHKuK4QQnZPEbV/mHwh3PWvrm9pfevK5XUQsLH7R1vrgQoLCbNtdiH8gDBl77m1WK1wyC07uh5oyW3uBvBzY+A74BcCMW23VuherXFUstti6On43RYUE9Gy7wBD43t3w3h9g82oYMQXi050Wl0tYzLYk88V8NzkvxFkUi4X/zJ9PS1UV8WPHcvkzz/RoP8FxcVy7ciXvzZxJ9uuvkzp9Ohm33urkaH2Tn5+BK65I57PPjrN27cnzEreHD1ewe3cxRqOeG28coVGUQtg0m1uZ9Nc7er2fn330p25tv+2BFQT5OfZ//Hepqsq6dev4/PPP+elPf9rpNt/73ve4++67ufXWWxk3bhzBwcE8/fTTAOTl5bFixQpOnDhBWloaOp2On//853z22WcsX778nErdrvzmN7/p+L5fv378/Oc/55133ulI3D755JPccsstPP744x3bjRo1CoCjR4/y3nvv8eWXXzJr1iwABgwY0O21aGtr48033yQ29sy51w9+8INztlm2bBmxsbEcOnSIzMxMVq5cSXl5OTt37iQqKgqAQYMGdWx/1113ce+99/LnP/8Zf39/du/eTXZ2NqtWrep2fEIIIYRwP0nc9kWqeqZHqckPhozrenvhOhGxTk2MAhAZB99fZPu+qsSWmD+5H05l2xKxGlZWZ6ZFERMa0GW7hNiwADLTos7/xfCJMGwCHNkJ+Yc9P3FrNMFtv4X1b8OUOWAwoqgqVVVVREVFobf/G7xYcl70aVt++1sKt2zBLzSU6999F6O//8XvdAFp06cz6bHH2Pb443x5770kXHopUUOGODFa3zVzZn8+++w469ad4mc/m3TO795+29YP9MorBxIT0/1qaCH6qn//+9+EhIRgNptRFIUFCxbwu9/97oLb//GPfyQzM5P333+fXbt24d/+epidnY3VamXEiHM/OGltbSU6OtrheN59913++te/cuLECRoaGrBYLISFnflgde/evdx9992d3nfv3r0YDAamTp3q8PE6k56efk7SFuDYsWM89thjfPPNN1RUVHS0N8jLyyMzM5O9e/cyZsyYjqTtd82ZM4dFixbx4Ycfcsstt7BixQqmT59Ov379ehWrEEIIIdxDErd90aevQ1AoXHGD7VJ64buiEmxfY68ERYGy0xARD1XFmoRj0Ou476oMnli1+4Lb3HtlBgZ9J5db6nTwvZ/AFTdC0kAXRtlLZ38wEpcGtzx85neKgsUQAnFx3e4nbTabeeeddwC45ZZbMJlMzopYeKjcL7/km/aKsitfe42Igb1/3k969FEKNm0if+NG/n3zzSzYtg1jQM+q5PqSWbNslXObNp3GbLZiMtn+71RVlbffljYJwnMEmvzZ9sAKh7dXVZUfv/t7jpTnopzV11av0zE0th+v3/yYQy0QAk3d/1Bp+vTpvPTSS/j5+ZGUlITR2PXbkhMnTlBUVISiKOTm5pKVZbtarKGhAYPBwPbt2/H3P7dlQ0hIiEOxbNu2jVtvvZXHH3+cq666ivDwcN555x3+9KczlceBgYEXvH9XvwPQ6/Xn9Q3+bv9cgODg4PNuu/7660lPT+fVV18lKSkJRVHIzMzsGF52sWP7+fmxcOFCli9fzrx581i5ciVLly7t8j5CaEHOdYUQonPS2KivObgVdvzHdtm8E/tvCi+g10NCfwjQtiLssuGJPHrDJcSEnpssig0L4NEbLuGy4V0MQAuL8uykbWMtvPoLOHXA6btWVZWTJ09y8uRJtwyNEdpSFYUNDz0Eqsqoe+5h2E03OWW/eoOBa996i8CYGMr27mXjz3/ulP36upEj44mJCaKhoY0dOwo7bt+1q5hjx6oIDDQye/YwDSMUwkan0xHkF+Dw196io+SUnTonaQugqCo5ZafYW3TUof30pL9tcHAwgwYNIi0t7aJJ27a2Nn74wx9y880388QTT3DXXXdRVlYGwJgxY7BarZSXlzNo0KBzvhISEhyKZevWraSnp/PrX/+acePGMXjwYE6fPn3ONiNHjuwYhvZdWVlZKIrCpk2bOv19bGws9fX1NDY2dty2d+/ei8ZVWVnJkSNH+M1vfsPMmTMZPnw41dXV58W1d+9eqqqqLrAXW7uEtWvX8ve//x2LxcK8efMuemwh3E3OdYUQonOSuO1Lqkvg4xdt30+ZC6nyJlNo47Lhibz5wAz+cNtEfjl3NH+4bSJv/HRG10nb7yo9DV+ssFW4eoLWZnjr/6DoOHzyd1uvYScyGo3MnTuXuXPnXvQNrvB+Or2eH3z2GVl33cW0v/zFqfsOSUrie//8J0FxcQy87jqn7ttX6fU6ZsywDWlc+//bu/OwKKu+D+DfYdh3ZRFUFjcQFTE1FXvMtXCXXFDzTcklF6zU9PWxHlKr53VLxS3NSrFyNzULdwJzQVHck9CMwAVEURZFtpnz/oGMjMzADAIzMN/PdXE1c8+573Pmx5np5+Hc5xz9W3F8y5aiZRIGDvSGtbWpTtpGVFFCCKw5sR0SqB50lUCCNSe268UAyieffILMzEysXLkSs2fPhpeXF8aOHQsA8PLywqhRozB27Fjs3r0biYmJiI2NxYIFCxAREaHR9Zs1a4bk5GRs27YNN2/exMqVK7Fnzx6lMnPnzsXWrVsxd+5cxMfH48qVK1i0aBGAojVxx4wZg7Fjx2Lv3r1ITExEdHQ0duzYAQDo2LEjLC0t8fHHH+PmzZvYsmULwsPDy21XnTp14ODggPXr1+Ovv/7Cb7/9hhkzZiiVGTlyJFxcXBAYGIiTJ0/i77//xk8//YSYmBhFGR8fH3Tq1AmzZ8/GyJEjy52lS6QLzHWJiFTjwK2hkBVC8tNyIC8HaOgN9Hhb1y0iAyc1ksDP0wHdWzWAn6eD6uUR1Ml9Anw3Bzj1M3BZ9eyWalWQD2xbUDRoa2kLjPwYkFbuMiRGRkZo3bo1WrduzV2gDYStmxsCvvkGJlXwD+xGvXtj/N9/o1Hv3pV+7dqqZ8+igdvIyEQAgEwmx7ZtxcskcINPqnkKZIVIzU6HgOqBWQGB1Ox0FMgKq7llyqKjoxEWFoYffvgBtra2MDIywg8//IDjx49j7dq1AIo27Bo1ahRmzpwJb29vBAYG4uzZs3B3d9eojoEDB2L69OmYOnUq2rRpg1OnTiE0NFSpTLdu3bBz507s27cPbdq0QY8ePRAbG6t4fe3atRg6dCimTJmC5s2bY8KECYoZtnXr1sWPP/6I/fv3w9fXF1u3bi1zPd9iRkZG2LZtG+Li4tCqVStMnz4dS5YsUSpjamqKw4cPw9nZGX379oWvry8WLlwI6Qt5yLhx45Cfn68Y8CbSN8x1iYhUkwh9+DN6BWVlZcHOzg6ZmZlKmweQMrlcjqc/r4XVpaOAuTUwaSlg76zrZuktuVyOtLQ0ODs7196k4e5NYL0Gt0i/92W5SxPoLF7HfwIifwQsrIGQVbrbdE0mA3YuAf48A5iaA2M+Bxo0VVnUIPpWJTLEeN0+fhy5Dx+i6aBBWp/7MvHKTEqCtasrpKaGMWu0IrH6++9HaNJkJYyNjfDo0WzExt5Bz57fo04dc6SmzoSpae1dM14Xn0XmeEXKikNubi4SExPRqFEjmFdwrerUrAd49DRb7et1LW1Rz0bzDb50RQiBwsJCGBsbV2jZBkPw+eefY+fOnbh8+bJO41UZ/ba6GWI+UlGMlXYYL+0wXtphvDSn77kuf3uG4Pq5okFbAAicykFbKpoValzOgv/GJkXl9FXnQUA9T+DpY+DgBt20QQjg13VFg7ZSY2DEHLWDti9LLpfjzp07uHPnjmJHaapdcu7fx68jRmBvYCDit26ttnr/+vlnfO/nh+Mff1xtddZEjRvXgaenPQoL5Th+PAlbtxYtkzB0aItaPWhLtZuLrSN86jVS+1MTBm2pbI8fP8bVq1exevVqvP/++7puDpFazHWJiFTj4jGGIPcxhNQEaPcGJM076ro1pA/snYCpa4CcLPVlLG2LyukrqTEwMAT4djZw9TjQ+nXAq331tuFCJHDhKCAxAobMABq3rrKqCgsL8e233wIA5syZA1MDmRlpKIRcjgNjxuDx3buo27w5mgwYUH11C4G8zEycW7oUbt27o0m/ftVWd03Tq1cjfPvtBaxfH4fDh4vWug0KaqHjVhERqTd16lRs3boVgYGBXCaB9BpzXSIi1Tjj1hC07oYHQ+ZA9Bqt65aQPrF3KloGQd2PPg/aFmvQFPB/NsD169dFG4RVp9ZdgVZdgP6TgBb+VVqVRCKBnZ0d7OzseBtoLXRu2TIkHjgAqZkZBmzfDlNr62qru1lgINp+8AEA4OCYMci+fbva6q5pbGzMAAB79yYgJ6cAAPDuuz9j9+54XTaLiEit8PBw5OXlYfv27aXWvSXSJ8x1iYhU44zb2qywQHE7vKyua/m3xhPVRN1GAvGngUf3gLMHgH8Nrr66jU2AIdOBakguTUxMMG3atCqvh6rf3dOncXzOHABAjxUr4NS66mZuq/P64sW4c+IE7p0/j4i330bQb7/BiDs6K9m9Ox5hYadLHb9zJxtDh+7Arl1BGDzYRwctIyIiqvmY6xIRqcYZt7XVzUvAmveBWwm6bglR1TI1AwZMAd4MLlr3tqr9eQY48B1QvPYWZwTQS8h99Ai/jhgBeWEhvIOC0Pq993TSDmMzM/Tfvh2mNja4ffw4Ts2fr5N26CuZTI4PPzwIVdu5Fh+bNu0gZDKuyUdERERERJWHA7e1UfYjYHdY0QzES9G6bg1R1WvcumjQ1qiKbwFMvArsXAqc+bVofVuil3T9p5+QlZQEu8aN8eb69Tq9NbBO06Z4c/16AMDp//4Xt0+c0Flb9M3x48m4fVv9muBCALduZeH48eRqbBUREREREdV2vA+ytpHLigZtn2QAzh5AQLCOG0RUzQrygVt/Vv5GYXdvAlv/D5AVAM07Am16VO71y1FYWIhdu3YBAIYOHQpj3sZeK7QePx5mdnawa9QIZnZ2um4Omo8YgeSoKEjNzODy6qu6bo7eSEnJrtRyREREpIy5LhGRavw2rG1O7AYSLwMmZsCwmUX/lfPWTTIQOVnAd3OAR2nApKWAs3vlXPfBHeDHz4D8p4BnK2DIDKCaN/iQy+VISEhQPKbaw3vYMF03Qckba9dCYsQbckpydbWp1HJERESkjLkuEZFq/JdZbZJ0DYjaVvS433uAU0PdtoeoulnYAI4NAHkh8POaohnoLysrHfhhftGgsGtjYMQcwMT05a+rJalUiv79+6N///7cFbqGy8/OxsFx4/AkNVXXTVGp5KCtvLAQt37/XYet0Q9durijYUNbtUtaSySAm5stunSppD8WERERGRjmukREqnHgtrZ4kgXsWgYIOeDXrdpv4ybSCxIJ0Pc9wNQCuHMdiD3wcteTyYDNXwCZ9wGH+sCoUMDcsnLaqiWpVIp27dqhXbt2TGZrMCEEjkyahKsbNmDPwIEQqna70hMFOTnY0bMndnTvjtvHj+u6OTollRphxYreAErvR1j8PCysN6RSplVE+i46OhoSiQQZGRlVWk+3bt0wbdq0Kq3jZTRr1gxhYWG6bgaRAnNdIiLV+C+M2kIiKZoN6NCgaOCKyFDZOQJvjC56HLkZyEir+LWkUqDbcKCOC/DOXMDavlKaSIbr6saNiN+yBRKpFN3DwnS6GVl5TCwtYevhASGX49eRI5Hz4IGum6RTgwf7YNeuIDRoYKt0vGFDW+zaFYTBg3101DKimuf+/fuYPHky3N3dYWZmBhcXFwQEBODkyZNVXnfnzp2RkpICOz1YV5yIiIioPFzjtrawtAFGzgGeZAJmFrpuDZFutXsTuHIcSL4G/LquaKZsRQfIfDoBzdoBxiaV20YtCSFw//59AICTk5NeD/iRag/++AORU6cCAP713/+iQefOOm5R+Xp99RVSzpzBo+vXcTA4GG/98otB973Bg30waJA3jh9PRkpKNlxdbdCliztn2hJpaciQIcjPz8emTZvQuHFj3Lt3D5GRkUhPT6/yuk1NTeHi4lLl9dR2MpkMEokERlwTnSoJc10iItX4f9qa7kkmUHyrrUTCGYFEAGBkBAycAkiNgb8uAJePaX6uXAYcDleeqavjQVsAKCgowNq1a7F27VoUFBToujmkpYKcHPwSFITCp0/hGRCADrNm6bpJGjG1tsaAHTsgNTPD3xERiFu+XNdN0jmp1Ajdunli5EhfdOvmyUFbIi1lZGTg+PHjWLRoEbp37w4PDw906NABc+bMwcCBA5XKjR8/Hk5OTrC1tUWPHj1w6dIlxeuXLl1C9+7dYWNjAzs7O3Ts2BHnzp0DACQlJWHAgAGoU6cOrKys0LJlS+zfvx+A6qUSfvrpJ7Rs2RJmZmbw9PTE0qVLldrs6emJ//u//8PYsWNhY2MDd3d3rF+/vtz3WlhYiKlTp8LOzg6Ojo4IDQ1VWiLn0aNHGD16NOrUqQNLS0v06dMHN27cULw+b948tGnTRumaYWFh8PT0VDwPDg5GYGAgvvzyS7i6usLBwQEhISFKuUJaWhoGDBgACwsLNGrUCJs3by7V1mXLlsHX1xdWVlZwc3PDlClT8PjxY8Xr4eHhsLe3x759+9CiRQuYmZnhxIkTMDExQeoLa7ZPmzYNXbp0KTc+RCUx1yUiUo3/2qjJnj4BvvlfYHcYkPdU160h0i+ODYCuQUDTVwD3FpqdIwQQsR449TMQ/ilQqF9Jo6WlJSwtdbPGLr2c3z74AOnXrsHKxQV9vv9eaQMwfefs54fuz9ZB/H32bKTExuq2QURUrvz8fOTn5ysNEspkMuTn56OwsLBSy2rL2toa1tbW2Lt3L/Ly8tSWGzZsGNLS0nDgwAHExcWhbdu26NmzJx4+fAgAGDVqFBo2bIizZ8/i3LlzmDVrFkxMiv7QGhISgry8PPz++++4cuUKFi1aBGtra5X1xMXFISgoCCNGjMCVK1cwb948hIaGIjw8XKnc0qVL0b59e1y4cAFTpkzB5MmTkZCQUOZ73bRpE4yNjREbG4sVK1Zg2bJl+PbbbxWvBwcH49y5c9i3bx9iYmIghEDfvn21HrSKiorCzZs3ERUVhU2bNiE8PFyp/cHBwbh16xaioqKwa9curF27FmlpyktJGRkZYeXKlfjjjz+wadMm/Pbbb/jf//1fpTI5OTlYtGgRvv32W/zxxx9o3749GjdujB9++EFRpqCgAJs3b8bYsWO1eg9EAHNdIiJVuFRCTSUEsG/Ns1mBkqJNyYhI2b8GAxIjzZdJiNoKxB0GIAF6/Y9ezLQtZmpqilk1ZJYmKcvLzMSdEycAiQT9tmyBlbOzrpukNb+JE5H822+4vnMnDo4di+DLl2vU4DORoVmwYAEAYObMmbCysgIAnDx5ElFRUXjllVeUZrZ++eWXKCgowIcffgh7e3sAwNmzZ3Ho0CH4+vpi8ODBirIrVqxATk4OJk+eDOcKfpcZGxsjPDwcEyZMwLp169C2bVt07doVI0aMQOvWrQEAJ06cQGxsLNLS0mBmZqZo5969e7Fr1y689957SE5OxqxZs9C8eXMIIdCoUSMYGxf90yY5ORlDhgyBr68vAKBx48Zq27Ns2TL07NkToaGhAAAvLy9cu3YNS5YsQXBwsKJc3759MWXKFADA7NmzsXz5ckRFRcHb21vttd3c3LB8+XJIJBJ4e3vjypUrWL58OSZMmIAbN25g3759OHnyJDo/Wzpn8+bNcHNzw969ezFs2DCNY1qnTh2sXr0aUqkUzZs3R79+/RAZGYkJEybg+vXrOHDgAGJjY/Hqq68CAL799lu0aKH8R+2SG6l5enriiy++wKRJk/DVV18pjhcUFOCrr76Cn5+f4ti4ceOwceNGRY7yyy+/IDc3F0FBQRq3nwhgrktEpA7/1VVTnT0IxMcARsbAsI8Acytdt4hI/xhJlQdtc3PUl435Bfh9Z9Hjfu8Brf5VtW0jg2FmZ4f/OXcOg3bvhnv37rpuToVIJBIEfPMNmgwYgAHbt3PQloheypAhQ3D37l3s27cPvXv3RnR0NNq2bauYJXrp0iU8fvwYDg4Oihm61tbWSExMxM2bNwEAM2bMwPjx49GrVy8sXLhQcRwAPvjgA3zxxRd47bXXMHfuXFy+fFltW+Lj4/Haa68pHXvttddw48YNyGQyxbHiQWWg6DvRxcWl1KzVF3Xq1ElpnU5/f3/FdePj42FsbIyOHTsqXndwcIC3tzfi4+PLvO6LWrZsCalUqnju6uqqaFtxPe3atVO83rx5c8UgfbGjR4+iZ8+eaNCgAWxsbPDOO+8gPT0dOTnPcydTU1OlOABFs3n/+usvnD59GkDRkgpBQUGKPxgQERHRy+GM25ooJRE4tKHo8RujgQbNdNseIn2XmwMc2gj8fQmYsqL0Bn6Xop9/pnq8Dbzau9qbSLWbqbU1mgUG6roZL8XMzg5v7dun62YQkQbmzJkDAIqlA4CiwchOnTqV2kxq5syZpcq++uqraNu2bamyH374YamyFWVubo433ngDb7zxBkJDQzF+/HjMnTsXwcHBePz4MVxdXREdHV3qvOIBx3nz5uHtt99GREQEDhw4gHnz5mHr1q0YPHgwxo8fj4CAAERERODw4cNYsGABli5divfff7/C7X3xPUskEsjlVXvHm5GRUallKVQto/Cybfvnn3/Qv39/TJ48Gf/9739Rt25dnDhxAuPGjUN+fr7i1nULC4tSG0Y5OztjwIAB2LhxIxo1aoQDBw6o/L0RERFRxXDgVhMZ94GcLPWvW9oC9k7VU29BHvDTckBWCDRuDXTqX/n1EtU2RkbAzYtA1gPgl6+AzoHPX7t1HTjwTdHjTgOALkN10cJyFRYWYt+zQbOBAwcqbgctS1ZyMp4+eKD2dQtHR9i6u1daGw21XnV1n1u6FBbOzmjxP/8DSyenKqtbF7KSk5F09CiMLS1R18ur1OuG8juujrr1oV65XI6HDx9C1K2rGMiryljTyzM1NS11TCqVKs3KrKyylaVFixbYu3cvAKBt27ZITU2FsbGx0kZcL/Ly8oKXlxemTZuGESNGIDw8XLG0g5ubGyZNmoRJkyZhzpw5+Oabb1QO3Pr4+ODkyZNKx06ePAkvLy+VMdDGmTNnlJ6fPn0azZo1g1QqhY+PDwoLC3HmzBnFUgnp6elISEhQLGPg5OSE1NRUCCEUA6YXL17Uqg3NmzdHYWEh4uLiFEslJCQkKG3OFhcXB7lcjqVLlyo+4zt27NC4jvHjx2PkyJFo2LAhmjRpUmoGM5EmKpLrEhEZAn4blifjPrA6pOxNioxNgKlrKnfwVpN6k+KBzAdVM2hMVJvkZAOPM4oeXz1R9PMiiRHQsZ/m6+FWM7lcjitXrgAA+vcv/w82WcnJ+M7bG7LcXLVlpObmGJeQUKmDL4ZWryZ1nw8Lq7K6dSErORnfNm0KeRmb5xja77iq6ja0eskwpKenY9iwYRg7dixat24NGxsbnDt3DosXL8agQYMAAL169YK/vz8CAwOxePFieHl54e7du4iIiMBbb72Fli1bYtasWRg6dCgaNWqEW7duIS4uTjFoO23aNPTp0wdeXl549OgRoqKi4OPjo7I9H330EV599VV8/vnnGD58OGJiYrB69WqltV0rKjk5GTNmzMDEiRNx/vx5rFq1CkuXLgUANGvWDIMGDcKECRPw9ddfw8bGBv/+97/RoEEDRRy6deuG+/fvY/HixRg6dCgOHjyIAwcOwNbWVuM2eHt7o3fv3pg4cSLWrl0LY2NjTJs2DRYWz+8+atq0KQoKCrBq1SoMGDAAJ0+exLp16zSuIyAgALa2tvjiiy/w2WefaXweUUna5rpERIaCi9SVJyer/J3lCwvKnpFbVfXKqqBeotooJwuQF5ZdRsiBp4+rpz0VIJVKERAQgICAAI1mAD198KDMQRcAkOXmljmTryIMrV5d160LTx88KHPQFuDvmPUSqWdtbY2OHTti+fLleP3119GqVSuEhoZiwoQJWL16NYCiW/3379+P119/He+++y68vLwwYsQIJCUloV69epBKpUhPT8fo0aPh5eWF4cOHIyAgAPPnzwcAyGQyhISEwMfHB71794aXl5fagdi2bdtix44d2LZtG1q1aoVPP/0Un332mdLGZBU1evRoPH36FB06dEBISAg+/PBDvPfee4rXN27ciHbt2qF///7w9/eHEAL79+9XLH3g4+ODr776CmvWrIGfnx9iY2MVS1toY+PGjahfvz66du2KwYMHY8KECUqby/n5+WHZsmVYtGgRWrVqhc2bNys2uNOEkZERgoODIZPJMHr0aK3bRwRon+sSERkKzritLGnJgFwGWNoAdV2LjsllwN2b6s+xsAYc6j9/fvv688cP7lRNO4moRpJKpejUqVOlX/fh9euQSKWwadgQFg4OAID87Gxk/P232nOs69eHpVPRTP/8x4+RUWJDmIfXr6s7TWW9JVk6O8Patej7szAvD+nXruHRw4eQpKSU2gzLwtERNg0aAABk+fka1ysvLMS98+cVz19cO9C8bl3YN2pU9JpcjtS4OJQorFy2Th3UacY1xsvy6MYN5D58qPb1eu3bw+hZP8j4+288vX9fbVmh4Wz4B3/8AYeWLWH8bCf67Nu38eTePQBQ3GoshMDDhw8BBwc4+PjA5NnMsyf37iGneLOhZ2UlEolSHy9Lxt9/Q2puDgCw9fCA6bPNeZ4+fIjHd++WeDPKfcnWwwNmz2bQPX34ENm3bgF4uc8TANi4ucGibl0AQF5WFjITE9Vew7pBA1g6OgIACnLK2MiR6CWZmZlhwYIF5Q4M2tjYYOXKlVi5cqXK17du3ap4LIRAYWGh4tbqVatWqb1ut27dSn33DxkyBEOGDFF7zj///FPqWHlLFpRc53Xt2rUqy9SpUwfff/99mdcpXu6hpI8//ljxuHhDt5LCwsKUnru4uODXX39VPBdCYOTIkUq3ok+fPh3Tp09XOu+dd95RPA4ODi5zMPvOnTvo27cvXJ/9f5xIW1WV6xIR1XQcuK0se58llX7dgbc+KHpcWAB8O1v9OS06A0Gznj8vqywRURWIGDkSAPDmN9+g9fjxAIC7MTHYFRCg9pzuYWFo92yDmrSLF7GtS5cK11tSp08+wb+++AIAkJWUhB/atlV7frtp09B9+XIAQE5amsrrqVKQk4Md3burfd1n1Cj0+/FHAICsoACbO3RQW7ZpYCAC9+zRqF5DdeI//0FCGeskfpCdDVNrawDA6S++wNWNG9WWHXr4sEZ1Hhg9Gg3+9S/FAPz5VatwdvFiteXHXLkCp1atAACX1q3DqXnzNKpHlV+GDVM8DoqMhHuPHgCAhO3bcXTKFLXnvfXLL2jy7LbQv3/9FQfGjNGqXnX9P+C77+A7diwA4M7Jk9jdt6/aa/RYtQptp04FAKT/+adW9ROR4crMzMSVK1ewZcsWxfqkREREVHk4cFtZrOsWrXVrVXLNKQlgX0/9OVZ2ys9Lli0sAB6rn6VERIZFCIHMzEwAgJ2dXaldnSvK3NERUhMTmDzbMRoApGZmsCpjxozJs1mEACA1NVUqKysoQK4Gt08X16t0XRsbxWMjqRRWrq6Qy+WldjUHANMS6/tJjIxg7uioUb2QSGDTsGGpY4p2PZudWHRYApsX1u8sGffiWceknqWzM+yeDaCqVCKeFo6OZZZ9cda1OlYuLjAqMYvMzM4ONg0bPp9hJwQEALlMBiMjI6WyJlZWsKxXTzEjtvgceUEB8kps5KOOmb294npGJfq31NwcFi/0l5J9SVpiwyepuTmsXFwAPPs8paeXW6+qzxMAGJdYw9K4vM91ye8AFdciIlJl0KBBiI2NxaRJk/DGG2/oujlUg1VVrktEVNNx4LayvP0xUL+J8jFTM2Ca5gv7K5W9exNYr/0aVkRUOxUUFGDFihUAgDlz5lTazt7DDh1CvRdmtrp17YrJJW/rLoNrhw5KZe+dP48f2rWrUL0l2Tdpgom3byMtLQ3Ozs4qB2+LWdevj2GHDmlUr5mNDSY+uw29PFJTU0xMStKoLKnWc9Uq9CzjluWSui5ejK5lzIwtucRFWQZHRMDWzU3xvNPHH6NTiduKgaINUFT1rVdnzsSrKtaP1LRfB0VGquzXvu++C99339Wo/c2DgtA8KEiresv7PAGAe48eGn+unXx9NSpHRFRySQiil1FVuS4RUU3HgVsiohrChLPgiIiIiKiWYq5LRFQaB26JiGoAU1NTpc1IiIiIiIhqC+a6RESqabZgnCGztC1au7YsxiZF5WpDvUS1kQF+niwcHRW726sjNTeHxbNd5FlvzaxbF/g7rr66Da1eqhjF+s1ENQD7KxERkXb0YsbtmjVrsGTJEqSmpsLPzw+rVq1ChzJ28q5W9k7A1DVATpb6Mpa2ReVqQ71EtZEBfp5s3d0xLiEBT8vYsMvC0RG2L2y+xXprVt26wN9x9dWtL/XK5XI8fPgQdevWVawJXJv6dE1VfEtxTk4OLEpsREekz3JycgDwlngiIiJN6Xzgdvv27ZgxYwbWrVuHjh07IiwsDAEBAUhISICzs7Oum1fE3kk3Azq6qpeoNqrhn6fCwkLs378fANC3b18YG5f/9W3r7q6TgRVDq1fXdesCf8eGVa9cLodEg40CqXpJpVLY29sjLS0NAGBpaWmwu7ALIVBYWAhjY2ODjYE2dBEvIQRycnKQlpYGe3t7SKXSaqmXao6K5LpERIZA59+Gy5Ytw4QJE/Dus92W161bh4iICGzYsAH//ve/ddw6IiL9IJfLceHCBQBA7969ddwaIiLSBy4uLgCgGLw1VEIIyOVyGBkZceBWA7qMl729vaLfEpXEXJeISDWdDtzm5+cjLi4Oc+bMURwzMjJCr169EBMTU6p8Xl4e8vLyFM+zsopue5bL5ZDL5VXf4BpKLpcrEjQqH+OlHcZLcy8TK4lEgm7duikeG0K82be0w3hpjrHSji7ixd+NZiQSCVxdXeHs7IyCggJdN0dn5HI50tPT4eDgwFnhGtBVvExMTDjTltSSSqXo3r274jERERXR6cDtgwcPIJPJUK9ePaXj9erVw59//lmq/IIFCzB//vxSx+/fv4/c3Nwqa2dNJ5fLkZmZCSEEk1kNMF7aYbw097Kx8vb2BgCkp6dXdtP0EvuWdhgvzTFW2tFFvLKzs6ulHm1puy/Dzp07ERoain/++QfNmjXDokWL0Ldv30pvl1QqNeiBDrlcDhMTE5ibm/MzrQHGi/SRVCrF66+/rutmEBHpHZ0vlaCNOXPmYMaMGYrnWVlZcHNzg5OTE2xta89u8JVNLpdDIpHAycmJyZkGGC/tMF6aY6y0w3hph/HSHGOlHV3Ey9zcvFrq0Ya2+zKcOnUKI0eOxIIFC9C/f39s2bIFgYGBOH/+PFq1aqWDd0BERERENY1OB24dHR0hlUpx7949peP37t1TufaRmZkZzMzMSh03MjLiP7zKIZFIGCctMF7aYbw0V9FYFW/qARjWBjTsW9phvDTHWGmnuuOlj78XbfdlWLFiBXr37o1Zs2YBAD7//HMcOXIEq1evxrp166q17URE+s5Qc10iovLoNCs2NTVFu3btEBkZqTgml8sRGRkJf39/HbaMiEi/FBQU4Msvv8SXX35p0OsYEhHpQvG+DL169VIcK2tfBgCIiYlRKg8AAQEBassTERky5rpERKrpfKmEGTNmYMyYMWjfvj06dOiAsLAwPHnyRDGboSxCCADPNykj1eRyObKzs7mOlYYYL+0wXpp7mVjl5+cr1vLOysqCqalpVTRRr7BvaYfx0hxjpR1dxKs4tyvO9XRN230ZACA1NVVl+dTUVLX1vLgRb2ZmJgAgIyODG7aVQS6XK/7fyM90+Rgv7TBemnuZWJXMdTMyMgwm12Xf0hzjpR3GS3O6iJU2ua7OB26HDx+O+/fv49NPP0VqairatGmDgwcPlkp0VSneuMLNza2qm0lEpDcWLlyo6yYQEVWL7Oxs2NnZ6boZ1UbdRrweHh46aA0RkW4w1yUiQ6FJrqvzgVsAmDp1KqZOnar1efXr18etW7dgY2PDNXDKULyJ261bt7iJmwYYL+0wXppjrLTDeGmH8dIcY6UdXcRLCIHs7GzUr1+/Wuorj7b7MgCAi4uLVuWB0hvxyuVyPHz4EA4ODsx1y8DPtHYYL+0wXppjrLTDeGmH8dIO46U5fc919WLgtqKMjIzQsGFDXTejxrC1teUHVguMl3YYL80xVtphvLTDeGmOsdJOdcdLn2baltyXITAwEMDzfRnUTT7w9/dHZGQkpk2bpjh25MiRMvdxULURr729/cs232DwM60dxks7jJfmGCvtMF7aYby0w3hpTl9z3Ro9cEtEREREVB3K25dh9OjRaNCgARYsWAAA+PDDD9G1a1csXboU/fr1w7Zt23Du3DmsX79el2+DiIiIiGoQDtwSEREREZWjvH0ZkpOTlTa06Ny5M7Zs2YL//Oc/+Pjjj9GsWTPs3bsXrVq10tVbICIiIqIahgO3BsDMzAxz584tdesdqcZ4aYfx0hxjpR3GSzuMl+YYK+0wXs+VtS9DdHR0qWPDhg3DsGHDqrhVxD6qHcZLO4yX5hgr7TBe2mG8tMN4aU7fYyURQghdN4KIiIiIiIiIiIiInjMqvwgRERERERERERERVScO3BIRERERERERERHpGQ7cEhEREREREREREekZDtzWcAsWLMCrr74KGxsbODs7IzAwEAkJCWWeEx4eDolEovRjbm5eTS3WrXnz5pV6782bNy/znJ07d6J58+YwNzeHr68v9u/fX02t1T1PT89S8ZJIJAgJCVFZ3tD61u+//44BAwagfv36kEgk2Lt3r9LrQgh8+umncHV1hYWFBXr16oUbN26Ue901a9bA09MT5ubm6NixI2JjY6voHVSfsmJVUFCA2bNnw9fXF1ZWVqhfvz5Gjx6Nu3fvlnnNinyea4ry+lZwcHCp9967d+9yr1sb+xZQfrxUfY9JJBIsWbJE7TVra//SJG/Izc1FSEgIHBwcYG1tjSFDhuDevXtlXrei33dE5WGuqx3mutphrls25rqaY66rHea62mGuq7namOty4LaGO3bsGEJCQnD69GkcOXIEBQUFePPNN/HkyZMyz7O1tUVKSoriJykpqZparHstW7ZUeu8nTpxQW/bUqVMYOXIkxo0bhwsXLiAwMBCBgYG4evVqNbZYd86ePasUqyNHjgBAmTtkG1LfevLkCfz8/LBmzRqVry9evBgrV67EunXrcObMGVhZWSEgIAC5ublqr7l9+3bMmDEDc+fOxfnz5+Hn54eAgACkpaVV1duoFmXFKicnB+fPn0doaCjOnz+P3bt3IyEhAQMHDiz3utp8nmuS8voWAPTu3VvpvW/durXMa9bWvgWUH6+ScUpJScGGDRsgkUgwZMiQMq9bG/uXJnnD9OnT8csvv2Dnzp04duwY7t69i8GDB5d53Yp83xFpgrmu9pjrao65btmY62qOua52mOtqh7mu5mplriuoVklLSxMAxLFjx9SW2bhxo7Czs6u+RumRuXPnCj8/P43LBwUFiX79+ikd69ixo5g4cWIlt6xm+PDDD0WTJk2EXC5X+boh9y0AYs+ePYrncrlcuLi4iCVLliiOZWRkCDMzM7F161a11+nQoYMICQlRPJfJZKJ+/fpiwYIFVdJuXXgxVqrExsYKACIpKUltGW0/zzWVqniNGTNGDBo0SKvrGELfEkKz/jVo0CDRo0ePMssYSv96MW/IyMgQJiYmYufOnYoy8fHxAoCIiYlReY2Kft8RVQRz3bIx1305zHXVY66rOea62mGuqx3mutqpDbkuZ9zWMpmZmQCAunXrllnu8ePH8PDwgJubGwYNGoQ//vijOpqnF27cuIH69eujcePGGDVqFJKTk9WWjYmJQa9evZSOBQQEICYmpqqbqXfy8/Px448/YuzYsZBIJGrLGXLfKikxMRGpqalK/cfOzg4dO3ZU23/y8/MRFxendI6RkRF69eplcH0uMzMTEokE9vb2ZZbT5vNc20RHR8PZ2Rne3t6YPHky0tPT1ZZl33ru3r17iIiIwLhx48otawj968W8IS4uDgUFBUp9pXnz5nB3d1fbVyryfUdUUcx1y8dct2KY62qHue7LYa5bPua6FcNcV1ltyHU5cFuLyOVyTJs2Da+99hpatWqltpy3tzc2bNiAn3/+GT/++CPkcjk6d+6M27dvV2NrdaNjx44IDw/HwYMHsXbtWiQmJqJLly7Izs5WWT41NRX16tVTOlavXj2kpqZWR3P1yt69e5GRkYHg4GC1ZQy5b72ouI9o038ePHgAmUxm8H0uNzcXs2fPxsiRI2Fra6u2nLaf59qkd+/e+P777xEZGYlFixbh2LFj6NOnD2Qymcry7FvPbdq0CTY2NuXeDmUI/UtV3pCamgpTU9NS/5Asq69U5PuOqCKY65aPuW7FMdfVDnPdimOuWz7muhXHXPe52pLrGld5DVRtQkJCcPXq1XLXJfH394e/v7/ieefOneHj44Ovv/4an3/+eVU3U6f69OmjeNy6dWt07NgRHh4e2LFjh0Z/kTJk3333Hfr06YP69eurLWPIfYsqR0FBAYKCgiCEwNq1a8ssa8if5xEjRige+/r6onXr1mjSpAmio6PRs2dPHbZM/23YsAGjRo0qdzMZQ+hfmuYNRPqCuW75DOG7q6ow16XqwFxXM8x1K4657nO1JdfljNtaYurUqfj1118RFRWFhg0banWuiYkJXnnlFfz1119V1Dr9ZW9vDy8vL7Xv3cXFpdTugvfu3YOLi0t1NE9vJCUl4ejRoxg/frxW5xly3yruI9r0H0dHR0ilUoPtc8WJbFJSEo4cOVLmDARVyvs812aNGzeGo6Oj2vdu6H2r2PHjx5GQkKD1dxlQ+/qXurzBxcUF+fn5yMjIUCpfVl+pyPcdkbaY61YMc13NMNfVHnNd7THXrTjmupphrvtcbcp1OXBbwwkhMHXqVOzZswe//fYbGjVqpPU1ZDIZrly5AldX1ypooX57/Pgxbt68qfa9+/v7IzIyUunYkSNHlP7Sbgg2btwIZ2dn9OvXT6vzDLlvNWrUCC4uLkr9JysrC2fOnFHbf0xNTdGuXTulc+RyOSIjI2t9nytOZG/cuIGjR4/CwcFB62uU93muzW7fvo309HS1792Q+1ZJ3333Hdq1awc/Pz+tz60t/au8vKFdu3YwMTFR6isJCQlITk5W21cq8n1HpCnmui+Hua5mmOtqj7mudpjrvhzmupphrltLc90q3/6MqtTkyZOFnZ2diI6OFikpKYqfnJwcRZl33nlH/Pvf/1Y8nz9/vjh06JC4efOmiIuLEyNGjBDm5ubijz/+0MVbqFYfffSRiI6OFomJieLkyZOiV69ewtHRUaSlpQkhSsfq5MmTwtjYWHz55ZciPj5ezJ07V5iYmIgrV67o6i1UO5lMJtzd3cXs2bNLvWbofSs7O1tcuHBBXLhwQQAQy5YtExcuXFDsDrtw4UJhb28vfv75Z3H58mUxaNAg0ahRI/H06VPFNXr06CFWrVqleL5t2zZhZmYmwsPDxbVr18R7770n7O3tRWpqarW/v8pUVqzy8/PFwIEDRcOGDcXFixeVvsvy8vIU13gxVuV9nmuysuKVnZ0tZs6cKWJiYkRiYqI4evSoaNu2rWjWrJnIzc1VXMNQ+pYQ5X8WhRAiMzNTWFpairVr16q8hqH0L03yhkmTJgl3d3fx22+/iXPnzgl/f3/h7++vdB1vb2+xe/duxXNNvu+IKoK5rnaY62qPua56zHU1x1xXO8x1tcNcV3O1MdflwG0NB0Dlz8aNGxVlunbtKsaMGaN4Pm3aNOHu7i5MTU1FvXr1RN++fcX58+erv/E6MHz4cOHq6ipMTU1FgwYNxPDhw8Vff/2leP3FWAkhxI4dO4SXl5cwNTUVLVu2FBEREdXcat06dOiQACASEhJKvWbofSsqKkrl5684JnK5XISGhop69eoJMzMz0bNnz1Jx9PDwEHPnzlU6tmrVKkUcO3ToIE6fPl1N76jqlBWrxMREtd9lUVFRimu8GKvyPs81WVnxysnJEW+++aZwcnISJiYmwsPDQ0yYMKFUUmoofUuI8j+LQgjx9ddfCwsLC5GRkaHyGobSvzTJG54+fSqmTJki6tSpIywtLcVbb70lUlJSSl2n5DmafN8RVQRzXe0w19Uec131mOtqjrmudpjraoe5ruZqY64redYgIiIiIiIiIiIiItITXOOWiIiIiIiIiIiISM9w4JaIiIiIiIiIiIhIz3DgloiIiIiIiIiIiEjPcOCWiIiIiIiIiIiISM9w4JaIiIiIiIiIiIhIz3DgloiIiIiIiIiIiEjPcOCWiIiIiIiIiIiISM9w4JaIiIiIiIiIiIhIz3DgloioCkgkEuzdu1dvrqPvoqOjIZFIkJGRoeumEBEREVE5mOtqh7kuEVUUB26JqEZKTU3F+++/j8aNG8PMzAxubm4YMGAAIiMjdd20Cpk3bx7atGlT6nhKSgr69OlTpXV7enpCIpGU+lm4cGGV1ktEREREqjHXrTzMdYmoJjPWdQOIiLT1zz//4LXXXoO9vT2WLFkCX19fFBQU4NChQwgJCcGff/6p6yZWGhcXl2qp57PPPsOECROUjtnY2FRL3URERET0HHPdysdcl4hqKs64JaIaZ8qUKZBIJIiNjcWQIUPg5eWFli1bYsaMGTh9+jSAooRXIpHg4sWLivMyMjIgkUgQHR0N4PktS4cOHcIrr7wCCwsL9OjRA2lpaThw4AB8fHxga2uLt99+Gzk5OYrreHp6IiwsTKlNbdq0wbx589S2efbs2fDy8oKlpSUaN26M0NBQFBQUAADCw8Mxf/58XLp0STEDIDw8HIDy7WOdO3fG7Nmzla57//59mJiY4PfffwcA5OXlYebMmWjQoAGsrKzQsWNHxfsti42NDVxcXJR+rKyslOIUERGB1q1bw9zcHJ06dcLVq1eVrvHTTz+hZcuWMDMzg6enJ5YuXar0el5eHmbPng03NzeYmZmhadOm+O6775TKxMXFoX379rC0tETnzp2RkJBQbtuJiIiIahPmus8x1yUiQ8eBWyKqUR4+fIiDBw8iJCREkWyVZG9vr/U1582bh9WrV+PUqVO4desWgoKCEBYWhi1btiAiIgKHDx/GqlWrXqrdNjY2CA8Px7Vr17BixQp88803WL58OQBg+PDh+Oijj9CyZUukpKQgJSUFw4cPL3WNUaNGYdu2bRBCKI5t374d9evXR5cuXQAAU6dORUxMDLZt24bLly9j2LBh6N27N27cuPFS7QeAWbNmYenSpTh79iycnJwwYMAARUIeFxeHoKAgjBgxAleuXMG8efMQGhqqSMoBYPTo0di6dStWrlyJ+Ph4fP3117C2tlaq45NPPsHSpUtx7tw5GBsbY+zYsS/dbiIiIqKagrkuc10iIiWCiKgGOXPmjAAgdu/eXWa5xMREAUBcuHBBcezRo0cCgIiKihJCCBEVFSUAiKNHjyrKLFiwQAAQN2/eVBybOHGiCAgIUDz38PAQy5cvV6rPz89PzJ07V/EcgNizZ4/a9i1ZskS0a9dO8Xzu3LnCz8+vVLmS10lLSxPGxsbi999/V7zu7+8vZs+eLYQQIikpSUilUnHnzh2la/Ts2VPMmTNHbVs8PDyEqampsLKyUvoprqc4Ttu2bVOck56eLiwsLMT27duFEEK8/fbb4o033lC67qxZs0SLFi2EEEIkJCQIAOLIkSMq26DqdxERESEAiKdPn6ptOxEREVFtwlyXuS4RUUlc45aIahRR4i/wlaV169aKx/Xq1VPc4lXyWGxs7EvVsX37dqxcuRI3b97E48ePUVhYCFtbW62u4eTkhDfffBObN29Gly5dkJiYiJiYGHz99dcAgCtXrkAmk8HLy0vpvLy8PDg4OJR57VmzZiE4OFjpWIMGDZSe+/v7Kx7XrVsX3t7eiI+PBwDEx8dj0KBBSuVfe+01hIWFQSaT4eLFi5BKpejatWuZ7Sj5u3B1dQUApKWlwd3dvczziIiIiGoD5rrMdYmISuLALRHVKM2aNYNEIil3UwYjo6KVYEomv8W3Or3IxMRE8VgikSg9Lz4ml8uVrv1iUq3u2gAQExODUaNGYf78+QgICICdnR22bdtWal0sTYwaNQoffPABVq1ahS1btsDX1xe+vr4AgMePH0MqlSIuLg5SqVTpvBdv03qRo6MjmjZtqnV7NGVhYaFRuRd/FwCUYk9ERERUmzHXZa5LRFQS17glohqlbt26CAgIwJo1a/DkyZNSr2dkZAAo+os9AKSkpCheK7l5w8twcnJSum5WVhYSExPVlj916hQ8PDzwySefoH379mjWrBmSkpKUypiamkImk5Vb96BBg5Cbm4uDBw9iy5YtGDVqlOK1V155BTKZDGlpaWjatKnST2Xs2Fu8GQYAPHr0CNevX4ePjw8AwMfHBydPnlQqf/LkSXh5eUEqlcLX1xdyuRzHjh176XYQERER1VbMdZnrEhGVxIFbIqpx1qxZA5lMhg4dOuCnn37CjRs3EB8fj5UrVypucbKwsECnTp2wcOFCxMfH49ixY/jPf/5TKfX36NEDP/zwA44fP44rV65gzJgxpf7qX1KzZs2QnJyMbdu24ebNm1i5ciX27NmjVMbT0xOJiYm4ePEiHjx4gLy8PJXXsrKyQmBgIEJDQxEfH4+RI0cqXvPy8sKoUaMwevRo7N69G4mJiYiNjcWCBQsQERFR5nvKzs5Gamqq0k9WVpZSmc8++wyRkZG4evUqgoOD4ejoiMDAQADARx99hMjISHz++ee4fv06Nm3ahNWrV2PmzJmK9zdmzBiMHTsWe/fuRWJiIqKjo7Fjx44y20VERERkaJjrMtclIlLQ5QK7REQVdffuXRESEqLYbKBBgwZi4MCBis0YhBDi2rVrwt/fX1hYWIg2bdqIw4cPq9yw4dGjR4pzNm7cKOzs7JTqenEzhczMTDF8+HBha2sr3NzcRHh4eLkbNsyaNUs4ODgIa2trMXz4cLF8+XKlenJzc8WQIUOEvb29ACA2btyo8jpCCLF//34BQLz++uul4pKfny8+/fRT4enpKUxMTISrq6t46623xOXLl9XG0sPDQwAo9TNx4kSlOP3yyy+iZcuWwtTUVHTo0EFcunRJ6Tq7du0SLVq0ECYmJsLd3V0sWbJE6fWnT5+K6dOnC1dXV2FqaiqaNm0qNmzYoFRHyd/FhQsXBACRmJiotu1EREREtRFzXea6RERCCCERogpWPyciolojOjoa3bt3x6NHj2Bvb6/r5hARERERVRrmukSkz7hUAhEREREREREREZGe4cAtERERERERERERkZ7hUglEREREREREREREeoYzbomIiIiIiIiIiIj0DAduiYiIiIiIiIiIiPQMB26JiIiIiIiIiIiI9AwHbomIiIiIiIiIiIj0DAduiYiIiIiIiIiIiPQMB26JiIiIiIiIiIiI9AwHbomIiIiIiIiIiIj0DAduiYiIiIiIiIiIiPQMB26JiIiIiIiIiIiI9Mz/A+oedQDt8auzAAAAAElFTkSuQmCC",
-      "text/plain": [
-       "<Figure size 1400x400 with 2 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "fig, axes = plt.subplots(1, 2, figsize=(14, 4))\n",
-    "\n",
-    "ax = axes[0]\n",
-    "ax.plot(all_epochs[:n_epochs_run], all_train[:n_epochs_run],\n",
-    "        marker=\"o\", color=\"steelblue\", label=\"Train loss (session 1)\")\n",
-    "ax.plot(all_epochs[n_epochs_run:], all_train[n_epochs_run:],\n",
-    "        marker=\"o\", color=\"navy\", label=\"Train loss (session 2)\")\n",
-    "ax.plot(all_epochs[:n_epochs_run], all_test[:n_epochs_run],\n",
-    "        marker=\"s\", linestyle=\"--\", color=\"coral\", label=\"Test loss (session 1)\")\n",
-    "ax.plot(all_epochs[n_epochs_run:], all_test[n_epochs_run:],\n",
-    "        marker=\"s\", linestyle=\"--\", color=\"darkred\", label=\"Test loss (session 2)\")\n",
-    "ax.axvline(x=n_epochs_run + 0.5, color=\"gray\", linestyle=\":\", label=\"Session boundary\")\n",
-    "ax.set_xlabel(\"Cumulative Epoch\")\n",
-    "ax.set_ylabel(\"Loss\")\n",
-    "ax.set_title(\"Training & Test Loss (20 Epochs Total)\")\n",
-    "ax.legend(fontsize=8)\n",
-    "ax.grid(True, alpha=0.3)\n",
-    "\n",
-    "ax = axes[1]\n",
-    "acc_all   = [m[\"pixel_accuracy\"] if m else None for m in all_metrics]\n",
-    "valid_ep  = [e for e, a in zip(all_epochs, acc_all) if a is not None]\n",
-    "valid_acc = [a for a in acc_all if a is not None]\n",
-    "ax.plot(valid_ep, valid_acc, marker=\"^\", color=\"seagreen\", label=\"Pixel accuracy\")\n",
-    "ax.axvline(x=n_epochs_run + 0.5, color=\"gray\", linestyle=\":\", label=\"Session boundary\")\n",
-    "ax.set_ylim(0, 1)\n",
-    "ax.set_xlabel(\"Cumulative Epoch\")\n",
-    "ax.set_ylabel(\"Pixel Accuracy\")\n",
-    "ax.set_title(\"Validation Pixel Accuracy (20 Epochs Total)\")\n",
-    "ax.legend()\n",
-    "ax.grid(True, alpha=0.3)\n",
-    "\n",
-    "plt.tight_layout()\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "\n",
-    "## 📦 Step 6: Export the Model\n",
-    "\n",
-    "`export_model` packages the trained weights into a [BioImage.IO](https://bioimage.io)-compatible artifact including model weights, architecture code, test samples, a cover image, and a full RDF descriptor. The artifact is uploaded to the `bioimage-io/colab-annotations` collection by default.\n",
-    "\n",
-    "We set **Nils Mechtel from KTH** as the author."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-13T07:45:32.465005Z",
-     "iopub.status.busy": "2026-04-13T07:45:32.464805Z",
-     "iopub.status.idle": "2026-04-13T07:46:14.765169Z",
-     "shell.execute_reply": "2026-04-13T07:46:14.763772Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "✅ Model exported successfully!\n",
-      "{\n",
-      "  \"artifact_id\": \"bioimage-io/cellpose-7e546f39\",\n",
-      "  \"model_name\": \"cellpose-7e546f39\",\n",
-      "  \"status\": \"exported\",\n",
-      "  \"artifact_url\": \"https://hypha.aicell.io/bioimage-io/artifacts/cellpose-7e546f39\",\n",
-      "  \"download_url\": \"https://hypha.aicell.io/bioimage-io/artifacts/cellpose-7e546f39/create-zip-file\",\n",
-      "  \"files\": [\n",
-      "    \"model_weights.pth\",\n",
-      "    \"model.py\",\n",
-      "    \"input_sample.npy\",\n",
-      "    \"output_sample.npy\",\n",
-      "    \"cover.png\",\n",
-      "    \"doc.md\",\n",
-      "    \"rdf.yaml\",\n",
-      "    \"training_params.json\",\n",
-      "    \"training_history.json\"\n",
-      "  ]\n",
-      "}\n"
-     ]
-    }
-   ],
-   "source": [
-    "export_result = await cellpose_svc.export_model(\n",
-    "    session_id=continued_session_id,\n",
-    "    authors=[\n",
-    "        {\n",
-    "            \"name\": \"Nils Mechtel\",\n",
-    "            \"affiliation\": \"KTH Royal Institute of Technology\",\n",
-    "        }\n",
-    "    ],\n",
-    ")\n",
-    "\n",
-    "exported_artifact_id = export_result[\"artifact_id\"]\n",
-    "\n",
-    "print(\"✅ Model exported successfully!\")\n",
-    "print(json.dumps(export_result, indent=2, default=str))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The exported artifact contains:\n",
-    "\n",
-    "| File | Description |\n",
-    "|------|-------------|\n",
-    "| `model_weights.pth` | Fine-tuned PyTorch model weights |\n",
-    "| `model.py` | Cellpose model architecture adapter |\n",
-    "| `input_sample.npy` / `output_sample.npy` | Example tensors for the BioImage.IO test suite |\n",
-    "| `cover.png` | Auto-generated cover image |\n",
-    "| `rdf.yaml` | BioImage.IO Resource Description File |\n",
-    "| `training_history.json` | Full per-epoch metrics |\n",
-    "| `training_params.json` | Original training configuration |"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "\n",
-    "## 🗂️ Step 7: List Exported Models for This Dataset\n",
-    "\n",
-    "`list_models_by_dataset` queries the artifact collection and returns all model artifacts trained on the specified dataset. Our newly exported model should appear here."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-13T07:46:14.769579Z",
-     "iopub.status.busy": "2026-04-13T07:46:14.769121Z",
-     "iopub.status.idle": "2026-04-13T07:46:15.364511Z",
-     "shell.execute_reply": "2026-04-13T07:46:15.363106Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Found 3 exported model(s) trained on 'bioimage-io/annotation-mnw8359y-ehab':\n",
-      "\n",
-      "  ID      : bioimage-io/cellpose-fe2818e8\n",
-      "  Name    : cellpose-fe2818e8\n",
-      "  Created : 2026-04-13 00:29\n",
-      "  URL     : https://hypha.aicell.io/bioimage-io/artifacts/cellpose-fe2818e8\n",
-      "\n",
-      "  ID      : bioimage-io/cellpose-1887bf8a\n",
-      "  Name    : cellpose-1887bf8a\n",
-      "  Created : 2026-04-13 08:54\n",
-      "  URL     : https://hypha.aicell.io/bioimage-io/artifacts/cellpose-1887bf8a\n",
-      "\n",
-      "  ID      : bioimage-io/cellpose-7e546f39\n",
-      "  Name    : cellpose-7e546f39\n",
-      "  Created : 2026-04-13 09:45\n",
-      "  URL     : https://hypha.aicell.io/bioimage-io/artifacts/cellpose-7e546f39\n",
-      "\n",
-      "✅ Our exported model 'bioimage-io/cellpose-7e546f39' is listed.\n"
-     ]
-    }
-   ],
-   "source": [
-    "models = await cellpose_svc.list_models_by_dataset(\n",
-    "    dataset_id=DATASET_ARTIFACT\n",
-    ")\n",
-    "\n",
-    "print(f\"Found {len(models)} exported model(s) trained on '{DATASET_ARTIFACT}':\\n\")\n",
-    "\n",
-    "for model in models:\n",
-    "    ts = model.get(\"created_at\")\n",
-    "    created_str = (\n",
-    "        datetime.datetime.fromtimestamp(ts).strftime(\"%Y-%m-%d %H:%M\")\n",
-    "        if ts else \"—\"\n",
-    "    )\n",
-    "    print(\n",
-    "        f\"  ID      : {model.get('id')}\\n\"\n",
-    "        f\"  Name    : {model.get('name')}\\n\"\n",
-    "        f\"  Created : {created_str}\\n\"\n",
-    "        f\"  URL     : {model.get('url')}\\n\"\n",
-    "    )\n",
-    "\n",
-    "model_ids = [m.get(\"id\") for m in models]\n",
-    "assert exported_artifact_id in model_ids, \"⚠️  Exported model not found in list!\"\n",
-    "print(f\"✅ Our exported model '{exported_artifact_id}' is listed.\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "\n",
-    "## 🎉 Summary\n",
-    "\n",
-    "In this tutorial you completed a full Cellpose fine-tuning workflow:\n",
-    "\n",
-    "| Step | Action | Key API Call |\n",
-    "|------|--------|-------------|\n",
-    "| 1 | Started a 10-epoch training run on annotated brightfield images | `start_training()` |\n",
-    "| 2 | Visualised per-epoch train/test loss and pixel accuracy | `get_training_status()` + matplotlib |\n",
-    "| 3 | Listed all training sessions for the dataset | `list_training_sessions(dataset_artifact_ids=[...])` |\n",
-    "| 4 | Continued training for 10 more epochs from the checkpoint | `restart_training(session_id, n_epochs=10)` |\n",
-    "| 5 | Visualised the combined 20-epoch curves | `get_training_status()` + matplotlib |\n",
-    "| 6 | Exported the final model as a BioImage.IO artifact | `export_model(session_id, authors=[...])` |\n",
-    "| 7 | Listed exported models for the dataset | `list_models_by_dataset(dataset_id=...)` |\n",
-    "\n",
-    "### 🔗 Next Steps\n",
-    "\n",
-    "- Browse the exported model at the URL printed in Step 6\n",
-    "- Use the [BioEngine Model Runner tutorial](../model-runner/tutorial_model_runner.ipynb) to run inference with your new model\n",
-    "- Collect more annotations via [BioImage.IO Colab](https://bioimage.io/#/colab) and repeat the fine-tuning loop\n",
-    "- Deploy your own BioEngine worker for private data — see the [deployment guide](https://github.com/aicell-lab/bioengine-worker)\n"
-   ]
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "bioengine-worker",
+   "display_name": "base",
    "language": "python",
    "name": "python3"
   },
@@ -1096,9 +354,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary

- **Bug fix**: `infer()` now handles PNG/JPEG/BMP images in addition to TIFF. Previously `_images_from_artifact` always used `tifffile.imread`, causing `TiffFileError` on PNG datasets. Now detects by file extension and uses PIL for non-TIFF formats, converting to CHW layout expected by Cellpose.
- **Pillow** added to Ray Serve `runtime_env` pip dependencies.
- **Version bump**: `0.0.15` → `0.0.16`
- **Tutorial notebook** updated with three new sections (after model comparison):
  1. Export the fine-tuned model as a BioImage.IO artifact
  2. Continue fine-tuning from the exported model artifact
  3. Delete training sessions (with note that published model artifacts cannot be removed via this app)
- Notebook updated to use the existing `bioimage-io/annotation-mnw8359y-ehab` dataset artifact (downloads samples for visualization instead of requiring local data)
- Auth cell now accepts `HYPHA_TOKEN` env var for automated/CI execution

## Test plan

- [ ] Deploy v0.0.16, then run the full tutorial notebook end-to-end
- [ ] Verify `infer()` works on PNG images from `bioimage-io/annotation-mnw8359y-ehab`
- [ ] Verify export → retrain from artifact ID → delete session flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)