### PR TITLE
fix(slurm): make slurm mode work and cluster-agnostic

### DIFF
--- a/apps/gpu-test/gpu_test_deployment.py
+++ b/apps/gpu-test/gpu_test_deployment.py
@@ -1,0 +1,77 @@
+"""Minimal GPU sanity-check deployment for BioEngine SLURM mode validation.
+
+Requests 1 GPU per replica and exposes two methods:
+- `ping`: liveness probe; returns a small dict so the deployment can be tested without GPU calls.
+- `gpu_info`: shells out to `nvidia-smi -L` inside the replica and reports
+  `CUDA_VISIBLE_DEVICES`. No heavy pip deps — uses only the stdlib so the
+  runtime env builds in seconds.
+"""
+
+import logging
+import os
+import subprocess
+import time
+from typing import Any, Dict, List
+
+from hypha_rpc.utils.schema import schema_method
+from ray import serve
+
+logger = logging.getLogger("ray.serve")
+
+
+@serve.deployment(
+    ray_actor_options={
+        "num_cpus": 1,
+        "num_gpus": 1,
+        "memory": 1 * 1024**3,
+        "runtime_env": {},
+    }
+)
+class GpuTest:
+    def __init__(self) -> None:
+        self.start_time = time.time()
+
+    @schema_method
+    async def ping(self) -> Dict[str, Any]:
+        """Cheap liveness probe; does not invoke nvidia-smi."""
+        return {
+            "status": "ok",
+            "uptime": time.time() - self.start_time,
+            "cuda_visible_devices": os.environ.get("CUDA_VISIBLE_DEVICES"),
+        }
+
+    @schema_method
+    async def gpu_info(self) -> Dict[str, Any]:
+        """Run `nvidia-smi -L` inside the replica and report visible GPUs.
+
+        Returns:
+            {
+                "cuda_visible_devices": str | None,
+                "nvidia_smi_list": list of strings (one per visible device),
+                "returncode": int,
+                "stderr": str (empty on success),
+            }
+        """
+        try:
+            proc = subprocess.run(
+                ["nvidia-smi", "-L"],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+            devices: List[str] = [
+                line.strip() for line in proc.stdout.splitlines() if line.strip()
+            ]
+            return {
+                "cuda_visible_devices": os.environ.get("CUDA_VISIBLE_DEVICES"),
+                "nvidia_smi_list": devices,
+                "returncode": proc.returncode,
+                "stderr": proc.stderr.strip(),
+            }
+        except FileNotFoundError:
+            return {
+                "cuda_visible_devices": os.environ.get("CUDA_VISIBLE_DEVICES"),
+                "nvidia_smi_list": [],
+                "returncode": -1,
+                "stderr": "nvidia-smi not found on PATH inside the replica",
+            }

--- a/apps/gpu-test/manifest.yaml
+++ b/apps/gpu-test/manifest.yaml
@@ -1,0 +1,16 @@
+name: GPU Test
+id: gpu-test
+id_emoji: '🎮'
+description: Minimal GPU sanity-check app — calls nvidia-smi on a Ray Serve replica with 1 GPU and reports CUDA_VISIBLE_DEVICES.
+type: ray-serve
+format_version: 0.5.0
+version: 1.0.0
+authors:
+  - {name: Nils Mechtel, affiliation: KTH, github_user: nilsmechtel}
+maintainers: [nilsmechtel]
+license: MIT
+tags: [test, bioengine, gpu]
+deployments:
+  - gpu_test_deployment:GpuTest
+authorized_users:
+  - "*"

--- a/bioengine/cluster/ray_cluster.py
+++ b/bioengine/cluster/ray_cluster.py
@@ -88,6 +88,8 @@ class RayCluster:
         default_mem_in_gb_per_cpu: int = 16,
         default_time_limit: str = "4:00:00",
         further_slurm_args: Optional[List[str]] = None,
+        gpu_slurm_flag: str = "--gpus={n}",
+        further_apptainer_args: Optional[List[str]] = None,
         # Autoscaling configuration parameters
         min_workers: int = 0,
         max_workers: int = 4,
@@ -127,6 +129,11 @@ class RayCluster:
             default_mem_in_gb_per_cpu: Default memory per CPU in GB. Default 16.
             default_time_limit: Default SLURM job time limit. Default '4:00:00'.
             further_slurm_args: Additional SLURM arguments for job submission.
+            gpu_slurm_flag: Template for the GPU sbatch directive (default
+                "--gpus={n}"). Use "--gres=gpu:{n}" on clusters that require gres,
+                or "" to omit and supply via ``further_slurm_args``.
+            further_apptainer_args: Extra CLI flags forwarded to ``apptainer exec``
+                inside each SLURM worker job (e.g. additional ``--bind`` mounts).
             min_workers: Minimum number of workers for autoscaling. Default 0.
             max_workers: Maximum number of workers for autoscaling. Default 4.
             scale_up_cooldown_seconds: Cooldown between scale-up operations. Default 60.
@@ -249,6 +256,8 @@ class RayCluster:
                         "default_mem_in_gb_per_cpu": int(default_mem_in_gb_per_cpu),
                         "default_time_limit": str(default_time_limit),
                         "further_slurm_args": further_slurm_args or [],
+                        "gpu_slurm_flag": str(gpu_slurm_flag),
+                        "further_apptainer_args": further_apptainer_args or [],
                         "min_workers": int(min_workers),
                         "max_workers": int(max_workers),
                         "scale_up_cooldown_seconds": int(scale_up_cooldown_seconds),

--- a/bioengine/cluster/slurm_workers.py
+++ b/bioengine/cluster/slurm_workers.py
@@ -50,6 +50,8 @@ class SlurmWorkers:
         default_mem_in_gb_per_cpu: int = 16,
         default_time_limit: str = "4:00:00",
         further_slurm_args: Optional[List[str]] = None,
+        gpu_slurm_flag: str = "--gpus={n}",
+        further_apptainer_args: Optional[List[str]] = None,
         # Autoscaling configuration parameters
         min_workers: int = 0,
         max_workers: int = 4,
@@ -73,6 +75,17 @@ class SlurmWorkers:
             default_mem_in_gb_per_cpu: Default memory (GB) to allocate per CPU
             default_time_limit: Default SLURM job time limit (HH:MM:SS format)
             further_slurm_args: Additional SLURM arguments to include in job submissions
+                (e.g. ["--account=my-acct", "--partition=gpu", "-C", "thin"]).
+            gpu_slurm_flag: Template for the SLURM GPU directive. The literal token
+                "{n}" is replaced with the requested GPU count. Common values:
+                "--gpus={n}" (default; Berzelius, generic clusters) or
+                "--gres=gpu:{n}" (clusters that require the gres syntax). Set to an
+                empty string to omit the directive (e.g. when GPUs are requested via
+                ``further_slurm_args``).
+            further_apptainer_args: Additional CLI flags passed to ``apptainer exec``
+                between the built-in flags and the container image. Use for extra
+                bind mounts (e.g. ["--bind", "/proj/aicell:/proj/aicell"]) or to
+                forward host env vars.
             min_workers: Minimum number of workers to maintain
             max_workers: Maximum number of workers allowed
             scale_up_cooldown_seconds: Cooldown period in seconds between scale-ups
@@ -83,7 +96,8 @@ class SlurmWorkers:
             debug: Enable debug logging
 
         Raises:
-            ValueError: If worker_workspace_dir is None
+            ValueError: If worker_workspace_dir is None, or if gpu_slurm_flag is
+                non-empty but does not contain the "{n}" placeholder.
         """
         # Set up logging
         self.logger = create_logger(
@@ -112,6 +126,15 @@ class SlurmWorkers:
         self.default_mem_in_gb_per_cpu = default_mem_in_gb_per_cpu
         self.default_time_limit = default_time_limit
         self.further_slurm_args = further_slurm_args if further_slurm_args else []
+        if gpu_slurm_flag and "{n}" not in gpu_slurm_flag:
+            raise ValueError(
+                "gpu_slurm_flag must be empty or contain the '{n}' placeholder "
+                f"(got: {gpu_slurm_flag!r})"
+            )
+        self.gpu_slurm_flag = gpu_slurm_flag
+        self.further_apptainer_args = (
+            further_apptainer_args if further_apptainer_args else []
+        )
 
         # Autoscaling configuration parameters
         self.min_workers = min_workers
@@ -135,6 +158,10 @@ class SlurmWorkers:
         time_limit: str,
         further_slurm_args: List[str],
     ) -> str:
+        # Ray reports resources as floats; sbatch directives need integers.
+        num_gpus = int(num_gpus)
+        num_cpus = int(num_cpus)
+        mem_in_gb_per_cpu = max(1, int(mem_in_gb_per_cpu))
         """
         Create a SLURM batch script for launching a Ray worker in a container.
 
@@ -156,17 +183,23 @@ class SlurmWorkers:
         """
         try:
             # Define the apptainer command with the Ray worker command
-            apptainer_cmd = (
-                "apptainer exec "
-                "--nv "
-                "--cleanenv "
-                "--env=SLURM_JOB_ID='${SLURM_JOB_ID}' "
-                "--pwd /app "
-                f"--bind {self.worker_workspace_dir}:${{HOME}}/.bioengine"
-            )
+            apptainer_args = [
+                "apptainer exec",
+                "--nv",
+                "--cleanenv",
+                "--env=SLURM_JOB_ID='${SLURM_JOB_ID}'",
+                "--pwd /app",
+                f"--bind {self.worker_workspace_dir}:${{HOME}}/.bioengine",
+            ]
+            apptainer_args.extend(arg for arg in self.further_apptainer_args if arg)
+            apptainer_cmd = " ".join(apptainer_args)
             self.logger.info(
                 f"Binding workspace directory '{self.worker_workspace_dir}' to container directory '{os.environ['HOME']}/.bioengine'"
             )
+            if self.further_apptainer_args:
+                self.logger.info(
+                    f"Additional apptainer args: {self.further_apptainer_args}"
+                )
 
             # Define the Ray worker command that will run inside the container and add it to the command
             ray_worker_cmd = (
@@ -189,12 +222,19 @@ class SlurmWorkers:
                 else ""
             )
 
+            # Optional GPU directive — some clusters use "--gres=gpu:N" instead of "--gpus=N"
+            gpu_directive = (
+                f"#SBATCH {self.gpu_slurm_flag.format(n=num_gpus)}"
+                if self.gpu_slurm_flag and num_gpus > 0
+                else ""
+            )
+
             # Define content of batch script with SLURM directives
             batch_script = f"""#!/bin/bash
             #SBATCH --job-name={self.job_name}
             #SBATCH --ntasks=1
             #SBATCH --nodes=1
-            #SBATCH --gpus={num_gpus}
+            {gpu_directive}
             #SBATCH --cpus-per-task={num_cpus}
             #SBATCH --mem-per-cpu={mem_in_gb_per_cpu}G
             #SBATCH --time={time_limit}
@@ -286,6 +326,9 @@ class SlurmWorkers:
 
             if proc.returncode != 0:
                 error_msg = stderr.decode() if stderr else "Unknown error"
+                self.logger.error(
+                    f"sbatch returned exit {proc.returncode}: {error_msg.strip()}"
+                )
                 raise subprocess.CalledProcessError(
                     proc.returncode, "sbatch", stderr=error_msg
                 )
@@ -551,10 +594,12 @@ class SlurmWorkers:
 
                 # Check if the worker node has already been added to the Ray cluster
                 cluster_state = (
-                    await self.ray_cluster.cluster_state_handle.get_state.remote()
+                    await self.ray_cluster.proxy_actor_handle.get_cluster_state.remote()
                 )
-                for node_id, node_resources in cluster_state["nodes"].items():
+                node_id = None
+                for candidate_id, node_resources in cluster_state["nodes"].items():
                     if node_resources["slurm_job_id"] == submitted_job_id:
+                        node_id = candidate_id
                         self.logger.info(
                             f"Worker node with ID '{node_id}' is now running in the Ray cluster"
                         )
@@ -566,11 +611,11 @@ class SlurmWorkers:
         except asyncio.CancelledError:
             self.logger.info("Worker creation task was cancelled")
             if submitted_job_id:
-                self._cancel_jobs([submitted_job_id])
+                await self._cancel_jobs([submitted_job_id])
         except Exception as e:
             self.logger.error(f"Error starting worker: {e}")
             if submitted_job_id:
-                self._cancel_jobs([submitted_job_id])
+                await self._cancel_jobs([submitted_job_id])
         finally:
             self.worker_creation_task = None
 
@@ -670,22 +715,26 @@ class SlurmWorkers:
         if not can_scale_up:
             return
 
-        # Get the required resources
+        # Get the required resources (some pending items — e.g. jobs — do not
+        # carry a `required_resources` field, so probe each candidate).
         required_resources = None
-        for resource_type, pending_resources in self.ray_cluster.status["cluster"][
-            "pending_resources"
-        ].items():
-            if not pending_resources or resource_type not in [
-                "actors",
-                "jobs",
-                "tasks",
-            ]:
-                continue
-            required_resources = pending_resources[-1]["required_resources"]
-            break
+        for resource_type in ("actors", "tasks", "jobs"):
+            pending_items = self.ray_cluster.status["cluster"][
+                "pending_resources"
+            ].get(resource_type, [])
+            for item in reversed(pending_items):
+                candidate = item.get("required_resources") if item else None
+                if candidate:
+                    required_resources = candidate
+                    break
+            if required_resources:
+                break
         if not required_resources:
-            self.logger.error("No pending resources found, skipping scale up")
-            return
+            self.logger.info(
+                "No pending resources with explicit requirements found; "
+                "scaling up with defaults."
+            )
+            required_resources = {}
 
         num_cpus = required_resources.get("CPU", 1)
         num_gpus = required_resources.get("GPU", 0)
@@ -729,18 +778,15 @@ class SlurmWorkers:
         A node is considered idle if it has no active CPU or GPU usage.
 
         Args:
-            node_resources: Dictionary containing node resource information with keys
-                      'total_cpu', 'available_cpu', 'total_gpu', 'available_gpu'
+            node_resources: Dictionary containing node resource information with
+                keys 'total_cpu', 'used_cpu', 'total_gpu', 'used_gpu'
+                (as produced by ``BioEngineProxyActor.get_cluster_state``).
 
         Returns:
             True if the node is completely idle (no used CPUs or GPUs), False otherwise
         """
-        used_cpus = node_resources["total_cpu"] - node_resources["available_cpu"]
-        # GPU nodes
-        if node_resources["total_gpu"] > 0:
-            used_gpus = node_resources["total_gpu"] - node_resources["available_gpu"]
-        else:
-            used_gpus = 0
+        used_cpus = node_resources["used_cpu"]
+        used_gpus = node_resources["used_gpu"] if node_resources["total_gpu"] > 0 else 0
 
         # Node is idle if no GPUs or CPUs are used
         return used_gpus == 0 and used_cpus == 0

--- a/bioengine/cluster/slurm_workers.py
+++ b/bioengine/cluster/slurm_workers.py
@@ -546,10 +546,12 @@ class SlurmWorkers:
         try:
             submitted_job_id = None
 
-            # Set default values if not provided
-            num_gpus = num_gpus if num_gpus is not None else self.default_num_gpus
-            num_cpus = num_cpus if num_cpus is not None else self.default_num_cpus
-            mem_in_gb_per_cpu = (
+            # Set default values if not provided. Ray reports resources as
+            # floats (e.g. 1.0); coerce here so log lines, the sbatch GPU
+            # directive, and downstream consumers all see plain ints.
+            num_gpus = int(num_gpus if num_gpus is not None else self.default_num_gpus)
+            num_cpus = int(num_cpus if num_cpus is not None else self.default_num_cpus)
+            mem_in_gb_per_cpu = int(
                 mem_in_gb_per_cpu
                 if mem_in_gb_per_cpu is not None
                 else self.default_mem_in_gb_per_cpu

--- a/bioengine/utils/network.py
+++ b/bioengine/utils/network.py
@@ -1,17 +1,74 @@
+import ipaddress
 import socket
+import struct
 from copy import copy
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
+
+
+def _enumerate_ipv4_addresses() -> List[str]:
+    """Enumerate IPv4 addresses bound to the host's network interfaces.
+
+    Uses ``socket.if_nameindex`` + the ``SIOCGIFADDR`` ioctl, which works
+    inside minimal Linux containers (no ``/usr/bin/ip`` required). On
+    non-Linux platforms (or if ``fcntl`` is unavailable) returns an empty
+    list and the caller falls back to the legacy UDP-connect trick.
+    """
+    try:
+        import fcntl  # Linux/Unix only
+    except ImportError:
+        return []
+    if not hasattr(socket, "if_nameindex"):
+        return []
+
+    addresses: List[str] = []
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        for _, name in socket.if_nameindex():
+            if name == "lo":
+                continue
+            try:
+                packed = fcntl.ioctl(
+                    sock.fileno(),
+                    0x8915,  # SIOCGIFADDR
+                    struct.pack("256s", name[:15].encode()),
+                )
+                addr = socket.inet_ntoa(packed[20:24])
+            except OSError:
+                continue
+            if addr == "127.0.0.1":
+                continue
+            addresses.append(addr)
+    finally:
+        sock.close()
+    return addresses
 
 
 def get_internal_ip() -> str:
     """
-    Get the internal IP address of the system (cross-platform).
+    Get the cluster-internal IPv4 address of the host.
 
-    Works on Linux, macOS, and Windows using the socket module only.
+    On multi-homed hosts (e.g. HPC login nodes with both a public network
+    and a private compute network) prefer the RFC 1918 private address that
+    other cluster nodes can route to. Falls back to the legacy
+    ``connect-to-8.8.8.8`` trick.
 
     Returns:
-        The internal IP address as a string.
+        The internal IPv4 address as a string.
     """
+    addresses = _enumerate_ipv4_addresses()
+    if addresses:
+        private = [a for a in addresses if ipaddress.IPv4Address(a).is_private]
+        if private:
+            # Prefer 10.x and 172.16-31.x over 192.168.x (compute clusters
+            # typically use the larger private blocks).
+            private.sort(
+                key=lambda a: 0 if not a.startswith("192.168.") else 1
+            )
+            return private[0]
+        return addresses[0]
+
+    # Fallback: open a UDP socket to a public address; the kernel picks the
+    # source IP via the routing table.
     with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
         s.connect(("8.8.8.8", 80))  # No data is sent
         return s.getsockname()[0]

--- a/bioengine/worker/__main__.py
+++ b/bioengine/worker/__main__.py
@@ -369,6 +369,24 @@ For detailed documentation, visit: https://github.com/aicell-lab/bioengine
         help="Additional SLURM sbatch arguments for specialized cluster configurations. "
         'Example: "--partition=gpu" "--qos=high-priority"',
     )
+    slurm_job_group.add_argument(
+        "--gpu-slurm-flag",
+        type=str,
+        metavar="TEMPLATE",
+        help="Template for the GPU sbatch directive. The token '{n}' is replaced "
+        "with the requested GPU count. Default: '--gpus={n}'. Use "
+        "'--gres=gpu:{n}' on clusters that require gres syntax. Pass an empty "
+        "string to omit the directive (e.g. when GPUs are requested via "
+        "--further-slurm-args).",
+    )
+    slurm_job_group.add_argument(
+        "--further-apptainer-args",
+        type=str,
+        nargs="+",
+        metavar="ARG",
+        help="Additional CLI flags forwarded to 'apptainer exec' inside each "
+        'SLURM worker job. Example: "--bind" "/proj/aicell:/proj/aicell".',
+    )
 
     # Ray autoscaling configuration options
     ray_autoscaling_group = parser.add_argument_group(

--- a/bioengine/worker/__main__.py
+++ b/bioengine/worker/__main__.py
@@ -48,6 +48,7 @@ License: MIT
 import argparse
 import asyncio
 import json
+import shlex
 import sys
 from typing import Dict
 
@@ -364,10 +365,10 @@ For detailed documentation, visit: https://github.com/aicell-lab/bioengine
     slurm_job_group.add_argument(
         "--further-slurm-args",
         type=str,
-        nargs="+",
-        metavar="ARG",
-        help="Additional SLURM sbatch arguments for specialized cluster configurations. "
-        'Example: "--partition=gpu" "--qos=high-priority"',
+        metavar="ARGS",
+        help="Additional SLURM sbatch arguments for specialized cluster configurations, "
+        "passed as a single quoted, shell-style string. "
+        'Example: --further-slurm-args "--partition=gpu --qos=high-priority"',
     )
     slurm_job_group.add_argument(
         "--gpu-slurm-flag",
@@ -382,10 +383,10 @@ For detailed documentation, visit: https://github.com/aicell-lab/bioengine
     slurm_job_group.add_argument(
         "--further-apptainer-args",
         type=str,
-        nargs="+",
-        metavar="ARG",
+        metavar="ARGS",
         help="Additional CLI flags forwarded to 'apptainer exec' inside each "
-        'SLURM worker job. Example: "--bind" "/proj/aicell:/proj/aicell".',
+        "SLURM worker job, passed as a single quoted, shell-style string. "
+        'Example: --further-apptainer-args "--bind /proj/aicell:/proj/aicell".',
     )
 
     # Ray autoscaling configuration options
@@ -543,6 +544,21 @@ def read_startup_applications(
     return group_configs
 
 
+def split_slurm_string_args(group_configs):
+    """Split shell-style string args into List[str] for SlurmWorkers.
+
+    ``--further-slurm-args`` and ``--further-apptainer-args`` take a single
+    quoted string on the CLI (argparse rejects ``nargs="+"`` values that
+    look like flags). Split here so downstream code keeps its List[str] API.
+    """
+    slurm_options = group_configs.get("SLURM Job Options", {})
+    for key in ("further_slurm_args", "further_apptainer_args"):
+        raw = slurm_options.get(key)
+        if isinstance(raw, str):
+            slurm_options[key] = shlex.split(raw)
+    return group_configs
+
+
 async def main(group_configs):
     """Main function to initialize and register BioEngine worker"""
     # Create BioEngine worker instance
@@ -572,6 +588,9 @@ if __name__ == "__main__":
 
         # Process startup applications if provided
         group_configs = read_startup_applications(group_configs)
+
+        # Split shell-style SLURM args into List[str]
+        group_configs = split_slurm_string_args(group_configs)
 
         # Start the main worker process
         asyncio.run(main(group_configs))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.8.17"
+version = "0.8.18"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [

--- a/scripts/start_hpc_worker.sh
+++ b/scripts/start_hpc_worker.sh
@@ -275,7 +275,7 @@ fi
 cleanup() {
     # TODO: try to prevent SIGINT and SIGTERM from being sent to the container, then call service.cleanup() using http API
     echo "Making sure the Ray head node is stopped..."
-    $CONTAINER_CMD exec "$IMAGE_PATH" ray stop --force
+    $CONTAINER_CMD exec "$IMAGE" ray stop --force
 
     # If running in SLURM mode, cancel any remaining SLURM jobs
     if [[ "$MODE" == "slurm" ]]; then

--- a/scripts/start_hpc_worker.sh
+++ b/scripts/start_hpc_worker.sh
@@ -10,7 +10,7 @@ get_version_from_pyproject() {
 
 # Get version from GitHub API for remote execution
 get_version_from_github() {
-    local github_url="https://raw.githubusercontent.com/aicell-lab/bioengine-worker/main/pyproject.toml"
+    local github_url="https://raw.githubusercontent.com/aicell-lab/bioengine/main/pyproject.toml"
     if command -v curl >/dev/null 2>&1; then
         curl -s "$github_url" | grep -E '^version\s*=' | sed -E 's/version\s*=\s*"(.*)"/\1/' | head -1
     elif command -v wget >/dev/null 2>&1; then
@@ -33,7 +33,7 @@ if [[ -z "$VERSION" ]]; then
     if [[ -z "$VERSION" ]]; then
         echo "❌ Error: Could not determine version from local pyproject.toml or GitHub."
         echo "   This script requires either:"
-        echo "   1. Running from a cloned bioengine-worker repository, or"
+        echo "   1. Running from a cloned bioengine repository, or"
         echo "   2. Internet access to fetch version from GitHub"
         exit 1
     else
@@ -43,7 +43,7 @@ else
     echo "✅ Found version $VERSION from local pyproject.toml"
 fi
 
-DEFAULT_IMAGE="ghcr.io/aicell-lab/bioengine-worker:$VERSION"
+DEFAULT_IMAGE="ghcr.io/aicell-lab/bioengine:$VERSION"
 WORKING_DIR=$(pwd)
 
 # Save all arguments
@@ -141,9 +141,12 @@ add_env() {
 # Check if the mode is set to something else than "slurm"
 MODE=$(get_arg_value "--mode" "slurm")
 if [[ "$MODE" != "slurm" ]]; then
-    echo "Error: Invalid mode '$MODE'. For modes other than 'slurm', please run the 'bioengine-worker' container directly. Check out the configuration wizard at https://bioimage.io/#/bioengine."
+    echo "Error: Invalid mode '$MODE'. For modes other than 'slurm', please run the 'bioengine' container directly. Check out the configuration wizard at https://bioimage.io/#/bioengine."
     exit 1
 fi
+
+# Always pass --mode slurm to the worker (the bioengine CLI requires it)
+set_arg_value "--mode" "$MODE"
 
 # === Load BioEngine image ===
 


### PR DESCRIPTION
Slurm mode hadn't been touched in a long time. This PR fixes the bugs that prevented autoscaling, makes the per-cluster knobs configurable, and patches the additional issues that surfaced while wiring the deployment wizard end-to-end on Berzelius.

## Autoscaling bug fixes

- `_add_worker` referenced `ray_cluster.cluster_state_handle.get_state` — the proxy actor attribute is `proxy_actor_handle.get_cluster_state`. Scale-up hung forever waiting for a node that never matched.
- `_check_is_idle` read `available_cpu` / `available_gpu` from `node_resources`, but `BioEngineProxyActor.get_cluster_state` outputs `used_cpu` / `used_gpu`. Scale-down could never identify an idle worker.
- `_cancel_jobs` was awaited as a sync call in two exception handlers; the coroutine was discarded silently.
- `_check_scale_up` `KeyError`'d on pending items without `required_resources` (e.g. job submissions).
- Ray reports resources as floats (`1.0`); the sbatch directive `#SBATCH --gpus=1.0` is rejected by SLURM ("Requested node configuration is not available"). Coerce to `int` once at the top of `_add_worker` so the log line, the sbatch directive, and every downstream consumer see plain ints.
- `sbatch` stderr was hidden behind `subprocess.CalledProcessError.__str__`, surfacing only the exit code. Log the stderr text on failure.

## Cluster-agnostic SLURM options

- `gpu_slurm_flag` (default `--gpus={n}`) — clusters that require gres syntax can pass `--gres=gpu:{n}`. Empty string omits the directive.
- `further_apptainer_args` — extra flags forwarded to `apptainer exec`, primarily for additional `--bind` mounts (e.g. `/proj/aicell` on Berzelius).

Both options are wired through `RayCluster` and the `bioengine.worker` CLI.

## CLI / script bugs that blocked the wizard's HPC flow

- `--further-slurm-args` and `--further-apptainer-args` were declared with `nargs="+"`; argparse refuses values starting with `--`, so `--further-apptainer-args "--bind /proj/x:/proj/x"` errored with `expected at least one argument`. Both now take a single shell-style string and are `shlex.split()` in `__main__` before being passed to `SlurmWorkers` (which still receives `List[str]`).
- `scripts/start_hpc_worker.sh` validated `--mode slurm` but never added it back to `BIOENGINE_WORKER_ARGS`, so the CLI errored with `required: --mode`. Add `set_arg_value "--mode" "$MODE"` after validation.
- The script's cleanup trap exec'd `"$IMAGE_PATH"` but the script only ever sets `$IMAGE`. Every shutdown emitted `FATAL: "ray": executable file not found in $PATH`. Now uses `$IMAGE` so `ray stop --force` actually runs inside the container.
- Stale `aicell-lab/bioengine-worker` references left over after the repo rename: GitHub URL for the remote version lookup, default GHCR image name, error message.

## Multi-homed IP detection (HPC login nodes)

`get_internal_ip()` used the legacy `connect-to-8.8.8.8` UDP-socket trick, which picks the source IP of the route to the public internet — on Berzelius that's `130.236.x.x`, which compute nodes cannot reach (they live on `10.81.x.x`). Worker SLURM jobs failed with `Connection refused` at `ray start --address=130.236.x.x:6379`.

Now enumerates host interfaces via `socket.if_nameindex` + the `SIOCGIFADDR` ioctl (works inside the minimal Apptainer container without `/usr/bin/ip`) and prefers RFC 1918 private addresses. Falls back to the legacy trick when enumeration yields nothing.

## Verification on Berzelius (NSC, Sweden)

Followed the deployment wizard's HPC flow verbatim:

1. `mkdir -p /proj/aicell/users/x_nilme/.bioengine`
2. `export HYPHA_TOKEN=…`
3. `bash scripts/start_hpc_worker.sh --workspace-dir … --max-workers 2 --default-num-gpus 1 --default-num-cpus 4 --further-apptainer-args "--bind /proj/aicell:/proj/aicell" --worker-name wizard-hpc-test`

Results:

- Head boots inside Apptainer on `10.81.254.11:6379` (cluster-internal IP).
- Three concurrent `gpu-test` deployments (each `num_gpus=1`) → exactly **2** sbatch jobs submitted (cap held), 2 apps got A100-SXM4-80GB replicas and ran `gpu_info()`, 3rd app stayed pending with the expected Ray Serve "no GPU resources available" warning.
- 60s idle threshold reaped each worker; SIGINT shutdown ran clean (`ray stop --force` succeeds, all SLURM jobs scancel'd, no `FATAL` lines).
- `SlurmWorkers` info log now reads `Resources: 1 GPU(s), 4 CPU(s), 16G mem/CPU` (int form).
