### PR TITLE
fix: import geo_location directly from submodule on the head node (0.9.5)

### DIFF
--- a/bioengine/cluster/proxy_actor.py
+++ b/bioengine/cluster/proxy_actor.py
@@ -115,10 +115,7 @@ class BioEngineProxyActor:
             return self._cached_geo_location
 
         import asyncio
-        # Import directly from the submodule, not from `bioengine.utils`.
-        # The package __init__ pulls in artifact_utils -> hypha_rpc, which
-        # isn't installed on a plain Ray cluster head node (only the worker
-        # container has it). Direct submodule import sidesteps that.
+        # Submodule path avoids bioengine.utils.__init__ -> hypha_rpc (not on Ray head).
         from bioengine.utils.geo_location import (
             fetch_centroid_coordinates,
             fetch_geolocation,

--- a/bioengine/cluster/proxy_actor.py
+++ b/bioengine/cluster/proxy_actor.py
@@ -115,7 +115,14 @@ class BioEngineProxyActor:
             return self._cached_geo_location
 
         import asyncio
-        from bioengine.utils import fetch_centroid_coordinates, fetch_geolocation
+        # Import directly from the submodule, not from `bioengine.utils`.
+        # The package __init__ pulls in artifact_utils -> hypha_rpc, which
+        # isn't installed on a plain Ray cluster head node (only the worker
+        # container has it). Direct submodule import sidesteps that.
+        from bioengine.utils.geo_location import (
+            fetch_centroid_coordinates,
+            fetch_geolocation,
+        )
 
         async def _fetch() -> Dict[str, Optional[Union[str, float]]]:
             geo = await fetch_geolocation(logger=logger)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.9.4"
+version = "0.9.5"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Summary

Follow-up to PR #72. `BioEngineProxyActor.get_geo_location()` imports via `from bioengine.utils import fetch_centroid_coordinates, fetch_geolocation`, which triggers `bioengine/utils/__init__.py` and chain-imports `artifact_utils` → `hypha_rpc`. The Ray cluster head node has no `hypha_rpc` installed (only the BioEngine worker container does), so every call raised `ModuleNotFoundError: No module named 'hypha_rpc'` on a real external-cluster deployment.

Observed live on the TÜBİTAK worker right after rolling out 0.9.4: the worker's own geo resolved correctly (Sweden), the head's stayed `None`, retries kept failing with the same import error on every monitoring tick.

## Fix

Import directly from the submodule:

```python
from bioengine.utils.geo_location import (
    fetch_centroid_coordinates,
    fetch_geolocation,
)
```

This sidesteps the package `__init__.py` entirely. `bioengine/utils/geo_location.py` only depends on `httpx`, which is present on any reasonable Ray head node.

## Test plan

- [ ] CI: `docker-publish.yml` accepts 0.9.5 > 0.9.4 and builds the image.
- [ ] Roll a 0.9.5-ray2.54.1 overlay to the TÜBİTAK worker; verify `get_status['ray_cluster']['geo_location']['country_name']` returns Türkiye within a couple of monitoring ticks (no more import errors in worker logs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)