### PR TITLE
fix(apps): _get_application_service_ids handles dict, not list

### DIFF
--- a/bioengine/apps/manager.py
+++ b/bioengine/apps/manager.py
@@ -664,7 +664,8 @@ class AppsManager:
         if not replica_ids:
             return {"websocket_service_id": None, "webrtc_service_id": None}
 
-        replica_id = replica_ids[0]
+        # get_deployment_replicas returns Dict[replica_id -> actor_id], not a list.
+        replica_id = next(iter(replica_ids))
         workspace = self.server.config.workspace
         worker_client_id = self.server.config.client_id
         return {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.10.0"
+version = "0.10.1"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Summary

Hotfix for a bug introduced by PR #80. `get_app_status()` on a worker running 0.10.0 raised `KeyError: 0` whenever any application was deployed.

## Cause

PR #80 simplified `_get_application_service_ids` to read a single replica_id off `replica_ids`:

```python
replica_id = replica_ids[0]
```

But `get_deployment_replicas` on `BioEngineProxyActor` returns `Dict[replica_id -> actor_id]`, not a list (`bioengine/cluster/proxy_actor.py:482`). Indexing a dict with `0` raises `KeyError: 0`.

The old multi-replica code happened to work because it iterated keys (`for replica_id in replica_ids`); the singularised version assumed a list and never got integration-tested with a deployed app before merging.

## Fix

```python
replica_id = next(iter(replica_ids))
```

Works on dict (returns first key) and list (returns first element). With the proxy fixed at one replica per app, there's always exactly one entry.

## Reproducer (pre-fix)

```python
status = await worker.get_app_status(None)
# KeyError: 0
#   File "/app/bioengine/apps/manager.py", line 667, in _get_application_service_ids
#     replica_id = replica_ids[0]
#                  ~~~~~~~~~~~^^^
```

Observed live on `bioimage-io/bioengine-worker-kth-6c4749f5b7-tqwck` after rolling KTH to 0.10.0.

## Files

- `bioengine/apps/manager.py` — one-line fix at `_get_application_service_ids`.
- `pyproject.toml` — `0.10.0 → 0.10.1`.

## Test plan

- [x] Syntax check.
- [x] Confirmed live reproducer matches the traceback location.
- [ ] CI on this PR — `docker-publish.yml` builds and pushes `ghcr.io/aicell-lab/bioengine-worker:0.10.1`.
- [ ] After merge: re-roll the four workers (KTH, deNBI, TÜBİTAK, Berzelius) onto 0.10.1; verify `get_app_status(None)` returns the singular `service_ids` dict without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)