### PR TITLE
feat(start_hpc_worker.sh): support apptainer sandbox images (accept + auto-build)

### DIFF
--- a/scripts/start_hpc_worker.sh
+++ b/scripts/start_hpc_worker.sh
@@ -174,6 +174,13 @@ if [[ "$IMAGE" == *.sif ]]; then
         echo "Error: Image file $IMAGE not found."
         exit 1
     fi
+elif [[ -d "$IMAGE" ]]; then
+    # Apptainer sandbox directory image. Required on hosts where
+    # `apptainer pull` / `apptainer build sif` is broken (e.g. kernel
+    # yama.ptrace_scope=2 blocks the proot/mksquashfs path). Built
+    # elsewhere with `apptainer build --sandbox <dir> docker://...`
+    # and pointed at here via --image.
+    IMAGE=$(realpath $IMAGE)
 elif [[ "$IMAGE" != docker://* ]]; then
     # Add docker:// prefix if not present
     IMAGE="docker://${IMAGE}"

--- a/scripts/start_hpc_worker.sh
+++ b/scripts/start_hpc_worker.sh
@@ -109,6 +109,28 @@ set_arg_value() {
     fi
 }
 
+# Function: detect a boolean (presence-only) CLI flag and strip it from the
+# arguments forwarded to the worker. Writes the result ("true"/"false") into
+# the global TAKE_FLAG_RESULT and mutates BIOENGINE_WORKER_ARGS in place
+# (must therefore be invoked without command substitution so the parent
+# shell sees the change). The flag is removed so python never receives it.
+take_flag() {
+    local tag="$1"
+    TAKE_FLAG_RESULT=false
+    local cleaned=()
+    for ((i=0; i<${#BIOENGINE_WORKER_ARGS[@]}; i++)); do
+        local arg="${BIOENGINE_WORKER_ARGS[i]}"
+        if [[ "$arg" == "$tag" || "$arg" == "$tag=true" || "$arg" == "$tag=1" ]]; then
+            TAKE_FLAG_RESULT=true
+        elif [[ "$arg" == "$tag=false" || "$arg" == "$tag=0" ]]; then
+            : # explicit false; drop the arg but leave TAKE_FLAG_RESULT=false
+        else
+            cleaned+=("$arg")
+        fi
+    done
+    BIOENGINE_WORKER_ARGS=("${cleaned[@]}")
+}
+
 # Function to define bind mounts
 BIND_OPTS=()
 add_bind() {
@@ -163,8 +185,41 @@ mkdir -p $IMAGE_CACHEDIR
 SINGULARITY_CACHEDIR=$IMAGE_CACHEDIR
 APPTAINER_CACHEDIR=$IMAGE_CACHEDIR
 
-# Get the path to the image 
+# Get the path to the image
 IMAGE="$(get_arg_value "--image" $DEFAULT_IMAGE)"
+
+# Auto-sandbox flag: build (or reuse) an apptainer sandbox dir from the docker
+# reference, then use that as the image. Useful on clusters where the SIF
+# build path is broken (e.g. apptainer 1.5.x + yama.ptrace_scope=2 fails the
+# proot/mksquashfs invocation; see PR #76 context). The flag is stripped from
+# the arguments forwarded to the worker so python never sees it.
+take_flag "--sandbox"
+SANDBOX_MODE="$TAKE_FLAG_RESULT"
+
+if [[ "$SANDBOX_MODE" == "true" ]]; then
+    if [[ "$IMAGE" == *.sif || -d "$IMAGE" ]]; then
+        echo "Error: --sandbox cannot be combined with a local .sif or sandbox-dir --image; pass a docker reference instead."
+        exit 1
+    fi
+    # Strip an optional docker:// prefix to derive a safe directory name.
+    SANDBOX_SRC="${IMAGE#docker://}"
+    SANDBOX_NAME="$(echo "$SANDBOX_SRC" | tr '/:' '__')-sandbox"
+    SANDBOX_DIR="$IMAGE_CACHEDIR/$SANDBOX_NAME"
+    if [[ ! -d "$SANDBOX_DIR" ]]; then
+        echo "Building apptainer sandbox from docker://${SANDBOX_SRC} → $SANDBOX_DIR (one-time, this can take several minutes) ..."
+        APPTAINER_TMPDIR="${APPTAINER_TMPDIR:-$HOME/.apptainer-tmp}"
+        mkdir -p "$APPTAINER_TMPDIR"
+        if ! APPTAINER_TMPDIR="$APPTAINER_TMPDIR" \
+             $CONTAINER_CMD build --sandbox "$SANDBOX_DIR" "docker://${SANDBOX_SRC}"; then
+            echo "Error: sandbox build failed; aborting."
+            rm -rf "$SANDBOX_DIR"
+            exit 1
+        fi
+    else
+        echo "Reusing cached apptainer sandbox at $SANDBOX_DIR"
+    fi
+    IMAGE="$SANDBOX_DIR"
+fi
 
 # Get the image name and version
 if [[ "$IMAGE" == *.sif ]]; then
@@ -178,8 +233,8 @@ elif [[ -d "$IMAGE" ]]; then
     # Apptainer sandbox directory image. Required on hosts where
     # `apptainer pull` / `apptainer build sif` is broken (e.g. kernel
     # yama.ptrace_scope=2 blocks the proot/mksquashfs path). Built
-    # elsewhere with `apptainer build --sandbox <dir> docker://...`
-    # and pointed at here via --image.
+    # automatically when --sandbox is passed, or supplied directly via
+    # --image /path/to/sandbox-dir.
     IMAGE=$(realpath $IMAGE)
 elif [[ "$IMAGE" != docker://* ]]; then
     # Add docker:// prefix if not present


### PR DESCRIPTION
## Summary

Two small additions to `scripts/start_hpc_worker.sh` so it works on clusters where apptainer's SIF build path is broken:

1. **Accept an apptainer sandbox directory as `--image`** in addition to the existing `.sif` and `docker://` cases (commit `887c01a`).
2. **`--sandbox` flag for auto-build** from a `docker://` reference — caches under `$WORKSPACE_DIR/images/<sanitised-image-name>-sandbox` (commit `09c70f6`).

## Why

The Berzelius SLURM cluster's apptainer 1.5.0 upgrade (2026-05-18) combined with kernel `yama.ptrace_scope=2` breaks the proot/mksquashfs path used by `apptainer pull` and `apptainer build sif`. The cluster can't materialise a SIF on its own. The working workaround is to build a sandbox directory once and re-use it:

```bash
apptainer build --sandbox <dir> docker://ghcr.io/aicell-lab/bioengine-worker:0.9.7
```

The sandbox dir runs fine with `apptainer exec` — same surface as a SIF — but the script previously only accepted paths ending in `.sif` and added a `docker://` prefix to everything else, so passing the sandbox dir fell through to `docker://<dir>` and broke.

Commit 1 fixes that. Commit 2 builds on it so users don't have to remember the manual `apptainer build --sandbox` recipe — they just pass `--sandbox` and the script handles cache lookup + build.

## Changes

**Commit 1 — `887c01a` `feat(start_hpc_worker.sh): accept apptainer --sandbox directory image`**

Adds one `elif [[ -d "$IMAGE" ]]` branch between the `.sif` check and the `docker://` fallback. Calls `realpath` to absolutise (matches the `.sif` branch).

**Commit 2 — `09c70f6` `feat(start_hpc_worker.sh): add --sandbox flag for auto-build of sandbox image`**

- `--sandbox` absent: existing behaviour unchanged (`docker://` pulled into a SIF, or local `.sif` / sandbox-dir from `--image` used as-is).
- `--sandbox` present: derive deterministic cache path `$WORKSPACE_DIR/images/<sanitised-image-name>-sandbox`, build with `apptainer build --sandbox` if missing, otherwise reuse silently, then continue through the existing sandbox-dir code path.
- Mutually exclusive with a `.sif` or sandbox-dir `--image` (errors out with a clear message).
- The `--sandbox` arg is stripped from `BIOENGINE_WORKER_ARGS` before exec'ing python, so the worker never sees it.
- Adds a small private `take_flag` helper to plumb presence-only flags out of the args array (uses a global `TAKE_FLAG_RESULT` to avoid the subshell trap of `var=$(fn)` discarding the in-place array strip).

## Test plan

- [x] `bash -n scripts/start_hpc_worker.sh` syntax clean for both commits
- [x] Commit 1 runtime-verified end-to-end on Berzelius session `14c1f995` — the live `bioimage-io/bioengine-worker-berzelius` on 0.9.7 is running with the byte-identical elif body via a locally-patched copy
- [x] Commit 2 `take_flag` helper smoke-tested for presence / `=true` / `=false` / absent — all correct
- No CI to update — `scripts/` is not in `docker-publish.yml` trigger paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)