### PR TITLE
ci(docker-publish): also check legacy bioengine-worker tags for version comparison

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -54,8 +54,9 @@ jobs:
         echo "🔍 Fetching tags for $IMAGE..."
 
         if ! skopeo list-tags "$IMAGE" > /dev/null 2>&1; then
-           echo "❌ Image not found or no tags. Cannot determine previous version."
-           exit 1
+           echo "ℹ️ No image in registry yet — treating as first publish. Skipping version comparison."
+           echo "FIRST_PUBLISH=true" >> $GITHUB_ENV
+           exit 0
         fi
 
         TAGS=$(skopeo list-tags "$IMAGE" | jq -r '.Tags[]')
@@ -64,8 +65,9 @@ jobs:
         LATEST_VERSION=$(echo "$TAGS" | grep -v "latest" | sort -V | tail -n1)
 
         if [ -z "$LATEST_VERSION" ]; then
-           echo "❌ No valid version tags found."
-           exit 1
+           echo "ℹ️ No valid version tags found — treating as first publish. Skipping version comparison."
+           echo "FIRST_PUBLISH=true" >> $GITHUB_ENV
+           exit 0
         fi
 
         echo "📦 Latest registry version: $LATEST_VERSION"
@@ -73,6 +75,10 @@ jobs:
 
     - name: Check that version is updated and newer
       run: |
+        if [ "${FIRST_PUBLISH:-false}" = "true" ]; then
+          echo "ℹ️ First publish for this image — nothing to compare against."
+          exit 0
+        fi
         echo "📦 Previous version: $PREVIOUS_VERSION"
         echo "📦 Current version:  $VERSION"
         if [ "$VERSION" = "$PREVIOUS_VERSION" ]; then

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -50,35 +50,41 @@ jobs:
             sudo apt-get update && sudo apt-get install -y skopeo
         fi
 
-        IMAGE="docker://ghcr.io/${{ github.repository }}"
-        echo "🔍 Fetching tags for $IMAGE..."
+        # Check both the current image and the legacy bioengine-worker
+        # name (the repo was renamed; old releases live there).
+        IMAGES=(
+          "docker://ghcr.io/${{ github.repository }}"
+          "docker://ghcr.io/aicell-lab/bioengine-worker"
+        )
 
-        if ! skopeo list-tags "$IMAGE" > /dev/null 2>&1; then
-           echo "ℹ️ No image in registry yet — treating as first publish. Skipping version comparison."
-           echo "FIRST_PUBLISH=true" >> $GITHUB_ENV
-           exit 0
-        fi
+        ALL_TAGS=""
+        for IMAGE in "${IMAGES[@]}"; do
+          echo "🔍 Fetching tags for $IMAGE..."
+          if skopeo list-tags "$IMAGE" > /dev/null 2>&1; then
+            TAGS=$(skopeo list-tags "$IMAGE" | jq -r '.Tags[]')
+            echo "   found $(echo "$TAGS" | wc -l) tag(s)"
+            ALL_TAGS+=$'\n'"$TAGS"
+          else
+            echo "   not found in registry (skipping)"
+          fi
+        done
 
-        TAGS=$(skopeo list-tags "$IMAGE" | jq -r '.Tags[]')
-
-        # Filter out 'latest' and sort by version
-        LATEST_VERSION=$(echo "$TAGS" | grep -v "latest" | sort -V | tail -n1)
+        # Filter out 'latest' and any non-version tags, then sort
+        LATEST_VERSION=$(echo "$ALL_TAGS" \
+          | grep -E '^[0-9]+\.[0-9]+\.[0-9]+' \
+          | sort -V \
+          | tail -n1)
 
         if [ -z "$LATEST_VERSION" ]; then
-           echo "ℹ️ No valid version tags found — treating as first publish. Skipping version comparison."
-           echo "FIRST_PUBLISH=true" >> $GITHUB_ENV
-           exit 0
+          echo "❌ No version tags found in either registry namespace."
+          exit 1
         fi
 
-        echo "📦 Latest registry version: $LATEST_VERSION"
+        echo "📦 Latest published version (across both image names): $LATEST_VERSION"
         echo "PREVIOUS_VERSION=$LATEST_VERSION" >> $GITHUB_ENV
 
     - name: Check that version is updated and newer
       run: |
-        if [ "${FIRST_PUBLISH:-false}" = "true" ]; then
-          echo "ℹ️ First publish for this image — nothing to compare against."
-          exit 0
-        fi
         echo "📦 Previous version: $PREVIOUS_VERSION"
         echo "📦 Current version:  $VERSION"
         if [ "$VERSION" = "$PREVIOUS_VERSION" ]; then


### PR DESCRIPTION
## Summary

The last two runs of `Build and Publish Docker Images` failed at the "Get latest version from container registry" step with:

```
❌ Image not found or no tags. Cannot determine previous version.
Error: Process completed with exit code 1.
```

Reason: after the `bioengine-worker` → `bioengine` GitHub repo rename, the new GHCR namespace `ghcr.io/aicell-lab/bioengine` had no published tags. The version-comparison step treated that as fatal and bailed before any image could be built — so 0.8.17 / 0.8.18 never got published. All the existing releases (≤ 0.8.16) live under the legacy `ghcr.io/aicell-lab/bioengine-worker` namespace.

## Fix

- Fetch tags from **both** `ghcr.io/aicell-lab/bioengine` (new) and `ghcr.io/aicell-lab/bioengine-worker` (legacy), tolerating either one being absent.
- Pick the max version across the union of both tag sets.
- Tighten the version-tag filter to `^\d+\.\d+\.\d+` so `latest` and any odd manifest names are dropped uniformly.
- The strict "new version > latest published" rule is preserved across the rename — `0.8.18` still has to beat `0.8.17` published under the old name.

## Test plan

- [ ] Workflow run on this branch (via `workflow_dispatch`) reports `Latest published version (across both image names): 0.8.17` (from `bioengine-worker`) and confirms `0.8.18 > 0.8.17`.
- [ ] After merge, the next `main` push (or a manual `workflow_dispatch`) actually builds and publishes `ghcr.io/aicell-lab/bioengine:0.8.18` + `:latest`.
- [ ] A subsequent no-op bump test (e.g. local) should still fail if the version isn't strictly greater than the max of both registries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
