### PR TITLE
feat(webrtc): configurable ICE servers and update fetch URL, bump to …

### DIFF
--- a/bioengine/apps/builder.py
+++ b/bioengine/apps/builder.py
@@ -1208,6 +1208,7 @@ class AppBuilder:
         last_updated_at: Optional[float] = None,
         last_updated_by: Optional[str] = None,
         auto_redeploy: bool = False,
+        ice_servers: Optional[List[Dict[str, Any]]] = None,
     ) -> serve.Application:
         """
         Transform a deployment artifact into a fully functional BioEngine application.
@@ -1460,6 +1461,7 @@ class AppBuilder:
                 serve_http_url=self.serve_http_url,
                 proxy_actor_name=self.proxy_actor_name,
                 debug=debug,
+                ice_servers=ice_servers,
             )
 
             # Create application metadata

--- a/bioengine/apps/manager.py
+++ b/bioengine/apps/manager.py
@@ -1323,6 +1323,17 @@ class AppsManager:
             None,
             description="Set to true to enable debug logging for the whole application with all its deployments. If not specified, uses False for a new application, or preserves the previous setting if updating an existing application (only when application_id is specified).",
         ),
+        ice_servers: Optional[List[Dict[str, Any]]] = Field(
+            None,
+            description="Custom ICE server configurations for WebRTC connections. If provided, these are used instead of fetching from the default Hypha TURN server endpoint. Each entry should have a 'urls' key and optionally 'username' and 'credential' for TURN servers. Example: [{\"urls\": \"stun:stun.example.com:19302\"}, {\"urls\": \"turn:turn.example.com:3478\", \"username\": \"user\", \"credential\": \"pass\"}]. If not specified, ICE servers are fetched automatically.",
+            examples=[
+                [{"urls": "stun:stun.example.com:19302"}],
+                [
+                    {"urls": "stun:stun.example.com:19302"},
+                    {"urls": "turn:turn.example.com:3478", "username": "user", "credential": "pass"},
+                ],
+            ],
+        ),
         context: Dict[str, Any] = Field(
             ...,
             description="Authentication context containing user information, automatically provided by Hypha during service calls.",
@@ -1417,6 +1428,8 @@ class AppsManager:
                     auto_redeploy = existing_app["auto_redeploy"]
                 if debug is None:
                     debug = existing_app.get("debug", False)
+                if ice_servers is None:
+                    ice_servers = existing_app.get("ice_servers", None)
             else:
                 # For new applications, set creation time and default values
                 started_at = time.time()
@@ -1435,6 +1448,7 @@ class AppsManager:
                     auto_redeploy = False
                 if debug is None:
                     debug = False
+                # ice_servers defaults to None (fetch from URL)
 
             # Validate application_kwargs
             if not isinstance(application_kwargs, dict):
@@ -1525,6 +1539,7 @@ class AppsManager:
                 last_updated_at=last_updated_at,
                 last_updated_by=user_id,
                 auto_redeploy=auto_redeploy,
+                ice_servers=ice_servers,
             )
 
             # Check resources before creating deployment task
@@ -1562,6 +1577,7 @@ class AppsManager:
                 "last_updated_by": user_id,
                 "built_app": app,
                 "auto_redeploy": auto_redeploy,
+                "ice_servers": ice_servers,
                 "deployment_task": None,  # Control task for app deployment
                 "is_deployed": asyncio.Event(),  # Track the deployment process
                 "undeployment_task": None,  # Control task for app undeployment

--- a/bioengine/apps/proxy_deployment.py
+++ b/bioengine/apps/proxy_deployment.py
@@ -98,6 +98,7 @@ class ProxyDeployment:
         serve_http_url: str,
         proxy_actor_name: str,
         debug: bool,
+        ice_servers: Optional[List[Dict[str, Any]]] = None,
     ):
         """
         Initialize the BioEngine proxy deployment.
@@ -140,6 +141,11 @@ class ProxyDeployment:
             serve_http_url: URL for Ray Serve HTTP endpoint used for autoscaling coordination.
             proxy_actor_name: Actor name of the BioEngineProxyActor for replica registration.
             debug: Set to true to enable debug logging.
+            ice_servers: Optional list of ICE server configurations to use for WebRTC
+                        connections. If provided, these are used instead of fetching from
+                        the default URL. Example:
+                        [{"urls": "stun:stun.example.com:19302"},
+                         {"urls": "turn:turn.example.com:3478", "username": "u", "credential": "p"}]
         """
         logger.setLevel("DEBUG" if debug else "INFO")
         logger.info(
@@ -229,6 +235,9 @@ class ProxyDeployment:
 
         # Store entry deployment readiness
         self.entry_deployment_ready = False
+
+        # Custom ICE servers for WebRTC (None means fetch from default URL)
+        self.ice_servers = ice_servers
 
         # Service state
         self.server: RemoteService = None
@@ -643,21 +652,21 @@ class ProxyDeployment:
                 f"❌ Failed to initialize WebRTC connection for '{self.application_id}': {e}"
             )
 
+    ICE_SERVERS_URL = (
+        "https://hypha.aicell.io/turn-server/services/coturn/get_rtc_ice_servers"
+    )
+
     async def _fetch_ice_servers(self) -> Optional[List[Dict[str, Any]]]:
         """
-        Fetch custom ICE servers for WebRTC connections.
+        Resolve ICE servers for WebRTC connections.
 
         ICE (Interactive Connectivity Establishment) servers help establish
-        WebRTC connections through NAT and firewall traversal. This method
-        attempts to fetch custom ICE servers from the Hypha infrastructure.
+        WebRTC connections through NAT and firewall traversal.
 
-        ICE servers provide:
-        1. STUN servers: Discover public IP addresses
-        2. TURN servers: Relay traffic when direct connection fails
-        3. Support for various network configurations
-
-        The method gracefully falls back to None if custom servers are unavailable,
-        allowing hypha-rpc to use its built-in default servers.
+        Resolution order:
+        1. If custom ICE servers were provided at deploy time, use them directly.
+        2. Otherwise, fetch from the Hypha TURN server endpoint.
+        3. If the fetch fails, fall back to None (hypha-rpc uses built-in defaults).
 
         Returns:
             List of ICE server configurations, or None to use defaults.
@@ -666,11 +675,15 @@ class ProxyDeployment:
             [{"urls": "stun:stun.server.com:19302"},
              {"urls": "turn:turn.server.com:3478", "username": "...", "credential": "..."}]
         """
+        if self.ice_servers is not None:
+            logger.info(
+                f"✅ Using custom ICE servers provided at deploy time for {self.application_id}"
+            )
+            return self.ice_servers
+
         try:
             async with AsyncClient(timeout=30) as client:
-                response = await client.get(
-                    "https://ai.imjoy.io/public/services/coturn/get_rtc_ice_servers"
-                )
+                response = await client.get(self.ICE_SERVERS_URL)
                 response.raise_for_status()
                 ice_servers = response.json()
                 logger.info(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.7.1"
+version = "0.7.2"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
…v0.7.2

- Update ICE server fetch URL from ai.imjoy.io to hypha.aicell.io/turn-server
- Add `ice_servers` parameter to `deploy_app` to pass custom ICE server configs
- Thread `ice_servers` through builder.build() and ProxyDeployment.__init__()
- Custom servers skip the HTTP fetch; None falls back to URL fetch then hypha-rpc defaults
- Store ice_servers in deployed application state (preserved on update if not re-specified)