### PR TITLE
feat(worker): add list_app_directories and clear_app_directory API methods

### DIFF
--- a/bioengine/apps/manager.py
+++ b/bioengine/apps/manager.py
@@ -1182,6 +1182,128 @@ class AppsManager:
         return created_artifact_id
 
     @schema_method
+    async def list_app_directories(
+        self,
+        context: Dict[str, Any] = Field(
+            ...,
+            description="Authentication context containing user information, automatically provided by Hypha during service calls.",
+        ),
+    ) -> List[Dict[str, Any]]:
+        """
+        Lists all application working directories under the BioEngine apps workspace.
+
+        Returns one entry per subdirectory found under the apps working directory,
+        including whether that directory belongs to a currently running application.
+
+        Returns:
+            List of dictionaries, each with:
+            - name: directory name (matches application_id for deployed apps)
+            - path: absolute path to the directory
+            - is_running: True if the directory belongs to a currently running app
+            - size_bytes: total disk usage of the directory in bytes
+
+        Raises:
+            PermissionError: If the caller is not a worker admin
+            RuntimeError: If the worker is not initialized
+        """
+        self._check_initialized()
+        check_permissions(
+            context=context,
+            authorized_users=self.admin_users,
+            resource_name="listing app directories",
+        )
+
+        apps_workdir = self.app_builder.apps_workdir
+        if not apps_workdir.exists():
+            return []
+
+        running = {
+            app_id
+            for app_id, info in self._deployed_applications.items()
+            if info["is_deployed"].is_set()
+        }
+
+        result = []
+        for entry in sorted(apps_workdir.iterdir()):
+            if not entry.is_dir():
+                continue
+            size = sum(f.stat().st_size for f in entry.rglob("*") if f.is_file())
+            result.append(
+                {
+                    "name": entry.name,
+                    "path": str(entry),
+                    "is_running": entry.name in running,
+                    "size_bytes": size,
+                }
+            )
+        return result
+
+    @schema_method
+    async def clear_app_directory(
+        self,
+        directory_name: str = Field(
+            ...,
+            description="Name of the app working directory to delete (must be a direct subdirectory of the apps workspace, not a path).",
+        ),
+        context: Dict[str, Any] = Field(
+            ...,
+            description="Authentication context containing user information, automatically provided by Hypha during service calls.",
+        ),
+    ) -> None:
+        """
+        Deletes an application working directory from the BioEngine apps workspace.
+
+        The directory is identified by name (as returned by list_app_directories).
+        Raises an error if the directory belongs to a currently running application —
+        stop the app first with stop_app() before clearing its directory.
+
+        Args:
+            directory_name: Name of the subdirectory to delete (e.g. "model-runner").
+
+        Raises:
+            PermissionError: If the caller is not a worker admin
+            RuntimeError: If the worker is not initialized, the directory belongs to a
+                         running app, or deletion fails
+            ValueError: If the directory does not exist or the name contains path separators
+        """
+        self._check_initialized()
+        check_permissions(
+            context=context,
+            authorized_users=self.admin_users,
+            resource_name=f"clearing app directory '{directory_name}'",
+        )
+
+        if "/" in directory_name or "\\" in directory_name or directory_name in (".", ".."):
+            raise ValueError(
+                f"directory_name must be a plain directory name, not a path: '{directory_name}'"
+            )
+
+        target = self.app_builder.apps_workdir / directory_name
+        if not target.exists():
+            raise ValueError(
+                f"Directory '{directory_name}' does not exist under the apps workspace."
+            )
+        if not target.is_dir():
+            raise ValueError(f"'{directory_name}' is not a directory.")
+
+        # Refuse if a running app owns this directory
+        if directory_name in self._deployed_applications:
+            info = self._deployed_applications[directory_name]
+            if info["is_deployed"].is_set():
+                raise RuntimeError(
+                    f"Cannot clear directory '{directory_name}': application is currently running. "
+                    "Stop it first with stop_app()."
+                )
+
+        import shutil
+        try:
+            shutil.rmtree(target)
+        except Exception as e:
+            raise RuntimeError(f"Failed to delete directory '{directory_name}': {e}")
+
+        self.logger.info(f"Cleared app directory: {target}")
+
+    @schema_method
     async def list_apps(
         self,
         context: Dict[str, Any] = Field(

--- a/bioengine/apps/manager.py
+++ b/bioengine/apps/manager.py
@@ -1241,9 +1241,9 @@ class AppsManager:
     @schema_method
     async def clear_app_directory(
         self,
-        directory_name: str = Field(
+        application_id: str = Field(
             ...,
-            description="Name of the app working directory to delete (must be a direct subdirectory of the apps workspace, not a path).",
+            description="Application ID whose working directory should be deleted. Must match a subdirectory of the apps workspace (e.g. 'model-runner').",
         ),
         context: Dict[str, Any] = Field(
             ...,
@@ -1253,45 +1253,45 @@ class AppsManager:
         """
         Deletes an application working directory from the BioEngine apps workspace.
 
-        The directory is identified by name (as returned by list_app_directories).
-        Raises an error if the directory belongs to a currently running application —
-        stop the app first with stop_app() before clearing its directory.
+        The directory is identified by application_id (as returned in the 'name' field
+        of list_app_directories). Raises an error if the application is currently running —
+        stop it first with stop_app() before clearing its directory.
 
         Args:
-            directory_name: Name of the subdirectory to delete (e.g. "model-runner").
+            application_id: ID of the application whose directory should be deleted (e.g. "model-runner").
 
         Raises:
             PermissionError: If the caller is not a worker admin
-            RuntimeError: If the worker is not initialized, the directory belongs to a
-                         running app, or deletion fails
-            ValueError: If the directory does not exist or the name contains path separators
+            RuntimeError: If the worker is not initialized, the app is currently running,
+                         or deletion fails
+            ValueError: If the directory does not exist or application_id contains path separators
         """
         self._check_initialized()
         check_permissions(
             context=context,
             authorized_users=self.admin_users,
-            resource_name=f"clearing app directory '{directory_name}'",
+            resource_name=f"clearing app directory '{application_id}'",
         )
 
-        if "/" in directory_name or "\\" in directory_name or directory_name in (".", ".."):
+        if "/" in application_id or "\\" in application_id or application_id in (".", ".."):
             raise ValueError(
-                f"directory_name must be a plain directory name, not a path: '{directory_name}'"
+                f"application_id must be a plain name, not a path: '{application_id}'"
             )
 
-        target = self.app_builder.apps_workdir / directory_name
+        target = self.app_builder.apps_workdir / application_id
         if not target.exists():
             raise ValueError(
-                f"Directory '{directory_name}' does not exist under the apps workspace."
+                f"No directory found for application '{application_id}' in the apps workspace."
             )
         if not target.is_dir():
-            raise ValueError(f"'{directory_name}' is not a directory.")
+            raise ValueError(f"'{application_id}' is not a directory.")
 
-        # Refuse if a running app owns this directory
-        if directory_name in self._deployed_applications:
-            info = self._deployed_applications[directory_name]
+        # Refuse if the app is currently running
+        if application_id in self._deployed_applications:
+            info = self._deployed_applications[application_id]
             if info["is_deployed"].is_set():
                 raise RuntimeError(
-                    f"Cannot clear directory '{directory_name}': application is currently running. "
+                    f"Cannot clear directory for '{application_id}': application is currently running. "
                     "Stop it first with stop_app()."
                 )
 
@@ -1299,7 +1299,7 @@ class AppsManager:
         try:
             shutil.rmtree(target)
         except Exception as e:
-            raise RuntimeError(f"Failed to delete directory '{directory_name}': {e}")
+            raise RuntimeError(f"Failed to delete directory for '{application_id}': {e}")
 
         self.logger.info(f"Cleared app directory: {target}")
 

--- a/bioengine/worker/worker.py
+++ b/bioengine/worker/worker.py
@@ -632,6 +632,8 @@ class BioEngineWorker:
             "run_code": self.code_executor.run_code,  # Requires admin permissions
             # 🚀 Application management
             "upload_app": self.apps_manager.upload_app,  # Admin required unless workspace+hypha_token provided
+            "list_app_directories": self.apps_manager.list_app_directories,  # Requires admin permissions
+            "clear_app_directory": self.apps_manager.clear_app_directory,  # Requires admin permissions
             "list_apps": self.apps_manager.list_apps,  # Requires admin permissions
             "get_app_manifest": self.apps_manager.get_app_manifest,  # Requires admin permissions
             "delete_app": self.apps_manager.delete_app,  # Requires admin permissions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.8.14"
+version = "0.8.15"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Summary
- **`list_app_directories`** — admin-only; lists all subdirectories of the apps workspace. Each entry has `name`, `path`, `size_bytes`, and `is_running` (true when a deployed app owns that directory).
- **`clear_app_directory(directory_name)`** — admin-only; deletes the named subdirectory. Raises `RuntimeError` if the directory belongs to a currently running app (stop it first with `stop_app()`). Validates that `directory_name` is a plain name with no path separators.
- Both methods registered in the worker service alongside the existing app management methods.
- Bumps version to `0.8.15`.

## Test plan
- [ ] Merge and wait for 0.8.15 image
- [ ] `list_app_directories()` returns entries for deployed app dirs with correct `is_running` flag
- [ ] `clear_app_directory` on a stopped app deletes the directory
- [ ] `clear_app_directory` on a running app raises `RuntimeError`
- [ ] `clear_app_directory` with a path-traversal name raises `ValueError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)