### PR TITLE
fix: make hypha_rpc optional for bioengine.utils import (0.9.6)

### DIFF
--- a/bioengine/cluster/proxy_actor.py
+++ b/bioengine/cluster/proxy_actor.py
@@ -115,11 +115,7 @@ class BioEngineProxyActor:
             return self._cached_geo_location
 
         import asyncio
-        # Submodule path avoids bioengine.utils.__init__ -> hypha_rpc (not on Ray head).
-        from bioengine.utils.geo_location import (
-            fetch_centroid_coordinates,
-            fetch_geolocation,
-        )
+        from bioengine.utils import fetch_centroid_coordinates, fetch_geolocation
 
         async def _fetch() -> Dict[str, Optional[Union[str, float]]]:
             geo = await fetch_geolocation(logger=logger)

--- a/bioengine/utils/artifact_utils.py
+++ b/bioengine/utils/artifact_utils.py
@@ -1,11 +1,15 @@
+from __future__ import annotations
+
 import base64
 import logging
 from pathlib import Path, PurePosixPath
-from typing import Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import httpx
 import yaml
-from hypha_rpc.rpc import ObjectProxy
+
+if TYPE_CHECKING:
+    from hypha_rpc.rpc import ObjectProxy
 
 from .logger import create_logger
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.9.5"
+version = "0.9.6"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Summary

Follow-up to PR #73. My previous "fix" — `from bioengine.utils.geo_location import X` instead of `from bioengine.utils import X` — did not actually work: Python still runs the parent package's `__init__.py` first, which imports `artifact_utils`, which imports `hypha_rpc`. The Ray head node has no `hypha_rpc` installed, so `get_geo_location()` kept raising `ModuleNotFoundError` on every retry. Caught live on TÜBİTAK right after rolling out 0.9.5 — head geo stayed `None`.

## Real fix

`bioengine/utils/artifact_utils.py` only uses `ObjectProxy` as a type annotation; no runtime code path needs it. Move the import behind `TYPE_CHECKING` and add `from __future__ import annotations` so the type names stay as strings at runtime. `bioengine.utils` now loads on any environment with `httpx` and `yaml`; the public API (`create_application_from_files`, etc.) is unchanged and still fails clearly if a caller actually invokes a hypha_rpc-using function — but currently nothing does at runtime.

Also reverts `proxy_actor.py` to the plain `from bioengine.utils import ...` import — the workaround there is no longer needed.

## Verified

```
$ python -c 'from bioengine.utils import fetch_geolocation, create_application_from_files'  # OK (hypha_rpc present)
$ python -c '<hypha_rpc blocked from sys.meta_path>; from bioengine.utils import fetch_geolocation'  # OK
```

## Test plan

- [ ] CI: docker-publish.yml accepts 0.9.6 > 0.9.5.
- [ ] Roll 0.9.6-ray2.54.1 to TÜBİTAK; verify `get_status['ray_cluster']['geo_location']['country_name']` returns Türkiye within a couple of monitoring ticks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)