### PR TITLE
fix: auto-reconnect Ray Client on stale Serve handle (0.9.2)

### DIFF
--- a/bioengine/apps/manager.py
+++ b/bioengine/apps/manager.py
@@ -229,7 +229,7 @@ class AppsManager:
                 # Application ID already exists, generate a new one
                 continue
 
-            serve_status = await asyncio.to_thread(serve.status)
+            serve_status = await self.ray_cluster.call_with_reconnect(serve.status)
             if application_id not in serve_status.applications:
                 # Application ID is unique and not already deployed
                 break
@@ -403,7 +403,7 @@ class AppsManager:
             app = self._deployed_applications[application_id]["built_app"]
 
             # Run the deployment in Ray Serve with unique route prefix
-            await asyncio.to_thread(
+            await self.ray_cluster.call_with_reconnect(
                 serve.run,
                 target=app,
                 name=application_id,
@@ -433,7 +433,7 @@ class AppsManager:
                 f"Failed to deploy application '{application_id}' with error: {e}"
             )
             try:
-                serve_status = await asyncio.to_thread(serve.status)
+                serve_status = await self.ray_cluster.call_with_reconnect(serve.status)
                 application = serve_status.applications.get(application_id)
                 if application:
                     for deployment_name, deployment in application.deployments.items():
@@ -529,7 +529,7 @@ class AppsManager:
         await self._cancel_deployment_process(application_id=application_id)
 
         try:
-            await asyncio.to_thread(
+            await self.ray_cluster.call_with_reconnect(
                 serve.delete, application_id
             )  # Note: Doesn't throw an error if app doesn't exist
             self.logger.info(
@@ -840,7 +840,7 @@ class AppsManager:
 
     async def recover_deployed_applications(self) -> None:
         """Recover app tracking state for already running Ray Serve BioEngine apps."""
-        serve_status = await asyncio.to_thread(serve.status)
+        serve_status = await self.ray_cluster.call_with_reconnect(serve.status)
         recovered_count = 0
 
         for application_id, application in serve_status.applications.items():
@@ -851,7 +851,9 @@ class AppsManager:
                 continue
 
             try:
-                app_handle = await asyncio.to_thread(serve.get_app_handle, application_id)
+                app_handle = await self.ray_cluster.call_with_reconnect(
+                    serve.get_app_handle, application_id
+                )
                 app_data = await asyncio.wait_for(
                     app_handle.get_app_data.remote(), timeout=10.0
                 )
@@ -1036,7 +1038,7 @@ class AppsManager:
         try:
             # Get status of actively running deployments
             await self.ray_cluster.check_connection()
-            serve_status = await asyncio.to_thread(serve.status)
+            serve_status = await self.ray_cluster.call_with_reconnect(serve.status)
 
             for application_id in apps_to_redeploy:
                 application_info = self._deployed_applications.get(application_id)
@@ -2075,7 +2077,7 @@ class AppsManager:
 
         # Get Ray Serve status
         await self.ray_cluster.check_connection()
-        serve_status = await asyncio.to_thread(serve.status)
+        serve_status = await self.ray_cluster.call_with_reconnect(serve.status)
 
         # Iterate over applications to check
         status_tasks = [

--- a/bioengine/cluster/ray_cluster.py
+++ b/bioengine/cluster/ray_cluster.py
@@ -25,6 +25,19 @@ from bioengine.utils import (
 )
 
 
+def _is_stale_handle_error(exc: BaseException) -> bool:
+    """Detect a Ray Client stale-handle error.
+
+    When a detached actor we hold a handle for (e.g. the Ray Serve controller)
+    is restarted on the cluster side, the server no longer knows about the
+    handle registered for our gRPC session. The next remote call surfaces a
+    plain ``Exception`` whose message contains "doesn't have a handle for".
+    Ray Client does not auto-recover this; we have to reconnect to register
+    fresh handles. Match on substring because the exception type is generic.
+    """
+    return "doesn't have a handle for" in str(exc)
+
+
 class RayCluster:
     """
     Manages Ray cluster lifecycle across different deployment environments.
@@ -840,6 +853,73 @@ class RayCluster:
         if not ray.is_initialized():
             self.logger.warning(f"Ray client disconnected. Reconnecting...")
             await self._connect_to_cluster()
+
+    async def reconnect(self) -> None:
+        """Tear down the Ray Client session and re-run the connection sequence.
+
+        Re-acquires every detached actor handle the worker holds:
+        ``BioEngineProxyActor`` (re-attached via ``get_if_exists=True``), and
+        — implicitly, on the next ``serve.*`` call — the Ray Serve controller.
+        Use this when a server-side actor restart has invalidated our handles
+        (see ``_is_stale_handle_error``); Ray Client does not auto-recover.
+
+        Notes:
+            ``ray.shutdown()`` only tears down our gRPC session, not the
+            cluster, so this is safe in external-cluster mode. For
+            single-machine/SLURM modes ``ray.shutdown()`` would stop the
+            cluster itself, so reconnect is only valid when the worker is a
+            Ray Client (i.e. external-cluster mode).
+        """
+        if self.mode != "external-cluster":
+            raise RuntimeError(
+                "RayCluster.reconnect() is only safe in external-cluster mode; "
+                f"current mode is '{self.mode}'."
+            )
+
+        self.logger.warning("Reconnecting Ray Client to refresh stale handles...")
+        try:
+            await asyncio.to_thread(ray.shutdown)
+        except Exception as e:
+            self.logger.debug(f"ray.shutdown() during reconnect raised: {e}")
+        # Drop the stale proxy actor handle before re-acquiring it; otherwise
+        # callers racing against the reconnect could hold and use it.
+        self.proxy_actor_handle = None
+        await self._connect_to_cluster()
+        self.logger.info("Ray Client reconnected; handles refreshed.")
+
+    async def call_with_reconnect(self, fn, *args, **kwargs):
+        """Run a blocking Ray API call with one automatic stale-handle recovery.
+
+        Executes ``fn(*args, **kwargs)`` on a thread (Ray's public ``serve.*``
+        functions are synchronous). If the call raises a stale-handle error
+        the worker reconnects and retries once. Any other exception, or a
+        second stale-handle error after reconnect, propagates to the caller.
+
+        Args:
+            fn: A blocking callable that performs a Ray operation
+                (e.g. ``ray.serve.status``, ``ray.serve.run``,
+                ``ray.serve.delete``, ``ray.serve.get_app_handle``).
+            *args, **kwargs: Forwarded to ``fn``.
+
+        Returns:
+            Whatever ``fn`` returns.
+
+        Raises:
+            The exception ``fn`` raises if it is not a stale-handle error, or
+            if the retry after reconnect also fails.
+        """
+        try:
+            return await asyncio.to_thread(fn, *args, **kwargs)
+        except Exception as exc:
+            if not _is_stale_handle_error(exc):
+                raise
+            self.logger.warning(
+                f"Stale Ray Client handle detected calling "
+                f"{getattr(fn, '__name__', repr(fn))!r}: {exc!s}. "
+                f"Reconnecting Ray Client and retrying once."
+            )
+            await self.reconnect()
+            return await asyncio.to_thread(fn, *args, **kwargs)
 
     async def monitor_cluster(self) -> None:
         """Monitor cluster status and update worker nodes history."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.9.1"
+version = "0.9.2"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Summary

When the Ray Serve controller (or any other server-side detached actor we hold a handle for) restarts on the cluster side, the next remote call against the stale handle raises `Exception: Can't run an actor the server doesn't have a handle for`. Ray Client does not re-resolve the handle, so subsequent `serve.*` calls keep failing and the worker's view of deployed apps silently diverges from the cluster's actual state.

**Real incident (2026-05-15, TÜBİTAK external-cluster worker on `ri-scale`):** `get_app_status` errored, the worker reported 0 deployed apps in `get_status`, but the cluster was running a `model-runner` Serve application with 3 deployments and 1 V100 allocated. State stayed divergent until the pod was manually restarted.

## Changes

- `bioengine/cluster/ray_cluster.py`
  - `_is_stale_handle_error(exc)` — module-level helper, substring match on `"doesn't have a handle for"`. Single source of truth for the detection rule.
  - `RayCluster.reconnect()` — `ray.shutdown()` + `_connect_to_cluster()`. Re-acquires `BioEngineProxyActor` (via `get_if_exists=True`) and lets the next `serve.*` call attach to the fresh Serve controller. Only valid in `external-cluster` mode (single-machine / SLURM modes own the cluster, so `ray.shutdown()` there would stop the cluster itself).
  - `RayCluster.call_with_reconnect(fn, *args, **kwargs)` — runs a blocking Ray API call on a thread, catches stale-handle errors, reconnects, and retries once. Other exceptions propagate. A second stale-handle error after reconnect also propagates.

- `bioengine/apps/manager.py` — routes every `serve.status` / `serve.run` / `serve.delete` / `serve.get_app_handle` call through `call_with_reconnect`. Touched call sites: `_generate_application_id`, `_deploy_application` (run + post-deploy status), `_undeploy_application`, `recover_deployed_applications`, `monitor_applications`, `get_app_status`.

- `pyproject.toml` — version `0.9.1` → `0.9.2`.

## Out of scope

- The `BioEngineProxyActor` handle on `RayCluster.proxy_actor_handle` is used in `monitor_cluster()` and `proxy_actor` direct calls. It can in principle go stale the same way; this PR doesn't wrap those. The proxy actor is detached and reattached on every reconnect, so once any `serve.*` call triggers a reconnect, the proxy handle is also fresh — but a proxy-only stale-handle scenario without a triggering `serve.*` call would still need a worker restart. Worth a follow-up.
- `ray_cluster.stop()` still calls `serve.shutdown()` directly; that path is shutting down anyway, so retrying through reconnect doesn't help.

## Test plan

- [ ] CI: `docker-publish.yml` accepts `0.9.2 > 0.9.1` and builds the image.
- [ ] Deploy `0.9.2-ray2.54.1` overlay to the TÜBİTAK worker; verify `get_app_status` returns the running `model-runner` deployments without a pod restart.
- [ ] Manually invalidate the handle by `kill`-ing the Serve controller actor on a test cluster; verify the worker logs `Stale Ray Client handle detected ... Reconnecting Ray Client and retrying once.` and the call returns successfully.
- [ ] Existing end-to-end tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)