### PR TITLE
fix(datasets): make zarr import lazy in chunk_cache to fix worker sta…

### DIFF
--- a/bioengine/datasets/chunk_cache.py
+++ b/bioengine/datasets/chunk_cache.py
@@ -5,12 +5,15 @@ A single ChunkCache can be shared across multiple HttpZarrStore instances so
 that the memory budget applies to the whole process rather than per-store.
 """
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import os
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
-from zarr.core.buffer import Buffer
+if TYPE_CHECKING:
+    from zarr.core.buffer import Buffer
 
 _DEFAULT_CACHE_SIZE_GB = int(os.getenv("BIOENGINE_DATASETS_ZARR_STORE_CACHE_SIZE", 1))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.8.11"
+version = "0.8.12"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
…rtup

chunk_cache.py imported zarr at module level, but zarr is only in the datasets extra — not in the worker image. builder.py imports BioEngineDatasets which pulls in ChunkCache, causing the worker pod to crash with ModuleNotFoundError: No module named 'zarr'.

Fix: guard the import with TYPE_CHECKING so it only runs for static analysis. Buffer is used purely as a type hint; no runtime behaviour changes. Bump to 0.8.12.