### PR TITLE
fix: BioEngineDatasets lazily re-resolves data server URL (0.9.3)

### DIFF
--- a/bioengine/datasets/datasets.py
+++ b/bioengine/datasets/datasets.py
@@ -54,6 +54,10 @@ class BioEngineDatasets:
         http_client (httpx.AsyncClient): HTTP client for service communication
     """
 
+    # Path of the per-host discovery file written by the data server.
+    # Class attribute so refresh() / _resolve_service_url() use the same path.
+    _CURRENT_SERVER_FILE = Path.home() / ".bioengine" / "datasets" / "bioengine_current_server"
+
     def __init__(
         self,
         data_server_url: Optional[str] = "auto",  # set to None for no data server
@@ -69,7 +73,12 @@ class BioEngineDatasets:
         authentication and logging for tracking access patterns.
 
         Args:
-            data_server_url: URL of the datasets server, or None to disable remote access
+            data_server_url: URL of the datasets server, ``"auto"`` to discover
+                via the per-host file written by the data server (default),
+                or ``None`` to disable remote access entirely. When ``"auto"``
+                and the file does not exist yet, the URL is re-resolved
+                lazily on every dataset operation, so a data server started
+                after the client is constructed will be picked up automatically.
             hypha_token: Optional default authentication token for accessing protected datasets
             chunk_cache_size_gb: Size of the in-memory LRU chunk cache for zarr data in GB.
                 All zarr stores opened by this client share one cache. Pass 0 to disable.
@@ -82,28 +91,77 @@ class BioEngineDatasets:
         self.logger.info(f"Initializing {self.__class__.__name__}")
         self.chunk_cache = ChunkCache(max_size_gb=chunk_cache_size_gb, logger=logger)
 
-        if data_server_url == "auto":
-            bioengine_dir = Path.home() / ".bioengine"
-            current_server_file = (
-                bioengine_dir / "datasets" / "bioengine_current_server"
-            )
-            try:
-                data_server_url = current_server_file.read_text().strip()
-            except FileNotFoundError:
-                data_server_url = None
-                self.logger.warning(
-                    f"No current data server found at "
-                    f"'{current_server_file}', proceeding without remote datasets"
-                )
-
+        # Remember the user's intent verbatim. "auto" stays "auto" so we can
+        # re-try the discovery file later if the data server hadn't started
+        # by the time this client was constructed.
+        self._requested_data_server_url: Optional[str] = data_server_url
         self.service_url: Optional[str] = None
         self.http_client: Optional[httpx.AsyncClient] = None
-        if data_server_url is not None:
-            self.service_url = data_server_url.rstrip("/")
-            self.http_client = httpx.AsyncClient(timeout=20)  # seconds
-            self.logger.info(f"Data server URL: {data_server_url}")
-
         self.default_token = hypha_token
+
+        # First attempt at construction. Non-fatal — a still-missing
+        # discovery file just means future operations will retry.
+        self._resolve_service_url(initial=True)
+
+    def _resolve_service_url(self, *, initial: bool = False) -> None:
+        """Lazily attach to the data server (no-op once attached).
+
+        Called at construction and at the top of every public method that
+        uses ``service_url``. The cheap path — ``service_url`` already set —
+        is a single attribute check; the slow path reads one small file.
+
+        Args:
+            initial: True when called from ``__init__``. Controls whether the
+                "discovery file not found" warning is emitted (we want one
+                warning at startup, not a fresh warning on every operation
+                for the lifetime of a client that never sees a data server).
+        """
+        if self.service_url is not None:
+            return  # already attached
+
+        requested = self._requested_data_server_url
+        if requested is None:
+            return  # caller opted out of remote datasets
+
+        if requested == "auto":
+            try:
+                requested = self._CURRENT_SERVER_FILE.read_text().strip()
+            except FileNotFoundError:
+                if initial:
+                    self.logger.warning(
+                        f"No current data server found at "
+                        f"'{self._CURRENT_SERVER_FILE}'. "
+                        f"Will retry on each dataset operation; "
+                        f"datasets will become available once the data server starts."
+                    )
+                return  # leave service_url None; next operation retries
+
+        self.service_url = requested.rstrip("/")
+        self.http_client = httpx.AsyncClient(timeout=20)  # seconds
+        self.logger.info(f"Data server URL: {self.service_url}")
+
+    async def refresh(self) -> Optional[str]:
+        """Force re-discovery of the data server URL.
+
+        Tears down the current HTTP client and re-runs the resolution that
+        ``__init__`` did. Useful when the data server has restarted on a
+        different URL, or when a caller wants to force a re-check without
+        waiting for the next dataset operation to do it lazily.
+
+        Returns:
+            The newly-resolved service URL, or ``None`` if the data server
+            is still unavailable. Callers can use the return value to decide
+            whether to proceed or wait longer.
+        """
+        if self.http_client is not None:
+            try:
+                await self.http_client.aclose()
+            except Exception as e:
+                self.logger.debug(f"Closing previous http_client raised: {e}")
+        self.service_url = None
+        self.http_client = None
+        self._resolve_service_url(initial=False)
+        return self.service_url
 
     async def set_chunk_cache_size_gb(self, gb: int) -> None:
         """
@@ -128,6 +186,7 @@ class BioEngineDatasets:
         Raises:
             RuntimeError: If the connection to the data server fails for any reason
         """
+        self._resolve_service_url()
         if self.service_url is None:
             return
 
@@ -159,6 +218,7 @@ class BioEngineDatasets:
         Raises:
             httpx.HTTPStatusError: If the request fails due to HTTP error
         """
+        self._resolve_service_url()
         if self.service_url is None:
             return {}
 
@@ -205,6 +265,7 @@ class BioEngineDatasets:
             ValueError: If the service_url is None or dataset does not exist
             httpx.HTTPStatusError: If the request fails due to HTTP error
         """
+        self._resolve_service_url()
         if self.service_url is None:
             raise ValueError(
                 f"Dataset '{dataset_id}' could not be accessed. No connection to data server."
@@ -357,6 +418,7 @@ class BioEngineDatasets:
         Returns:
             Dict with dataset_id, filename, size, and public flag.
         """
+        self._resolve_service_url()
         if self.service_url is None:
             raise ValueError("No connection to data server.")
 
@@ -399,6 +461,7 @@ class BioEngineDatasets:
         Returns:
             List of file paths relative to the save directory root.
         """
+        self._resolve_service_url()
         if self.service_url is None:
             raise ValueError("No connection to data server.")
 
@@ -442,6 +505,7 @@ class BioEngineDatasets:
         Returns:
             Raw file content as bytes.
         """
+        self._resolve_service_url()
         if self.service_url is None:
             raise ValueError("No connection to data server.")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.9.1"
+version = "0.9.3"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [

--- a/tests/test_datasets_lazy_resolution.py
+++ b/tests/test_datasets_lazy_resolution.py
@@ -1,0 +1,105 @@
+"""Unit tests for BioEngineDatasets lazy data-server discovery.
+
+Regression test for a bug where a deployment that received a BioEngineDatasets
+instance before the data server was running stayed permanently disconnected
+even after the data server wrote its discovery file. See the changelog for
+0.9.3 for the full incident.
+
+The tests do not require a running data server — they exercise only the
+client-side resolution logic by pointing `_CURRENT_SERVER_FILE` at a tmp
+path and writing / deleting it directly.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from bioengine.datasets import BioEngineDatasets
+
+
+@pytest.fixture
+def discovery_file(tmp_path, monkeypatch):
+    """Redirect the class-level discovery file path to a tmp location."""
+    path = tmp_path / "bioengine_current_server"
+    monkeypatch.setattr(BioEngineDatasets, "_CURRENT_SERVER_FILE", path)
+    return path
+
+
+def test_auto_no_file_yet_leaves_service_url_none(discovery_file):
+    """If the discovery file does not exist at construction, service_url is None."""
+    client = BioEngineDatasets(data_server_url="auto")
+    assert client.service_url is None
+    assert client.http_client is None
+
+
+@pytest.mark.asyncio
+async def test_list_datasets_returns_empty_when_no_server_yet(discovery_file):
+    """Without a data server, list_datasets returns {} (current behaviour preserved)."""
+    client = BioEngineDatasets(data_server_url="auto")
+    assert await client.list_datasets() == {}
+
+
+@pytest.mark.asyncio
+async def test_list_datasets_resolves_after_file_appears(discovery_file):
+    """The fix: list_datasets re-reads the discovery file when service_url is None."""
+    client = BioEngineDatasets(data_server_url="auto")
+    assert client.service_url is None
+
+    # Data server "starts" after the client was constructed and writes its URL.
+    discovery_file.parent.mkdir(parents=True, exist_ok=True)
+    discovery_file.write_text("http://example.invalid:9000\n")
+
+    # Force resolution without making a real HTTP request by triggering the
+    # lazy path directly; list_datasets() would also do this but then it
+    # would hit the network. We assert the resolution side-effect.
+    client._resolve_service_url()
+    assert client.service_url == "http://example.invalid:9000"
+    assert client.http_client is not None
+
+
+@pytest.mark.asyncio
+async def test_refresh_picks_up_changed_url(discovery_file):
+    """refresh() drops the old client and re-resolves from the discovery file."""
+    discovery_file.parent.mkdir(parents=True, exist_ok=True)
+    discovery_file.write_text("http://first.invalid:9000")
+
+    client = BioEngineDatasets(data_server_url="auto")
+    assert client.service_url == "http://first.invalid:9000"
+    first_client = client.http_client
+
+    discovery_file.write_text("http://second.invalid:9001")
+    new_url = await client.refresh()
+    assert new_url == "http://second.invalid:9001"
+    assert client.service_url == "http://second.invalid:9001"
+    # New httpx.AsyncClient created; old one is closed and replaced.
+    assert client.http_client is not first_client
+
+
+@pytest.mark.asyncio
+async def test_explicit_none_stays_disabled_after_resolve(discovery_file):
+    """data_server_url=None means "disable remote" — never auto-discover."""
+    discovery_file.parent.mkdir(parents=True, exist_ok=True)
+    discovery_file.write_text("http://example.invalid:9000")
+
+    client = BioEngineDatasets(data_server_url=None)
+    assert client.service_url is None
+
+    # Even with the discovery file present, calling list_datasets does not
+    # opt the client into remote access; the user said None and meant None.
+    assert await client.list_datasets() == {}
+    assert client.service_url is None
+
+
+@pytest.mark.asyncio
+async def test_explicit_url_does_not_re_resolve(discovery_file):
+    """A literal URL passed at construction is honored; subsequent calls don't re-read the file."""
+    discovery_file.parent.mkdir(parents=True, exist_ok=True)
+    discovery_file.write_text("http://discovered.invalid:9000")
+
+    client = BioEngineDatasets(data_server_url="http://explicit.invalid:9000")
+    assert client.service_url == "http://explicit.invalid:9000"
+
+    # Even after the discovery file changes, the client keeps the explicit URL.
+    discovery_file.write_text("http://changed.invalid:9001")
+    client._resolve_service_url()
+    assert client.service_url == "http://explicit.invalid:9000"


### PR DESCRIPTION
## Summary

Resolves the reported issue where `BioEngineDatasets` permanently locks in `service_url = None` if the discovery file `~/.bioengine/datasets/bioengine_current_server` is missing at construction time, and never re-checks even after the data server starts and writes the file. Long-lived injected clients in Ray Serve deployments (e.g. `chiron-manager`) could not see datasets that became available after deploy.

## Approach

The issue suggested two options: lazy re-read in `list_datasets()`, or an explicit `refresh()` method. I implemented **both** because they cover different scenarios:

- **Lazy resolution** (`_resolve_service_url`) handles the common case the issue describes: the client was constructed before the data server. No caller change required. Every public method now calls `_resolve_service_url()` first; the fast path is a single attribute check, the slow path reads one small file.
- **Explicit `refresh()`** handles the second-class case the lazy path can't: the data server has restarted on a new URL. The lazy path doesn't fire while `service_url` is already set, so it can't detect a server change. `refresh()` closes the old `httpx.AsyncClient` and re-runs the resolution.

## Changes

- `bioengine/datasets/datasets.py`
  - Store the user's request verbatim on `self._requested_data_server_url` (`"auto"` / explicit URL / `None`) instead of collapsing it at init.
  - Add `_resolve_service_url(*, initial=False)` — lazy attach. Re-read the discovery file when `service_url is None` and the request was `"auto"`. Initial-call warning only at construction so a never-attached client doesn't spam logs.
  - Add `async refresh()` — close old client, clear state, re-resolve. Returns the new URL or `None`.
  - Move the discovery file path to `_CURRENT_SERVER_FILE` class attribute so the new code and tests can target it uniformly (monkeypatchable).
  - Call `_resolve_service_url()` at the top of every public method touching `service_url`: `ping_data_server`, `list_datasets`, `list_files`, `save_file`, `list_saved_files`, `get_saved_file`. `get_file` benefits transitively via `list_datasets`.

- `tests/test_datasets_lazy_resolution.py` — six focused unit tests, no network, no data server required. Cover the lazy path, the explicit-`None`-stays-disabled invariant, the explicit-URL-doesn't-re-resolve invariant, and `refresh()` swapping URLs.

- `pyproject.toml`: `0.9.1` → `0.9.3`. `0.9.2` is reserved by PR #70 (Ray Client stale-handle reconnect, still open). The two PRs are independent; whichever lands first takes the lower version, the other rebases.

## Out of scope

- Per-call discovery-file polling has a steady-state cost of one filesystem stat per dataset operation (cheap; microseconds). I did not add an in-memory negative-cache because the operation count is bounded by what the deployment actually does, and a never-resolved client only retries when something would have queried datasets anyway.
- No locking around the resolve path. The current `BioEngineDatasets` is single-event-loop; concurrent calls from within one loop cannot race in the sync resolve method. Adding a lock is straightforward if a future caller introduces threads.

## Test plan

- [x] `python -m pytest tests/test_datasets_lazy_resolution.py -v --noconftest` — 6 passed.
- [ ] CI: docker-publish.yml accepts 0.9.3 > 0.9.1 (latest GHCR) and builds the image.
- [ ] Reproduce the original incident on a worker: deploy a `BioEngineDatasets`-using app with no data server, start the data server, call `list_datasets()` — should now return the populated dictionary without redeploying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)