### PR TITLE
refactor(proxy): fix ProxyDeployment at 1 replica, drop autoscaling + simplify service_ids

### DIFF
--- a/bioengine/apps/builder.py
+++ b/bioengine/apps/builder.py
@@ -95,7 +95,6 @@ class AppBuilder:
         apps_workdir: Where to store downloaded artifacts and working directories
         server: Hypha RPC server connection for authentication and artifact access
         artifact_manager: Service for downloading deployment code and manifests
-        serve_http_url: Base URL where Ray Serve exposes HTTP endpoints
 
     Parameter Conventions (API):
         - application_kwargs: Dictionary of keyword arguments for each deployment class
@@ -151,7 +150,6 @@ class AppBuilder:
         self.server: Optional[RemoteService] = None
         self.artifact_manager: Optional[ObjectProxy] = None
         self.worker_service_id: Optional[str] = None
-        self.serve_http_url: Optional[str] = None
         self.proxy_actor_name: Optional[str] = proxy_actor_name
         self.data_server_url: Optional[str] = None
 
@@ -160,7 +158,6 @@ class AppBuilder:
         server: RemoteService,
         artifact_manager: ObjectProxy,
         worker_service_id: str,
-        serve_http_url: str,
     ) -> None:
         """
         Connect the AppBuilder to external services required for operation.
@@ -172,13 +169,11 @@ class AppBuilder:
         Service Connections:
         • server: Your authenticated connection to the Hypha workspace
         • artifact_manager: Service that stores and retrieves deployment code
-        • serve_http_url: Where Ray Serve will expose your deployed applications
 
         Args:
             server: Live connection to Hypha server (from connect_to_server())
             artifact_manager: Proxy to artifact management service (from server.get_service())
             worker_service_id: BioEngine worker service ID
-            serve_http_url: Base URL where applications will be accessible via HTTP
 
         Example:
             ```python
@@ -189,14 +184,12 @@ class AppBuilder:
                 server=server,
                 artifact_manager=artifact_manager,
                 worker_service_id="my-workspace/bioengine-worker",
-                serve_http_url="http://localhost:8000"
             )
             ```
         """
         self.server = server
         self.artifact_manager = artifact_manager
         self.worker_service_id = worker_service_id
-        self.serve_http_url = serve_http_url
 
     def update_data_server_url(self, data_server_url: str) -> None:
         """
@@ -1610,7 +1603,6 @@ class AppBuilder:
                 worker_client_id=self.server.config.client_id,
                 proxy_service_token=proxy_service_token,
                 authorized_users=effective_authorized_users,
-                serve_http_url=self.serve_http_url,
                 proxy_actor_name=self.proxy_actor_name,
                 debug=debug,
                 ice_servers=ice_servers,
@@ -1665,7 +1657,7 @@ if __name__ == "__main__":
             proxy_actor_name="TEST_PROXY_ACTOR",
         )
         app_builder.complete_initialization(
-            server, artifact_manager, worker_service_id="test-worker", serve_http_url="https://test-url"
+            server, artifact_manager, worker_service_id="test-worker"
         )
 
         app = await app_builder.build(

--- a/bioengine/apps/manager.py
+++ b/bioengine/apps/manager.py
@@ -652,10 +652,9 @@ class AppsManager:
 
     async def _get_application_service_ids(
         self, application_id: str
-    ) -> Dict[str, Any]:
-        # WebSocket: one wildcard ID dispatched per-call with `mode='select:min:get_load'`
-        # (each ProxyDeployment replica exposes get_load). WebRTC: explicit per-replica
-        # list — the peer-connection handshake needs the concrete replica's client_id.
+    ) -> Dict[str, Optional[str]]:
+        # ProxyDeployment is fixed at one replica per application — one concrete
+        # service ID for each transport, no wildcards, no per-replica lists.
         replica_ids = (
             await self.ray_cluster.proxy_actor_handle.get_deployment_replicas.remote(
                 application_id=application_id,
@@ -663,24 +662,14 @@ class AppsManager:
             )
         )
         if not replica_ids:
-            return {
-                "websocket_service_id": None,
-                "websocket_service_ids": [],
-                "webrtc_service_ids": [],
-            }
+            return {"websocket_service_id": None, "webrtc_service_id": None}
 
+        replica_id = replica_ids[0]
         workspace = self.server.config.workspace
         worker_client_id = self.server.config.client_id
         return {
-            "websocket_service_id": f"{workspace}/{worker_client_id}-*:{application_id}",
-            "websocket_service_ids": [
-                f"{workspace}/{worker_client_id}-{replica_id}:{application_id}"
-                for replica_id in replica_ids
-            ],
-            "webrtc_service_ids": [
-                f"{workspace}/{worker_client_id}-{replica_id}:{application_id}-rtc"
-                for replica_id in replica_ids
-            ],
+            "websocket_service_id": f"{workspace}/{worker_client_id}-{replica_id}:{application_id}",
+            "webrtc_service_id": f"{workspace}/{worker_client_id}-{replica_id}:{application_id}-rtc",
         }
 
     async def _get_app_status(
@@ -735,21 +724,15 @@ class AppsManager:
         service_ids = await self._get_application_service_ids(application_id)
 
         # Build static site URL with runtime config params so the frontend
-        # knows which Hypha server and service to connect to. WebSocket ID is
-        # a wildcard (call with mode='select:min:get_load'); WebRTC starts on
-        # the first replica's concrete ID — the frontend can swap replicas at
-        # runtime via get_rtc_service_id() once connected.
+        # knows which Hypha server and service to connect to.
         base_static_url = application_info.get("static_site_url")
         static_site_url = None
         if base_static_url and service_ids["websocket_service_id"]:
-            ws_id = service_ids["websocket_service_id"]
-            rtc_ids = service_ids["webrtc_service_ids"]
-            rtc_id = rtc_ids[0] if rtc_ids else ""
             server_url = self.server.config.public_base_url
             params = (
                 f"server={server_url}"
-                f"&ws_service_id={ws_id}"
-                f"&webrtc_service_id={rtc_id}"
+                f"&ws_service_id={service_ids['websocket_service_id']}"
+                f"&webrtc_service_id={service_ids['webrtc_service_id']}"
             )
             static_site_url = f"{base_static_url}?{params}"
 

--- a/bioengine/apps/manager.py
+++ b/bioengine/apps/manager.py
@@ -834,7 +834,6 @@ class AppsManager:
             server=self.server,
             artifact_manager=self.artifact_manager,
             worker_service_id=worker_service_id,
-            serve_http_url=self.ray_cluster.serve_http_url,
         )
 
         # Ensure applications collection exists

--- a/bioengine/apps/proxy_deployment.py
+++ b/bioengine/apps/proxy_deployment.py
@@ -5,7 +5,6 @@ import time
 import uuid
 from typing import Any, Callable, Dict, List, Optional
 
-import httpx
 import ray
 from httpx import AsyncClient, HTTPStatusError, RequestError
 from hypha_rpc import connect_to_server, register_rtc_service
@@ -15,7 +14,6 @@ from pydantic import Field
 from ray.exceptions import RayTaskError
 from ray.serve import deployment, get_replica_context
 from ray.serve.handle import DeploymentHandle
-from starlette.requests import Request
 
 from bioengine.utils import get_pip_requirements
 
@@ -32,18 +30,14 @@ logger = logging.getLogger("ray.serve")
             ),
         },
     },
-    max_ongoing_requests=10,  # Default limit concurrent requests to avoid overload
-    autoscaling_config={
-        "min_replicas": 1,  # Always keep at least 1 replica running
-        "max_replicas": 10,  # Scale up to 10 replicas maximum
-        "target_ongoing_requests": 5,  # Target 5 ongoing requests per replica
-        "upscale_delay_s": 30.0,  # Wait 30s before scaling up
-        "downscale_delay_s": 300.0,  # Wait 5 minutes before scaling down
-        "upscale_smoothing_factor": 1.0,  # Aggressive upscaling
-        "downscale_smoothing_factor": 0.5,  # Conservative downscaling
-    },
-    health_check_period_s=10,  # Check health every 10 seconds
-    health_check_timeout_s=5,  # Timeout after 5 seconds
+    # Fixed at one replica. ProxyDeployment is a 0-CPU Hypha bridge — actual
+    # compute scaling lives in the inner deployments. Concurrency is bounded
+    # by the in-actor semaphore sized by the per-app max_ongoing_requests
+    # parameter; WebSocket and WebRTC calls both go through it.
+    num_replicas=1,
+    max_ongoing_requests=10,
+    health_check_period_s=10,
+    health_check_timeout_s=5,
 )
 class ProxyDeployment:
     """
@@ -95,7 +89,6 @@ class ProxyDeployment:
         proxy_service_token: str,
         worker_client_id: str,
         authorized_users: Dict[str, List[str]],
-        serve_http_url: str,
         proxy_actor_name: str,
         debug: bool,
         ice_servers: Optional[List[Dict[str, Any]]] = None,
@@ -140,7 +133,6 @@ class ProxyDeployment:
                             access. Method-specific entries take precedence over "*".
                             Example: {"*": ["admin@lab.edu"], "run": ["*"]}
 
-            serve_http_url: URL for Ray Serve HTTP endpoint used for autoscaling coordination.
             proxy_actor_name: Actor name of the BioEngineProxyActor for replica registration.
             debug: Set to true to enable debug logging.
             ice_servers: Optional list of ICE server configurations to use for WebRTC
@@ -251,15 +243,8 @@ class ProxyDeployment:
         # WebRTC peer connection tracking
         self._active_peer_connections: Dict[str, Dict[str, Any]] = {}
 
-        # Store request events
-        self.serve_http_url = serve_http_url
-        self._request_events: Dict[str, Dict[str, Any]] = {}
-
         # Lock for service registration
         self._registration_lock = asyncio.Lock()
-
-        # Start background cleanup task
-        self._cleanup_task = None
 
     async def get_app_data(self) -> Dict[str, Any]:
         """Return non-secret application metadata used for worker recovery."""
@@ -278,66 +263,6 @@ class ProxyDeployment:
         logger.info(
             f"✅ Updated authorized_users for '{self.application_id}': {authorized_users}"
         )
-
-    async def __call__(self, request: Request) -> Dict[str, Any]:
-        """
-        Handle HTTP requests for Ray Serve autoscaling coordination.
-
-        This endpoint receives HTTP requests from Ray Serve's HTTP proxy and waits for
-        corresponding WebRTC requests to complete. This ensures Ray Serve can properly
-        track request load for autoscaling decisions.
-
-        Only accepts POST requests with an X-Request-ID header that matches requests
-        initiated by the _mimic_request() method.
-
-        Args:
-            request: HTTP request object from Ray Serve's HTTP proxy
-
-        Returns:
-            Dictionary with completion status and request ID
-        """
-        logger.debug(
-            f"🌐 Received '{request.method}' request to ProxyDeployment"
-        )
-
-        # Only accept POST requests for mimic coordination
-        if request.method != "POST":
-            logger.error(
-                f"❌ Method '{request.method}' not supported - only POST allowed"
-            )
-            return {
-                "status": "error",
-                "message": f"Method '{request.method}' not supported - only POST allowed",
-            }
-
-        request_id = request.headers.get("X-Request-ID")
-        if not request_id:
-            logger.error(f"❌ Missing X-Request-ID header in request")
-            return {
-                "status": "error",
-                "message": "Missing X-Request-ID header",
-            }
-
-        logger.debug(f"⏳ Waiting for request: {request_id}")
-        # Wait for the corresponding request event
-        event_data = self._request_events.get(request_id)
-        if event_data:
-            try:
-                await asyncio.wait_for(
-                    event_data["event"].wait(), timeout=3600
-                )  # free after 1 hour
-                logger.debug(f"✅ Request completed: {request_id}")
-                return {"status": "completed", "request_id": request_id}
-            except asyncio.TimeoutError:
-                logger.error(f"⏱️ Request timed out after 1 hour: {request_id}")
-                return {"status": "timeout", "request_id": request_id}
-            finally:
-                # Always remove the event to prevent memory leaks
-                self._request_events.pop(request_id, None)
-        else:
-            logger.error(f"❌ Request not found: {request_id}")
-            # Request may have already completed
-            return {"status": "not_found", "request_id": request_id}
 
     # ===== Hypha Service Registration =====
     # Handles registration of WebSocket and WebRTC services with Hypha.
@@ -402,78 +327,6 @@ class ProxyDeployment:
             f"'{method_name}' on application '{self.application_id}'"
         )
 
-    async def _mimic_request(self, request_id: str) -> None:
-        """
-        Send HTTP request to Ray Serve to trigger autoscaling.
-
-        When users access the application through WebRTC connections, Ray Serve
-        doesn't automatically detect the load for autoscaling. This method sends
-        an HTTP request to the Ray Serve endpoint to mimic the load, ensuring
-        proper autoscaling behavior.
-
-        The request uses the same ID as the actual RPC call for coordination
-        with the __call__ method.
-
-        Args:
-            request_id: Unique identifier for correlating with the RPC call
-        """
-        logger.debug(f"📡 Sending autoscaling trigger for request: {request_id}")
-
-        try:
-            timeout = httpx.Timeout(connect=10.0, read=300.0, write=10.0, pool=10.0)
-
-            async with httpx.AsyncClient(timeout=timeout) as client:
-                await client.post(
-                    f"{self.serve_http_url}/{self.application_id}/",
-                    headers={"X-Request-ID": request_id},
-                    json={"mimic_request": True},
-                )
-
-            logger.debug(
-                f"✅ Autoscaling trigger sent successfully for request: {request_id}"
-            )
-
-        except Exception as e:
-            # Log but don't fail the user request
-            logger.error(
-                f"❌ Failed to send autoscaling trigger for '{self.application_id}' request {request_id}: {e}"
-            )
-            # Clean up orphaned event since HTTP request failed
-            self._request_events.pop(request_id, None)
-
-    async def _cleanup_orphaned_events(self) -> None:
-        """
-        Periodically clean up orphaned events that were never completed.
-
-        This background task runs every 5 minutes and removes events older than 2 hours
-        to prevent unbounded memory growth from failed or abandoned requests.
-        """
-        while True:
-            try:
-                await asyncio.sleep(300)  # Run every 5 minutes
-
-                current_time = time.time()
-                max_age = 7200  # 2 hours
-
-                orphaned_ids = []
-                for request_id, event_data in self._request_events.items():
-                    age = current_time - event_data["created_at"]
-                    if age > max_age:
-                        orphaned_ids.append(request_id)
-
-                if orphaned_ids:
-                    logger.info(
-                        f"🧹 Cleaning up {len(orphaned_ids)} orphaned events older than 2 hours"
-                    )
-                    for request_id in orphaned_ids:
-                        self._request_events.pop(request_id, None)
-
-            except asyncio.CancelledError:
-                logger.info(f"🛑 Cleanup task cancelled")
-                break
-            except Exception as e:
-                logger.error(f"❌ Error in cleanup task: {e}")
-
     def _create_deployment_function(
         self, method_schema: Dict[str, Any]
     ) -> Callable[..., Any]:
@@ -504,21 +357,19 @@ class ProxyDeployment:
         method_name = method_schema["name"]
 
         async def deployment_function(*args, context: Dict[str, Any], **kwargs) -> Any:
+            # Semaphore bounds concurrency for both WebSocket and WebRTC entry paths —
+            # they share this single wrapper, so a long-running call from either
+            # transport consumes one slot until it returns.
             async with self.service_semaphore:
-                request_id = str(uuid.uuid4())
-                event_created = False
                 try:
-                    # Check user permissions
                     await self._check_permissions(context, method_name=method_name)
 
-                    # Log the method call
                     user_info = context.get("user", {}) if context else {}
                     user_id = user_info.get("id", "unknown")
                     logger.info(
                         f"🎯 User '{user_id}' calling method '{method_name}' on app '{self.application_id}'"
                     )
 
-                    # Get the method from the entry deployment handle
                     method = getattr(self.entry_deployment_handle, method_name, None)
                     if method is None:
                         logger.error(
@@ -528,28 +379,6 @@ class ProxyDeployment:
                             f"Method '{method_name}' not found on entry deployment"
                         )
 
-                    # Create event with timestamp for tracking BEFORE starting mimic request
-                    self._request_events[request_id] = {
-                        "event": asyncio.Event(),
-                        "created_at": time.time(),
-                    }
-                    event_created = True
-
-                    # Create the mimic request task but don't await it to avoid blocking
-                    mimic_task = asyncio.create_task(self._mimic_request(request_id))
-
-                    # Add error handling for the mimic task (optional - runs in background)
-                    def handle_mimic_error(task):
-                        if task.exception():
-                            logger.error(
-                                f"❌ Mimic request task failed for '{self.application_id}' request ID {request_id}: {task.exception()}"
-                            )
-                            # Clean up orphaned event if mimic request failed
-                            self._request_events.pop(request_id, None)
-
-                    mimic_task.add_done_callback(handle_mimic_error)
-
-                    # Forward the request to the actual deployment
                     try:
                         result = await method.remote(*args, **kwargs)
                         logger.info(
@@ -561,32 +390,15 @@ class ProxyDeployment:
                             f"❌ Ray task error in method '{method_name}': {e}"
                         )
                         raise
-                    except Exception as e:
-                        logger.error(
-                            f"❌ Unexpected error in method '{method_name}': {e}"
-                        )
-                        raise
 
                 except PermissionError as e:
                     logger.warning(
                         f"⚠️ Permission denied for method '{method_name}': {e}"
                     )
-                    # Clean up event if created before permission error
-                    if event_created:
-                        self._request_events.pop(request_id, None)
                     raise
                 except Exception as e:
                     logger.error(f"❌ Error in proxy function '{method_name}': {e}")
-                    # Clean up event if created before error
-                    if event_created:
-                        self._request_events.pop(request_id, None)
                     raise
-                finally:
-                    # Signal that the request is complete, but don't remove the event yet
-                    # The event will be removed when the HTTP request completes in __call__
-                    event_data = self._request_events.get(request_id)
-                    if event_data:
-                        event_data["event"].set()
 
         return schema_function(
             func=deployment_function,
@@ -1045,12 +857,6 @@ class ProxyDeployment:
                 if not self.server or not self.websocket_service_id:
                     await self._register_services()
 
-                    # Start cleanup task on first successful registration
-                    if self._cleanup_task is None or self._cleanup_task.done():
-                        self._cleanup_task = asyncio.create_task(
-                            self._cleanup_orphaned_events()
-                        )
-
         # Check if Hypha server can be reached
         try:
             logger.debug("Pinging Hypha server to check connection...")
@@ -1062,8 +868,6 @@ class ProxyDeployment:
             )
             # Reset server connection to trigger re-connection on next call
             self.server = None
-            # Clear orphaned events since the connection is lost
-            self._request_events.clear()
             raise RuntimeError("Hypha server connection failed")
 
         # Check if the WebSocket service can be reached
@@ -1080,8 +884,6 @@ class ProxyDeployment:
             )
             # Reset service ID to trigger re-registration on next call
             self.websocket_service_id = None
-            # Clear orphaned events since the service is lost
-            self._request_events.clear()
             raise RuntimeError("WebSocket service connection failed")
 
         # All checks passed - deployment is healthy
@@ -1136,12 +938,12 @@ if __name__ == "__main__":
             app_data={},
             entry_deployment_handle=entry_deployment_handle,
             method_schemas=[method_schema],
+            max_ongoing_requests=10,
             server_url=server_url,
             workspace=workspace,
             proxy_service_token=token,
             worker_client_id=worker_client_id,
             authorized_users=["*"],
-            serve_http_url="not_used_in_mock",
             proxy_actor_name="mock_actor",
             debug=True,
         )

--- a/docs/apps-guide.md
+++ b/docs/apps-guide.md
@@ -1044,19 +1044,17 @@ app_status = await bioengine_worker_service.get_app_status(
 )
 
 # Extract service IDs
-websocket_service_id = app_status["service_ids"]["websocket_service_id"]   # wildcard, one per app
-webrtc_service_ids = app_status["service_ids"]["webrtc_service_ids"]       # one per replica
+websocket_service_id = app_status["service_ids"]["websocket_service_id"]
+webrtc_service_id = app_status["service_ids"]["webrtc_service_id"]
 ```
 
 #### WebSocket Connection
 
-Websocket connections send and receive their data through the connected Hypha server. The `websocket_service_id` is a wildcard that matches every ProxyDeployment replica of the application; pass `mode="select:min:get_load"` so Hypha picks the least-busy replica per call.
+Websocket connections send and receive their data through the connected Hypha server.
 
 ```python
-# Connect via WebSocket — Hypha selects the least-busy replica per call
-websocket_service = await hypha_client.get_service(
-    websocket_service_id, {"mode": "select:min:get_load"}
-)
+# Connect via WebSocket for real-time communication
+websocket_service = await hypha_client.get_service(websocket_service_id)
 
 # Call application methods
 result = await websocket_service.process_data(
@@ -1073,8 +1071,8 @@ WebRTC connections enable peer-to-peer communication for low-latency application
 # Requires aiortc to be installed
 from hypha_rpc import get_rtc_service
 
-# Connect via WebRTC for peer-to-peer communication — pick a specific replica
-peer_connection = await get_rtc_service(hypha_client, webrtc_service_ids[0])
+# Connect via WebRTC for peer-to-peer communication
+peer_connection = await get_rtc_service(hypha_client, webrtc_service_id)
 
 webrtc_service = await peer_connection.get_service(app_id)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.9.11"
+version = "0.10.0"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.9.10"
+version = "0.9.11"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [

--- a/tests/end_to_end/test_applications.py
+++ b/tests/end_to_end/test_applications.py
@@ -447,19 +447,10 @@ async def test_startup_application(
             assert isinstance(
                 service_ids, dict
             ), f"service_ids should be a dictionary for '{application_id}'"
-            for key in ("websocket_service_id", "websocket_service_ids", "webrtc_service_ids"):
+            for key in ("websocket_service_id", "webrtc_service_id"):
                 assert (
-                    key in service_ids
-                ), f"service_ids should contain {key} for '{application_id}'"
-            assert (
-                service_ids["websocket_service_id"]
-            ), f"Running application '{application_id}' should have a websocket_service_id"
-            assert (
-                len(service_ids["websocket_service_ids"]) > 0
-            ), f"Running application '{application_id}' should have at least one per-replica websocket_service_id"
-            assert (
-                len(service_ids["webrtc_service_ids"]) > 0
-            ), f"Running application '{application_id}' should have at least one webrtc_service_id"
+                    service_ids.get(key)
+                ), f"Running application '{application_id}' should have a {key}"
 
         # Validate resource allocation structure
         if app_info["application_resources"]:
@@ -972,12 +963,9 @@ async def test_call_demo_app_functions(
         service_ids = app_status["service_ids"]
 
         websocket_service_id = service_ids["websocket_service_id"]
-        webrtc_service_id = service_ids["webrtc_service_ids"][0]
+        webrtc_service_id = service_ids["webrtc_service_id"]
 
-        # Wildcard websocket ID needs a selection mode; least-busy replica per call
-        websocket_service = await hypha_client.get_service(
-            websocket_service_id, {"mode": "select:min:get_load"}
-        )
+        websocket_service = await hypha_client.get_service(websocket_service_id)
         assert (
             websocket_service
         ), f"Could not connect to WebSocket service {websocket_service_id}"
@@ -1121,12 +1109,9 @@ async def test_call_composition_app_functions(
         service_ids = app_status["service_ids"]
 
         websocket_service_id = service_ids["websocket_service_id"]
-        webrtc_service_id = service_ids["webrtc_service_ids"][0]
+        webrtc_service_id = service_ids["webrtc_service_id"]
 
-        # Wildcard websocket ID needs a selection mode; least-busy replica per call
-        websocket_service = await hypha_client.get_service(
-            websocket_service_id, {"mode": "select:min:get_load"}
-        )
+        websocket_service = await hypha_client.get_service(websocket_service_id)
         assert (
             websocket_service
         ), f"Could not connect to WebSocket service {websocket_service_id}"


### PR DESCRIPTION
## Summary

Follow-up to PR #79. After grilling the actual responsibilities of `ProxyDeployment`, autoscaling it turns out to be more cost than benefit. Fix it at one replica, delete the scaffolding that existed solely to support its autoscaling, and — since there's now only ever one proxy replica per app — collapse the `service_ids` payload back to a single concrete ID per transport.

**Bumps `0.9.10 → 0.10.0`** — breaking change at the user-visible API.

## Why fix the proxy at 1 replica

`ProxyDeployment` is a **0-CPU Hypha bridge** in front of an app's actual work deployments. Its job is:

1. Register WebSocket + WebRTC services on Hypha (per replica)
2. Authenticate callers via `authorized_users`
3. Throttle concurrency with an in-actor semaphore (`get_load` reports its occupancy)
4. Forward calls to the inner deployment via `entry_deployment_handle`

The actual compute work — and the compute-scaling decisions — live in the inner Ray Serve deployments downstream of the proxy.

| Aspect | Verdict |
|---|---|
| Does autoscaling the proxy distribute compute load? | ❌ — inner deployments scale independently. |
| Does it lift the `max_ongoing_requests` ceiling for high-concurrency apps? | ✅ — but raising `max_ongoing_requests` on the proxy does the same thing without the multi-replica overhead. |
| Is it safe for WebRTC clients? | ❌ — peer connections are sticky to a specific replica; downscale terminates them. |
| Code complexity cost | High — the whole `_mimic_request` / `__call__` / request-id event tracker / orphaned-event cleanup task exists only to make Ray Serve's HTTP-based autoscaler aware of WebRTC traffic. |

The `_mimic_request` mechanism specifically sends a fake HTTP request to the proxy's own `__call__` endpoint with the same `X-Request-ID` as the actual RPC call, so that Ray Serve's HTTP-traffic-based autoscaler sees load for WebRTC calls (which would otherwise bypass HTTP entirely). It's a real workaround, but it's only needed because the proxy itself autoscales.

## Changes (three commits)

### `91b2a8f` — proxy fixed at 1 replica

- **`bioengine/apps/proxy_deployment.py`** — `num_replicas=1` fixed; `autoscaling_config` removed; `__call__`, `_mimic_request`, `_cleanup_orphaned_events`, the `_request_events` tracker, `_cleanup_task`, and the `serve_http_url` constructor parameter all deleted. `_create_deployment_function` simplified to: acquire semaphore → check permissions → forward to inner deployment → return. WebSocket and WebRTC calls share this single wrapper, so they equally consume the same in-actor concurrency budget (both transports register against the same `service_functions` dict in `_register_services`).
- **`bioengine/apps/builder.py`** — `serve_http_url` plumbing removed (no longer needed by `ProxyDeployment.bind`).
- **`bioengine/apps/manager.py`** — drops `serve_http_url=self.ray_cluster.serve_http_url` from the `AppBuilder.complete_initialization` call. `serve_http_url` is still computed on `RayCluster` for diagnostics/logging; only the plumbing into the apps layer is gone.

### `bc907be` — service_ids singularized

With only ever one ProxyDeployment per app, the wildcard `websocket_service_id` and the per-replica `websocket_service_ids` / `webrtc_service_ids` lists introduced in PR #79 become dead complexity. Shape collapses to one concrete ID per transport:

```python
"service_ids": {
    "websocket_service_id": "<workspace>/<worker_client_id>-<replica_id>:<application_id>",
    "webrtc_service_id":    "<workspace>/<worker_client_id>-<replica_id>:<application_id>-rtc",
}
```

Callers connect to either ID directly — no `mode='select:min:get_load'` parameter needed.

- **`bioengine/apps/manager.py`** — `_get_application_service_ids` returns the singular shape; `_get_app_status`'s static-site-URL construction updated.
- **`docs/apps-guide.md`** — Service Discovery example switched back to singular access (matches the pre-PR-#79 docs intent).
- **`tests/end_to_end/test_applications.py`** — three call sites updated.

### `f1e8335` — bump to 0.10.0

Pre-1.0 convention: bump the minor version for breaking API changes. PR #79 (0.9.10) and this PR have reshaped `service_ids` twice within two releases and now fix ProxyDeployment at a single replica — enough surface-area churn to deserve a louder signal than another patch bump.

## How concurrency works after this PR

- `max_ongoing_requests` on `deploy_app(...)` (already an API parameter — `manager.py:1523`) sizes the in-actor `service_semaphore`.
- All Hypha calls (WebSocket and WebRTC) go through `_create_deployment_function`'s `async with self.service_semaphore` wrapper — both transports equally consume slots.
- Compute scaling is the inner deployments' job. The proxy stays small and predictable.

## Migration notes for downstream callers

Callers reading `get_app_status()` need to update:

```python
# OLD (0.9.10):
ws = app_status["service_ids"]["websocket_service_id"]   # wildcard
rtc = app_status["service_ids"]["webrtc_service_ids"][0] # list
svc = await client.get_service(ws, {"mode": "select:min:get_load"})

# NEW (0.10.0):
ws = app_status["service_ids"]["websocket_service_id"]   # concrete
rtc = app_status["service_ids"]["webrtc_service_id"]     # concrete
svc = await client.get_service(ws)                       # no mode needed
```

The `bioimage.io` dashboard reads `service_ids` and needs a parallel update. I'll dispatch the change request to the bioimage.io session.

## Net diff

`-266` lines, `+39` lines across `proxy_deployment.py`, `builder.py`, `manager.py`, `apps-guide.md`, `test_applications.py`, `pyproject.toml`.

## Test plan

- [x] Syntax check on all modified files passes.
- [x] No remaining references to removed surface (`_mimic_request`, `_request_events`, `__call__`, `serve_http_url` in proxy_deployment.py, `autoscaling_config`, `_cleanup_orphaned_events`, `websocket_service_ids`, `webrtc_service_ids`, `select:min:get_load`).
- [ ] CI on this PR — `docker-publish.yml` builds and pushes `ghcr.io/aicell-lab/bioengine-worker:0.10.0`.
- [ ] After merge: deploy `bioimage-io/demo-app` and `bioimage-io/composition-app`, confirm:
    - `get_app_status()` returns the singular `service_ids` dict with both IDs populated.
    - WebSocket and WebRTC connections both succeed; semaphore correctly bounds concurrent calls from each transport equally.
    - WebRTC peer connection survives an app redeploy without the `_mimic_request` machinery.
- [ ] Downstream UI follow-up in bioimage-io/bioimage.io needed — the dashboard reads `service_ids` and will need to switch from PR #79's wildcard shape to the new singular shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)