### PR TITLE
fix(apps): add 10s timeout to get_app_data remote calls during recovery

### DIFF
--- a/bioengine/apps/manager.py
+++ b/bioengine/apps/manager.py
@@ -851,7 +851,9 @@ class AppsManager:
 
             try:
                 app_handle = await asyncio.to_thread(serve.get_app_handle, application_id)
-                app_data = await app_handle.get_app_data.remote()
+                app_data = await asyncio.wait_for(
+                    app_handle.get_app_data.remote(), timeout=10.0
+                )
 
                 if not isinstance(app_data, dict):
                     raise ValueError("get_app_data() did not return a dictionary")
@@ -889,8 +891,9 @@ class AppsManager:
                 updated_authorized_users = self._inject_admin_users(
                     app_data["authorized_users"]
                 )
-                await app_handle.update_authorized_users.remote(
-                    updated_authorized_users
+                await asyncio.wait_for(
+                    app_handle.update_authorized_users.remote(updated_authorized_users),
+                    timeout=10.0,
                 )
 
                 self._deployed_applications[application_id] = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.8.12"
+version = "0.8.13"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Summary
- `recover_deployed_applications()` hung indefinitely when a ProxyDeployment had no running replicas (e.g. cellpose-finetuning stuck PENDING waiting for GPU nodes)
- This blocked the entire worker startup, preventing the `bioengine-worker` Hypha service from registering, causing the readiness probe to fail and keeping both old+new pods in `0/1 Running` state
- Fix: wrap both `get_app_data.remote()` and `update_authorized_users.remote()` calls with `asyncio.wait_for(..., timeout=10.0)`

## Test plan
- [ ] Merge and wait for 0.8.13 image to build
- [ ] Update Helm chart `appVersion` to 0.8.13 and redeploy
- [ ] Confirm new pod passes readiness probe even when GPU nodes are unavailable
- [ ] Confirm old 0.8.4 pod stops restarting once new pod is Ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)