### PR TITLE
feat(apps): per-method authorized_users in deploy_app, bump to v0.8.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,8 +177,8 @@ pytest tests/end_to_end/ -v
 - `bioengine/utils/artifact_utils.py` — All Hypha artifact CRUD helpers
 - `bioengine/apps/manager.py` — `deploy_app`, `upload_app`, lifecycle
 - `bioengine/apps/builder.py` — `build()` constructs Ray Serve app from artifact
-- `apps/demo-app/` — Reference BioEngine app (single deployment + frontend; ping, ascii_art, list_datasets, reverse_text)
-- `apps/composition-demo/` — Multi-deployment composition app (entry + 3 runtimes, reference for composition pattern)
+- `apps/demo-app/` — Reference BioEngine app (single deployment + frontend; ping, ascii_art, list_datasets, reverse_text); **always keep version at 1.0.0**
+- `apps/composition-demo/` — Multi-deployment composition app (entry + 3 runtimes, reference for composition pattern); **always keep version at 1.0.0**
 - `apps/model-runner/` — Production model-runner app
 - `apps/cellpose-finetuning/` — Cellpose fine-tuning app
 - `pyproject.toml` — Package version and dependencies; install with `pip install -e ".[cli]"` for CLI use

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,7 @@ pytest tests/end_to_end/ -v
 
 ## Code Conventions
 
+- **Git author**: Always commit as `nilsmechtel` (`nils.mech@gmail.com`) unless explicitly told otherwise.
 - **Permissions**: Use `check_permissions(context, authorized_users, resource_name)` from `bioengine.utils`
 - **Schema methods**: Decorate public API methods with `@schema_method` and use `pydantic.Field` for parameter descriptions
 - **Logging**: Use `create_logger("ComponentName", ...)` from `bioengine.utils`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,7 @@ pytest tests/end_to_end/ -v
 ## Code Conventions
 
 - **Git author**: Always commit as `nilsmechtel` (`nils.mech@gmail.com`) unless explicitly told otherwise.
+- **App authorized_users**: When deploying an app, the worker's `admin_users` and the deploying user are always injected into every key of `authorized_users` (including `"*"`). This guarantees admins can always call any app method regardless of the app's access rules.
 - **Permissions**: Use `check_permissions(context, authorized_users, resource_name)` from `bioengine.utils`
 - **Schema methods**: Decorate public API methods with `@schema_method` and use `pydantic.Field` for parameter descriptions
 - **Logging**: Use `create_logger("ComponentName", ...)` from `bioengine.utils`

--- a/apps/cell-image-search/manifest.yaml
+++ b/apps/cell-image-search/manifest.yaml
@@ -26,7 +26,4 @@ tags:
   - drug-discovery
 deployments:
   - main:CellImageSearch
-authorized_users:
-  "*":
-    - "*"
 frontend_entry: "frontend/index.html"

--- a/apps/cell-image-search/manifest.yaml
+++ b/apps/cell-image-search/manifest.yaml
@@ -14,7 +14,7 @@ license: MIT
 format_version: 0.5.0
 git_repo: https://github.com/aicell-lab/bioengine-worker
 type: ray-serve
-version: 0.21.4
+version: 0.21.5
 tags:
   - bioengine
   - image-search
@@ -27,5 +27,6 @@ tags:
 deployments:
   - main:CellImageSearch
 authorized_users:
-  - "*"
+  "*":
+    - "*"
 frontend_entry: "frontend/index.html"

--- a/apps/cellpose-finetuning/manifest.yaml
+++ b/apps/cellpose-finetuning/manifest.yaml
@@ -15,9 +15,10 @@ maintainers: []
 name: Cellpose Fine-Tuning
 tags: [cell-segmentation, deep-learning, biomedical-imaging, fine-tuning]
 type: ray-serve
-version: 0.0.28
+version: 0.0.29
 deployments:
   - main:CellposeFinetune
 authorized_users:
-  - "*" # Allow all users to access the application
+  "*":
+    - "*" # Allow all users to access the application
 frontend_entry: "frontend/index.html"

--- a/apps/cellpose-finetuning/manifest.yaml
+++ b/apps/cellpose-finetuning/manifest.yaml
@@ -18,7 +18,4 @@ type: ray-serve
 version: 0.0.29
 deployments:
   - main:CellposeFinetune
-authorized_users:
-  "*":
-    - "*" # Allow all users to access the application
 frontend_entry: "frontend/index.html"

--- a/apps/composition-demo/manifest.yaml
+++ b/apps/composition-demo/manifest.yaml
@@ -4,7 +4,7 @@ id_emoji: "🔬"
 description: "Multi-deployment composition demo with entry + 3 runtime deployments"
 type: ray-serve
 format_version: 0.5.0
-version: 1.0.0
+version: 1.0.1
 authors:
   - {name: "Test User", affiliation: "BioEngine Test"}
 license: MIT
@@ -15,5 +15,6 @@ deployments:
   - runtime_b:RuntimeB
   - runtime_c:RuntimeC
 authorized_users:
-  - "*"
+  "*":
+    - "*"
 frontend_entry: "frontend/index.html"

--- a/apps/composition-demo/manifest.yaml
+++ b/apps/composition-demo/manifest.yaml
@@ -4,7 +4,7 @@ id_emoji: "🔬"
 description: "Multi-deployment composition demo with entry + 3 runtime deployments"
 type: ray-serve
 format_version: 0.5.0
-version: 1.0.1
+version: 1.0.0
 authors:
   - {name: "Test User", affiliation: "BioEngine Test"}
 license: MIT

--- a/apps/composition-demo/manifest.yaml
+++ b/apps/composition-demo/manifest.yaml
@@ -14,7 +14,4 @@ deployments:
   - runtime_a:RuntimeA
   - runtime_b:RuntimeB
   - runtime_c:RuntimeC
-authorized_users:
-  "*":
-    - "*"
 frontend_entry: "frontend/index.html"

--- a/apps/demo-app/manifest.yaml
+++ b/apps/demo-app/manifest.yaml
@@ -17,7 +17,4 @@ type: ray-serve
 version: 1.0.0
 deployments:
   - demo_deployment:DemoDeployment
-authorized_users:
-  "*":
-    - "*" # Allow all users to access the application
 frontend_entry: "frontend/index.html"

--- a/apps/demo-app/manifest.yaml
+++ b/apps/demo-app/manifest.yaml
@@ -14,9 +14,10 @@ git_repo: https://github.com/aicell-lab/bioengine-worker
 links: []
 tags: [test, bioengine]
 type: ray-serve
-version: 0.1.0
+version: 0.1.1
 deployments:
   - demo_deployment:DemoDeployment
 authorized_users:
-  - "*" # Allow all users to access the application
+  "*":
+    - "*" # Allow all users to access the application
 frontend_entry: "frontend/index.html"

--- a/apps/demo-app/manifest.yaml
+++ b/apps/demo-app/manifest.yaml
@@ -14,7 +14,7 @@ git_repo: https://github.com/aicell-lab/bioengine-worker
 links: []
 tags: [test, bioengine]
 type: ray-serve
-version: 0.1.1
+version: 1.0.0
 deployments:
   - demo_deployment:DemoDeployment
 authorized_users:

--- a/apps/fibsem-mito-analysis/manifest.yaml
+++ b/apps/fibsem-mito-analysis/manifest.yaml
@@ -4,7 +4,7 @@ id_emoji: "🔬"
 description: "Automated mitochondria instance segmentation and morphological profiling for 2D electron microscopy images. Delegates GPU inference to the BioEngine model-runner service (poisonous-spider Attention U-Net), handles arbitrary image sizes via tiled inference with Gaussian blending."
 type: ray-serve
 format_version: 0.5.0
-version: 0.1.0
+version: 0.1.1
 authors:
   - {name: "BioEngine Team", affiliation: "KTH Royal Institute of Technology", github_user: "oeway"}
 maintainers: [oeway]
@@ -14,5 +14,6 @@ tags: [mitochondria, electron-microscopy, fibsem, segmentation, morphology, scal
 deployments:
   - analysis_deployment:MitoAnalysisDeployment
 authorized_users:
-  - "*"
+  "*":
+    - "*"
 frontend_entry: "frontend/index.html"

--- a/apps/fibsem-mito-analysis/manifest.yaml
+++ b/apps/fibsem-mito-analysis/manifest.yaml
@@ -13,7 +13,4 @@ git_repo: https://github.com/aicell-lab/bioengine-worker
 tags: [mitochondria, electron-microscopy, fibsem, segmentation, morphology, scalable, bioimage-model-zoo]
 deployments:
   - analysis_deployment:MitoAnalysisDeployment
-authorized_users:
-  "*":
-    - "*"
 frontend_entry: "frontend/index.html"

--- a/apps/model-runner/manifest.yaml
+++ b/apps/model-runner/manifest.yaml
@@ -18,6 +18,3 @@ version: 1.0.1
 deployments:
   - entry_deployment:EntryDeployment
   - runtime_deployment:RuntimeDeployment
-authorized_users:
-  "*":
-    - "*" # Allow all users to access the application

--- a/apps/model-runner/manifest.yaml
+++ b/apps/model-runner/manifest.yaml
@@ -14,9 +14,10 @@ maintainers: []
 name: Model Runner
 tags: []
 type: ray-serve
-version: 1.0.0
+version: 1.0.1
 deployments:
   - entry_deployment:EntryDeployment
   - runtime_deployment:RuntimeDeployment
 authorized_users:
-  - "*" # Allow all users to access the application
+  "*":
+    - "*" # Allow all users to access the application

--- a/bioengine/apps/builder.py
+++ b/bioengine/apps/builder.py
@@ -1209,6 +1209,8 @@ class AppBuilder:
         last_updated_by: Optional[str] = None,
         auto_redeploy: bool = False,
         ice_servers: Optional[List[Dict[str, Any]]] = None,
+        authorized_users: Optional[Dict[str, List[str]]] = None,
+        deploying_user: Optional[tuple] = None,
     ) -> serve.Application:
         """
         Transform a deployment artifact into a fully functional BioEngine application.
@@ -1416,6 +1418,28 @@ class AppBuilder:
                 }
             )
 
+            # Resolve authorized_users: deploy-time override > manifest (converted to dict).
+            if authorized_users is not None:
+                effective_authorized_users = authorized_users
+            else:
+                manifest_list = manifest.get("authorized_users", ["*"])
+                effective_authorized_users = {"*": manifest_list}
+
+            # Always ensure the deploying user has access to all methods.
+            if deploying_user:
+                dep_id, dep_email = deploying_user
+                for key in list(effective_authorized_users):
+                    rule = list(effective_authorized_users[key])
+                    if dep_id and dep_id not in rule:
+                        rule.append(dep_id)
+                    if dep_email and dep_email not in rule:
+                        rule.append(dep_email)
+                    effective_authorized_users[key] = rule
+                if "*" not in effective_authorized_users:
+                    effective_authorized_users["*"] = [
+                        v for v in [dep_id, dep_email] if v
+                    ]
+
             # Create the application
             sanitized_env_vars = self._sanitize_recovery_env_vars(application_env_vars)
             app_data = {
@@ -1428,7 +1452,7 @@ class AppBuilder:
                 "disable_gpu": disable_gpu,
                 "max_ongoing_requests": max_ongoing_requests,
                 "application_resources": required_resources,
-                "authorized_users": manifest["authorized_users"],
+                "authorized_users": effective_authorized_users,
                 "available_methods": [
                     method_schema["name"] for method_schema in method_schemas
                 ],
@@ -1457,7 +1481,7 @@ class AppBuilder:
                 workspace=self.server.config.workspace,
                 worker_client_id=self.server.config.client_id,
                 proxy_service_token=proxy_service_token,
-                authorized_users=manifest["authorized_users"],
+                authorized_users=effective_authorized_users,
                 serve_http_url=self.serve_http_url,
                 proxy_actor_name=self.proxy_actor_name,
                 debug=debug,
@@ -1470,7 +1494,7 @@ class AppBuilder:
                 "description": manifest["description"],
                 "version": version,
                 "resources": required_resources,
-                "authorized_users": manifest["authorized_users"],
+                "authorized_users": effective_authorized_users,
                 "available_methods": [
                     method_schema["name"] for method_schema in method_schemas
                 ],

--- a/bioengine/apps/builder.py
+++ b/bioengine/apps/builder.py
@@ -1207,6 +1207,7 @@ class AppBuilder:
         ice_servers: Optional[List[Dict[str, Any]]] = None,
         authorized_users: Optional[Dict[str, List[str]]] = None,
         deploying_user: Optional[tuple] = None,
+        admin_users: Optional[List[str]] = None,
     ) -> serve.Application:
         """
         Transform a deployment artifact into a fully functional BioEngine application.
@@ -1424,20 +1425,23 @@ class AppBuilder:
                 else:
                     effective_authorized_users = {"*": manifest_users}
 
-            # Always ensure the deploying user has access to all methods.
+            # Always ensure the deploying user and all admin users have access to all methods.
+            users_to_inject = []
             if deploying_user:
                 dep_id, dep_email = deploying_user
+                users_to_inject.extend([v for v in [dep_id, dep_email] if v])
+            if admin_users:
+                users_to_inject.extend(admin_users)
+
+            if users_to_inject:
                 for key in list(effective_authorized_users):
                     rule = list(effective_authorized_users[key])
-                    if dep_id and dep_id not in rule:
-                        rule.append(dep_id)
-                    if dep_email and dep_email not in rule:
-                        rule.append(dep_email)
+                    for user in users_to_inject:
+                        if user not in rule:
+                            rule.append(user)
                     effective_authorized_users[key] = rule
                 if "*" not in effective_authorized_users:
-                    effective_authorized_users["*"] = [
-                        v for v in [dep_id, dep_email] if v
-                    ]
+                    effective_authorized_users["*"] = list(users_to_inject)
 
             # Create the application
             sanitized_env_vars = self._sanitize_recovery_env_vars(application_env_vars)

--- a/bioengine/apps/builder.py
+++ b/bioengine/apps/builder.py
@@ -1418,12 +1418,15 @@ class AppBuilder:
                 }
             )
 
-            # Resolve authorized_users: deploy-time override > manifest (converted to dict).
+            # Resolve authorized_users: deploy-time override > manifest.
             if authorized_users is not None:
                 effective_authorized_users = authorized_users
             else:
-                manifest_list = manifest.get("authorized_users", ["*"])
-                effective_authorized_users = {"*": manifest_list}
+                manifest_users = manifest.get("authorized_users", ["*"])
+                if isinstance(manifest_users, dict):
+                    effective_authorized_users = manifest_users
+                else:
+                    effective_authorized_users = {"*": manifest_users}
 
             # Always ensure the deploying user has access to all methods.
             if deploying_user:

--- a/bioengine/apps/builder.py
+++ b/bioengine/apps/builder.py
@@ -38,8 +38,6 @@ class AppManifest(TypedDict, total=False):
     • description: What this application does (help text for users)
     • type: Deployment type (must be "ray-serve" for Ray Serve apps)
     • deployments: List of Python files to deploy (format: "file:ClassName")
-    • authorized_users: Who can access this app (user IDs or ["*"] for public)
-
     Optional Fields:
     • frontend_entry: Entry HTML file for the static frontend (e.g. "frontend/index.html").
                       When set, static site hosting is configured automatically.
@@ -52,7 +50,6 @@ class AppManifest(TypedDict, total=False):
     description: "Classifies images using a pre-trained CNN model"
     type: "ray-serve"
     deployments: ["classifier:ImageClassifier"]
-    authorized_users: ["user123", "*"]
     frontend_entry: "frontend/index.html"
     ```
     """
@@ -63,7 +60,6 @@ class AppManifest(TypedDict, total=False):
     description: str
     type: str
     deployments: List[str]
-    authorized_users: List[str]
     frontend_entry: str
 
 

--- a/bioengine/apps/manager.py
+++ b/bioengine/apps/manager.py
@@ -1462,7 +1462,7 @@ class AppsManager:
                 # ice_servers defaults to None (fetch from URL)
                 # authorized_users defaults to None (use manifest value)
 
-            # Caller identity for injection into authorized_users by the builder
+            # Caller identity and admin users for injection into authorized_users by the builder
             user_email = context["user"].get("email", "")
 
             # Validate application_kwargs
@@ -1557,6 +1557,7 @@ class AppsManager:
                 ice_servers=ice_servers,
                 authorized_users=authorized_users,
                 deploying_user=(user_id, user_email),
+                admin_users=self.admin_users,
             )
 
             # Check resources before creating deployment task

--- a/bioengine/apps/manager.py
+++ b/bioengine/apps/manager.py
@@ -1334,6 +1334,15 @@ class AppsManager:
                 ],
             ],
         ),
+        authorized_users: Optional[Dict[str, List[str]]] = Field(
+            None,
+            description="Per-method access control for the deployed application. Keys are method names or '*' (wildcard for all methods). Values are lists of allowed user IDs or email addresses; use ['*'] for public access. Method-specific entries take precedence over the wildcard. The user calling deploy_app is always granted access to all methods. If not specified, the manifest's authorized_users field is used as a wildcard rule for all methods, or the previous value is preserved when updating an existing application.",
+            examples=[
+                {"*": ["*"]},
+                {"*": ["user@lab.edu"], "run_inference": ["*"]},
+                {"train": ["admin@lab.edu"], "infer": ["*"]},
+            ],
+        ),
         context: Dict[str, Any] = Field(
             ...,
             description="Authentication context containing user information, automatically provided by Hypha during service calls.",
@@ -1430,6 +1439,8 @@ class AppsManager:
                     debug = existing_app.get("debug", False)
                 if ice_servers is None:
                     ice_servers = existing_app.get("ice_servers", None)
+                if authorized_users is None:
+                    authorized_users = existing_app.get("authorized_users", None)
             else:
                 # For new applications, set creation time and default values
                 started_at = time.time()
@@ -1449,6 +1460,10 @@ class AppsManager:
                 if debug is None:
                     debug = False
                 # ice_servers defaults to None (fetch from URL)
+                # authorized_users defaults to None (use manifest value)
+
+            # Caller identity for injection into authorized_users by the builder
+            user_email = context["user"].get("email", "")
 
             # Validate application_kwargs
             if not isinstance(application_kwargs, dict):
@@ -1540,6 +1555,8 @@ class AppsManager:
                 last_updated_by=user_id,
                 auto_redeploy=auto_redeploy,
                 ice_servers=ice_servers,
+                authorized_users=authorized_users,
+                deploying_user=(user_id, user_email),
             )
 
             # Check resources before creating deployment task

--- a/bioengine/apps/proxy_deployment.py
+++ b/bioengine/apps/proxy_deployment.py
@@ -94,7 +94,7 @@ class ProxyDeployment:
         workspace: str,
         proxy_service_token: str,
         worker_client_id: str,
-        authorized_users: List[str],
+        authorized_users: Dict[str, List[str]],
         serve_http_url: str,
         proxy_actor_name: str,
         debug: bool,
@@ -134,9 +134,11 @@ class ProxyDeployment:
 
             worker_client_id: Client ID of the worker that created this deployment.
 
-            authorized_users: List of user identifiers (IDs or emails) allowed to access
-                            this application. Use ["*"] for public access or empty list
-                            to deny all access.
+            authorized_users: Per-method access control dictionary. Keys are method names
+                            or "*" (applies to all methods). Values are lists of user IDs
+                            or emails allowed to call that method; use ["*"] for public
+                            access. Method-specific entries take precedence over "*".
+                            Example: {"*": ["admin@lab.edu"], "run": ["*"]}
 
             serve_http_url: URL for Ray Serve HTTP endpoint used for autoscaling coordination.
             proxy_actor_name: Actor name of the BioEngineProxyActor for replica registration.
@@ -326,32 +328,28 @@ class ProxyDeployment:
     # ===== Hypha Service Registration =====
     # Handles registration of WebSocket and WebRTC services with Hypha.
 
-    async def _check_permissions(self, context: Dict[str, Any]) -> None:
+    async def _check_permissions(
+        self, context: Dict[str, Any], method_name: str = "*"
+    ) -> None:
         """
-        Verify that a user is authorized to access this deployment.
+        Verify that a user is authorized to call a specific method on this deployment.
 
-        This method is called by proxy functions during service registration to
-        enforce access control based on the authorized_users list configured
-        during deployment initialization.
-
-        Permission Checking Process:
-        1. Validates that context contains user information
-        2. Extracts user ID and email from the context
-        3. Checks against the authorized_users list
-        4. Supports wildcard access ("*") for public deployments
-
-        Authorization Methods:
-        - Wildcard "*" in authorized_users allows all users
-        - User ID match against authorized_users list
-        - Email address match against authorized_users list
+        Resolves the effective authorized-users list for the given method:
+        1. Method-specific entry in authorized_users takes precedence.
+        2. Falls back to the wildcard "*" entry if no method-specific entry exists.
+        3. If neither exists, access is denied.
 
         Args:
-            context: Request context containing user information from Hypha
+            context: Request context containing user information from Hypha.
+            method_name: Name of the method being called. Defaults to "*" for
+                        app-level checks (e.g. health check).
 
         Raises:
-            PermissionError: If user is not authorized or context is invalid
+            PermissionError: If user is not authorized or context is invalid.
         """
-        logger.debug(f"🔒 Checking permissions for application: {self.application_id}")
+        logger.debug(
+            f"🔒 Checking permissions for '{method_name}' on application: {self.application_id}"
+        )
 
         if not isinstance(context, dict) or "user" not in context:
             logger.error(f"❌ Invalid context without user information")
@@ -362,21 +360,32 @@ class ProxyDeployment:
             logger.error(f"❌ Invalid user information in context")
             raise PermissionError("Invalid user information in context")
 
-        # Check authorization
-        user_id = user["id"]
-        user_email = user["email"]
+        user_id = user.get("id", "")
+        user_email = user.get("email", "")
 
-        if "*" in self.authorized_users:
-            logger.debug(f"✅ Wildcard access granted for user: {user_id}")
+        # Resolve the effective authorized list: method-specific > wildcard > deny
+        allowed = self.authorized_users.get(method_name) or self.authorized_users.get("*")
+        if not allowed:
+            logger.error(
+                f"❌ No authorization rule for method '{method_name}' and no wildcard '*' rule"
+            )
+            raise PermissionError(
+                f"User '{user_id}' ({user_email}) is not authorized to call "
+                f"'{method_name}' on application '{self.application_id}'"
+            )
+
+        if "*" in allowed:
+            logger.debug(f"✅ Public access granted for '{method_name}' to user: {user_id}")
             return
 
-        if user_id in self.authorized_users or user_email in self.authorized_users:
-            logger.debug(f"✅ User authorized: {user_id} ({user_email})")
+        if user_id in allowed or user_email in allowed:
+            logger.debug(f"✅ User authorized for '{method_name}': {user_id} ({user_email})")
             return
 
-        logger.error(f"❌ User not authorized: {user_id} ({user_email})")
+        logger.error(f"❌ User not authorized for '{method_name}': {user_id} ({user_email})")
         raise PermissionError(
-            f"User '{user_id}' ({user_email}) is not authorized to access application '{self.application_id}'"
+            f"User '{user_id}' ({user_email}) is not authorized to call "
+            f"'{method_name}' on application '{self.application_id}'"
         )
 
     async def _mimic_request(self, request_id: str) -> None:
@@ -486,7 +495,7 @@ class ProxyDeployment:
                 event_created = False
                 try:
                     # Check user permissions
-                    await self._check_permissions(context)
+                    await self._check_permissions(context, method_name=method_name)
 
                     # Log the method call
                     user_info = context.get("user", {}) if context else {}

--- a/bioengine/utils/artifact_utils.py
+++ b/bioengine/utils/artifact_utils.py
@@ -239,7 +239,6 @@ def validate_manifest(manifest: Dict[str, Any]) -> None:
         "description",
         "type",
         "deployments",
-        "authorized_users",
     ]
     for field in required_fields:
         if field not in manifest:
@@ -259,13 +258,6 @@ def validate_manifest(manifest: Dict[str, Any]) -> None:
             "Expected a non-empty list of deployment descriptions in the format 'python_file:class_name'."
         )
 
-    # Validate authorized_users format
-    authorized_users = manifest["authorized_users"]
-    if not isinstance(authorized_users, list) or len(authorized_users) == 0:
-        raise ValueError(
-            "Invalid authorized_users format in manifest. "
-            "Expected a non-empty list of user IDs or '*' for all users."
-        )
 
 
 def validate_artifact_id(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.7.2"
+version = "0.8.0"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
- Add `authorized_users` parameter to `deploy_app`: dict mapping method names (or "*" wildcard) to lists of allowed user IDs / emails; ["*"] = public
- Method-specific entries take precedence over the "*" wildcard rule
- Caller of deploy_app is always injected into every rule (and a "*" rule is created if none exists), ensuring the deployer always has access
- Falls back to manifest's authorized_users list (converted to {"*": [...]}) when no deploy-time override is provided
- Preserved on update when not re-specified
- ProxyDeployment._check_permissions now accepts method_name and resolves the effective rule per call