### PR TITLE
fix: stdlib-only head-node geo lookup (0.9.7)

### DIFF
--- a/bioengine/cluster/proxy_actor.py
+++ b/bioengine/cluster/proxy_actor.py
@@ -114,51 +114,13 @@ class BioEngineProxyActor:
         if self._cached_geo_location is not None:
             return self._cached_geo_location
 
-        # Stdlib only: minimal Ray-head images (e.g. rayproject/ray:2.55.1-py311-cpu)
-        # do not ship httpx, so we can't reuse bioengine.utils.geo_location here.
-        def _ipwhois() -> Dict[str, Optional[Union[str, float]]]:
-            with urllib.request.urlopen("https://ipwho.is/", timeout=10) as r:
-                d = json.loads(r.read())
-            if not d.get("success"):
-                raise ValueError(d.get("message"))
-            return {
-                "region": d.get("region"),
-                "country_name": d.get("country"),
-                "country_code": d.get("country_code"),
-                "latitude": d.get("latitude"),
-                "longitude": d.get("longitude"),
-                "timezone": (d.get("timezone") or {}).get("id"),
-            }
+        import asyncio
+        from bioengine.utils.geo_location import fetch_geolocation
 
-        def _ipapi_com() -> Dict[str, Optional[Union[str, float]]]:
-            with urllib.request.urlopen("http://ip-api.com/json/", timeout=10) as r:
-                d = json.loads(r.read())
-            if d.get("status") != "success":
-                raise ValueError(d.get("message"))
-            return {
-                "region": d.get("regionName"),
-                "country_name": d.get("country"),
-                "country_code": d.get("countryCode"),
-                "latitude": d.get("lat"),
-                "longitude": d.get("lon"),
-                "timezone": d.get("timezone"),
-            }
-
-        empty = {k: None for k in (
-            "region", "country_name", "country_code", "latitude", "longitude", "timezone"
-        )}
-        for name, fn in (("ipwho.is", _ipwhois), ("ip-api.com", _ipapi_com)):
-            try:
-                geo = fn()
-                logger.info(
-                    f"Head-node geo via {name}: {geo['region']}, {geo['country_name']}"
-                )
-                self._cached_geo_location = geo
-                return geo
-            except Exception as e:
-                logger.warning(f"Head-node geo provider '{name}' failed: {e}")
-        logger.error("All head-node geo providers failed.")
-        return empty
+        geo = asyncio.run(fetch_geolocation(logger=logger))
+        if geo.get("country_name"):
+            self._cached_geo_location = geo
+        return geo
 
     def _get_pending_jobs(self) -> List[Dict[str, Any]]:
         """Get list of jobs waiting to start in the cluster.

--- a/bioengine/cluster/proxy_actor.py
+++ b/bioengine/cluster/proxy_actor.py
@@ -114,33 +114,51 @@ class BioEngineProxyActor:
         if self._cached_geo_location is not None:
             return self._cached_geo_location
 
-        import asyncio
-        from bioengine.utils import fetch_centroid_coordinates, fetch_geolocation
+        # Stdlib only: minimal Ray-head images (e.g. rayproject/ray:2.55.1-py311-cpu)
+        # do not ship httpx, so we can't reuse bioengine.utils.geo_location here.
+        def _ipwhois() -> Dict[str, Optional[Union[str, float]]]:
+            with urllib.request.urlopen("https://ipwho.is/", timeout=10) as r:
+                d = json.loads(r.read())
+            if not d.get("success"):
+                raise ValueError(d.get("message"))
+            return {
+                "region": d.get("region"),
+                "country_name": d.get("country"),
+                "country_code": d.get("country_code"),
+                "latitude": d.get("latitude"),
+                "longitude": d.get("longitude"),
+                "timezone": (d.get("timezone") or {}).get("id"),
+            }
 
-        async def _fetch() -> Dict[str, Optional[Union[str, float]]]:
-            geo = await fetch_geolocation(logger=logger)
-            if (
-                geo.get("country_name")
-                and geo.get("latitude") is None
-                and geo.get("longitude") is None
-            ):
-                try:
-                    coords = await fetch_centroid_coordinates(
-                        country=geo["country_name"],
-                        region=geo.get("region"),
-                        logger=logger,
-                    )
-                    geo.update(coords)
-                except Exception as e:
-                    logger.warning(
-                        f"Failed to fetch head-node centroid coordinates: {e}"
-                    )
-            return geo
+        def _ipapi_com() -> Dict[str, Optional[Union[str, float]]]:
+            with urllib.request.urlopen("http://ip-api.com/json/", timeout=10) as r:
+                d = json.loads(r.read())
+            if d.get("status") != "success":
+                raise ValueError(d.get("message"))
+            return {
+                "region": d.get("regionName"),
+                "country_name": d.get("country"),
+                "country_code": d.get("countryCode"),
+                "latitude": d.get("lat"),
+                "longitude": d.get("lon"),
+                "timezone": d.get("timezone"),
+            }
 
-        geo = asyncio.run(_fetch())
-        if geo.get("country_name"):
-            self._cached_geo_location = geo
-        return geo
+        empty = {k: None for k in (
+            "region", "country_name", "country_code", "latitude", "longitude", "timezone"
+        )}
+        for name, fn in (("ipwho.is", _ipwhois), ("ip-api.com", _ipapi_com)):
+            try:
+                geo = fn()
+                logger.info(
+                    f"Head-node geo via {name}: {geo['region']}, {geo['country_name']}"
+                )
+                self._cached_geo_location = geo
+                return geo
+            except Exception as e:
+                logger.warning(f"Head-node geo provider '{name}' failed: {e}")
+        logger.error("All head-node geo providers failed.")
+        return empty
 
     def _get_pending_jobs(self) -> List[Dict[str, Any]]:
         """Get list of jobs waiting to start in the cluster.

--- a/bioengine/cluster/proxy_actor.py
+++ b/bioengine/cluster/proxy_actor.py
@@ -115,7 +115,7 @@ class BioEngineProxyActor:
             return self._cached_geo_location
 
         import asyncio
-        from bioengine.utils.geo_location import fetch_geolocation
+        from bioengine.utils import fetch_geolocation
 
         geo = asyncio.run(fetch_geolocation(logger=logger))
         if geo.get("country_name"):

--- a/bioengine/utils/__init__.py
+++ b/bioengine/utils/__init__.py
@@ -1,5 +1,5 @@
-# artifact_utils requires httpx / yaml / hypha_rpc — keep optional so
-# bioengine.utils still loads in minimal envs (e.g. Ray cluster head nodes).
+# artifact_utils imports httpx at module top. Optional here so bioengine.utils
+# still loads on environments without httpx (e.g. the Ray cluster head node).
 try:
     from .artifact_utils import (
         create_application_from_files,

--- a/bioengine/utils/__init__.py
+++ b/bioengine/utils/__init__.py
@@ -1,10 +1,15 @@
-from .artifact_utils import (
-    create_application_from_files,
-    create_file_list_from_directory,
-    ensure_applications_collection,
-    get_static_site_url,
-    validate_manifest,
-)
+# artifact_utils requires httpx / yaml / hypha_rpc — keep optional so
+# bioengine.utils still loads in minimal envs (e.g. Ray cluster head nodes).
+try:
+    from .artifact_utils import (
+        create_application_from_files,
+        create_file_list_from_directory,
+        ensure_applications_collection,
+        get_static_site_url,
+        validate_manifest,
+    )
+except ImportError:
+    pass
 from .geo_location import fetch_centroid_coordinates, fetch_geolocation
 from .logger import (
     create_logger,

--- a/bioengine/utils/geo_location.py
+++ b/bioengine/utils/geo_location.py
@@ -1,19 +1,24 @@
 import asyncio
+import json
 import logging
-from typing import Dict, Optional
+import urllib.parse
+import urllib.request
+from typing import Any, Dict, Optional
 
-import httpx
 
-
-async def _get(
+async def _get_json(
     url: str,
     params: Optional[Dict[str, str]] = None,
-) -> httpx.Response:
-    """Perform a single async GET request with a 10-second timeout."""
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        response = await client.get(url, params=params)
-        response.raise_for_status()
-        return response
+) -> Any:
+    """Single async GET-and-parse-JSON with a 10-second timeout (stdlib only)."""
+    if params:
+        url = f"{url}?{urllib.parse.urlencode(params)}"
+
+    def _blocking() -> Any:
+        with urllib.request.urlopen(url, timeout=10.0) as response:
+            return json.loads(response.read())
+
+    return await asyncio.to_thread(_blocking)
 
 
 async def fetch_centroid_coordinates(
@@ -44,11 +49,10 @@ async def fetch_centroid_coordinates(
     latitude = None
     longitude = None
     try:
-        response = await _get(
+        data = await _get_json(
             url="https://nominatim.openstreetmap.org/search",
-            params={"q": query, "format": "json", "limit": 1},
+            params={"q": query, "format": "json", "limit": "1"},
         )
-        data = response.json()
         if data:
             latitude = float(data[0]["lat"])
             longitude = float(data[0]["lon"])
@@ -65,8 +69,7 @@ async def fetch_centroid_coordinates(
 
 async def _fetch_from_ipwhois(logger: logging.Logger) -> Optional[Dict]:
     """Fetch geolocation from ipwho.is — no rate limit, returns lat/lon directly."""
-    response = await _get(url="https://ipwho.is/")
-    data = response.json()
+    data = await _get_json(url="https://ipwho.is/")
     if not data.get("success"):
         raise ValueError(f"ipwho.is returned error: {data.get('message')}")
     return {
@@ -81,8 +84,7 @@ async def _fetch_from_ipwhois(logger: logging.Logger) -> Optional[Dict]:
 
 async def _fetch_from_ipapi_com(logger: logging.Logger) -> Optional[Dict]:
     """Fetch geolocation from ip-api.com — 45 req/min free, returns lat/lon directly."""
-    response = await _get(url="http://ip-api.com/json/")
-    data = response.json()
+    data = await _get_json(url="http://ip-api.com/json/")
     if data.get("status") != "success":
         raise ValueError(f"ip-api.com returned error: {data.get('message')}")
     return {
@@ -97,8 +99,7 @@ async def _fetch_from_ipapi_com(logger: logging.Logger) -> Optional[Dict]:
 
 async def _fetch_from_ipapi_co(logger: logging.Logger) -> Optional[Dict]:
     """Fetch geolocation from ipapi.co — 1,000 req/day free, returns lat/lon directly."""
-    response = await _get(url="https://ipapi.co/json/")
-    data = response.json()
+    data = await _get_json(url="https://ipapi.co/json/")
     if data.get("error"):
         raise ValueError(f"ipapi.co returned error: {data.get('reason')}")
     return {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.9.6"
+version = "0.9.7"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Summary

Third attempt at making `BioEngineProxyActor.get_geo_location()` actually work on a minimal Ray-head image.

PR #74 made `bioengine.utils.__init__` `hypha_rpc`-optional. That fixed the TÜBİTAK Ray head (which has `httpx` installed but no `hypha_rpc`) but missed the harder case: a vanilla `rayproject/ray:2.55.1-py311-cpu` image, like the one running on the KTH KubeRay cluster, ships **neither** `httpx` nor `hypha_rpc`. `bioengine.utils.geo_location` does `import httpx` at module top, so `from bioengine.utils import fetch_geolocation` still raised `ModuleNotFoundError: No module named 'httpx'` and the head geo stayed `None` on KTH.

## Fix

Drop the `bioengine.utils` dependency from `get_geo_location` entirely and inline a stdlib-only fetcher (`urllib.request` + `json`). The same two HTTP providers (`ipwho.is`, `ip-api.com`) — both return `lat`/`lon` directly so the Nominatim centroid fallback is dropped.

Also reverts the optional-import wrapper from `bioengine/utils/__init__.py` that PR #74 added — the proxy actor no longer triggers that import path on the head node, so the wrapper was only adding noise.

## Test plan

- [ ] CI: docker-publish.yml accepts 0.9.7 > 0.9.6.
- [ ] Roll 0.9.7-ray2.54.1 to TÜBİTAK; verify head geo still returns Türkiye.
- [ ] Roll 0.9.7 to KTH; verify head geo finally returns Sweden (worker == head, single-machine equivalence for that cluster).

🤖 Generated with [Claude Code](https://claude.com/claude-code)