### PR TITLE
fix(cluster): include memory fields in cluster-level resource rollup

### DIFF
--- a/bioengine/cluster/proxy_actor.py
+++ b/bioengine/cluster/proxy_actor.py
@@ -398,6 +398,12 @@ class BioEngineProxyActor:
                 "used_cpu": 0,
                 "total_gpu": 0,
                 "used_gpu": 0,
+                "total_memory": 0,
+                "used_memory": 0,
+                "total_gpu_memory": 0,
+                "used_gpu_memory": 0,
+                "total_object_store_memory": 0,
+                "used_object_store_memory": 0,
             },
             "nodes": {},
         }
@@ -455,10 +461,13 @@ class BioEngineProxyActor:
                 "slurm_job_id": self._get_slurm_job_id(total_resources),
             }
 
-            # Accumulate cluster resources
+            # Accumulate cluster resources. Per-node GPU memory can be the
+            # string "NA" when the Ray dashboard is unavailable — skip
+            # non-numeric values so the rest of the rollup still works.
             for resource_name in cluster_state["cluster"].keys():
                 node_value = cluster_state["nodes"][node_id][resource_name]
-                cluster_state["cluster"][resource_name] += node_value
+                if isinstance(node_value, (int, float)):
+                    cluster_state["cluster"][resource_name] += node_value
 
         if self.check_pending_resources:
             # TODO: Don't count task/actor/job in runtime creation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.10.2"
+version = "0.10.3"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Problem

`get_cluster_state` populated `total_memory`, `used_memory`, `total_gpu_memory`, `used_gpu_memory`, `total_object_store_memory`, and `used_object_store_memory` for each node under `cluster_state["nodes"][node_id]` but never aggregated them to the cluster-level summary. The `cluster_state["cluster"]` accumulator was initialised with only CPU and GPU count keys, and the loop that summed per-node values across the cluster iterated those keys — so memory was silently dropped.

Callers reading `ray_cluster.cluster.total_memory` (BioEngine worker dashboards, custom facility dashboards, anything that summarises cluster resources from `get_status()`) received `undefined`. Downstream UIs rendered Memory cards as `—/—` even though the per-node data was correct.

## Fix

- `bioengine/cluster/proxy_actor.py` — add the six memory keys to the `cluster_state["cluster"]` initialisation so the existing accumulator loop picks them up.
- The accumulator loop now skips non-numeric per-node values, so the `"NA"` sentinel that `total_gpu_memory` / `used_gpu_memory` can be set to when the Ray dashboard is unreachable does not raise a `TypeError` on string + int.
- Per-node fields are unchanged; this only adds the cluster-level aggregation that was missing.

## Files changed

- `bioengine/cluster/proxy_actor.py` — five lines added to the cluster initialiser, one `isinstance` guard added inside the rollup loop.
- `pyproject.toml` — `0.10.2 → 0.10.3`.

## Test plan

- [x] Syntax check passes on `bioengine/cluster/proxy_actor.py`.
- [ ] CI on this PR — `docker-publish.yml` builds and pushes `ghcr.io/aicell-lab/bioengine-worker:0.10.3`.
- [ ] After merge: re-roll a worker onto 0.10.3 and confirm `get_status()["ray_cluster"]["cluster"]` includes the six memory keys with positive values for a non-empty cluster, and that any custom dashboard reading `cluster.total_memory` / `cluster.used_memory` renders sensible GB values instead of `—`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)