### PR TITLE
fix(cluster): per-version proxy actor with idle self-eviction

### DIFF
--- a/bioengine/cluster/proxy_actor.py
+++ b/bioengine/cluster/proxy_actor.py
@@ -77,6 +77,12 @@ class BioEngineProxyActor:
         self.gcs_address = ray.get_runtime_context().gcs_address
         self.dashboard_url = dashboard_url
 
+        # Record the BioEngine version that constructed this actor so a
+        # worker on a different version can detect the mismatch (via
+        # ``get_bioengine_version``) and kill+recreate.
+        from bioengine import __version__ as _bioengine_version
+        self.bioengine_version: Optional[str] = _bioengine_version
+
         # Create GCS client options
         gcs_options = GcsClientOptions.create(
             self.gcs_address,
@@ -103,6 +109,17 @@ class BioEngineProxyActor:
         self._cached_geo_location: Optional[Dict[str, Optional[Union[str, float]]]] = None
 
         logger.info(f"ClusterState initialized with GCS address: {self.gcs_address}")
+        logger.info(f"BioEngine version: {self.bioengine_version}")
+
+    def get_bioengine_version(self) -> Optional[str]:
+        """Return the BioEngine version recorded when this actor was constructed.
+
+        Used by workers attaching to an existing detached actor: if the
+        returned version does not match the worker's local
+        ``bioengine.__version__``, the worker kills this actor and creates
+        a fresh one so the code matches.
+        """
+        return self.bioengine_version
 
     def get_geo_location(self) -> Dict[str, Optional[Union[str, float]]]:
         """Return the head node's geographic location, fetched from the actor's egress IP.

--- a/bioengine/cluster/proxy_actor.py
+++ b/bioengine/cluster/proxy_actor.py
@@ -1,12 +1,14 @@
+import functools
+import logging
 import os
 import re
+import threading
 import time
 import json
 import urllib.error
 import urllib.request
 from dataclasses import asdict
-from typing import Any, Dict, List, Optional, Tuple, Union
-import logging
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import ray
 from ray.util.state import StateApiClient, get_log
@@ -26,6 +28,22 @@ from ray.util.state.exception import RayStateApiException
 
 logger = logging.getLogger("ray")
 date_format = "%Y-%m-%d %H:%M:%S %Z"
+
+
+def _touch_on_call(method: Callable) -> Callable:
+    """Decorator that updates ``self._last_called_at`` on every method invocation.
+
+    Used to drive the actor's idle self-eviction timer: any public method
+    that gets called from outside the actor counts as activity and resets
+    the clock. Internal helpers (whose names start with ``_``) are not
+    wrapped — they are reached only via calls that already touched the
+    timer at the public-method boundary.
+    """
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        self._last_called_at = time.time()
+        return method(self, *args, **kwargs)
+    return wrapper
 
 
 @ray.remote(
@@ -53,8 +71,18 @@ class BioEngineProxyActor:
     automatically restarts if it fails.
     """
 
+    # Idle self-eviction: if no public method has been called for this long
+    # the actor terminates itself. Workers heartbeat via get_cluster_state()
+    # in their monitor loop, so under normal use the timer is always reset
+    # well within this window. Reaches the threshold only when every worker
+    # that was using this version has stopped using it for an extended
+    # period (e.g. all workers upgraded to a different version).
+    IDLE_EVICTION_SECONDS: float = 24 * 60 * 60  # 24 hours
+    IDLE_CHECK_INTERVAL_SECONDS: float = 10 * 60  # 10 minutes
+
     def __init__(
         self,
+        bioengine_version: str,
         exclude_head_node: bool = False,
         check_pending_resources: bool = False,
         dashboard_url: Optional[str] = None,
@@ -66,6 +94,14 @@ class BioEngineProxyActor:
         cluster state and configures monitoring behavior.
 
         Args:
+            bioengine_version: BioEngine version of the worker that constructed
+                this actor. The worker reads its own ``bioengine.__version__``
+                locally (where the package is properly pip-installed) and
+                passes it in. The actor cannot rely on ``importlib.metadata``
+                because BioEngine reaches the cluster via Ray's ``py_modules``
+                upload, which adds the source to ``sys.path`` without
+                installing dist-info — so a self-introspected version would
+                always be ``None``.
             exclude_head_node: Skip head node in resource calculations (useful for worker-only metrics)
             check_pending_resources: Include pending jobs/actors/tasks in cluster state reports
             dashboard_url: Ray dashboard base URL (e.g. "http://127.0.0.1:8265"). When BioEngine
@@ -76,12 +112,7 @@ class BioEngineProxyActor:
         # Get the GCS address via public API
         self.gcs_address = ray.get_runtime_context().gcs_address
         self.dashboard_url = dashboard_url
-
-        # Record the BioEngine version that constructed this actor so a
-        # worker on a different version can detect the mismatch (via
-        # ``get_bioengine_version``) and kill+recreate.
-        from bioengine import __version__ as _bioengine_version
-        self.bioengine_version: Optional[str] = _bioengine_version
+        self.bioengine_version: str = bioengine_version
 
         # Create GCS client options
         gcs_options = GcsClientOptions.create(
@@ -108,19 +139,51 @@ class BioEngineProxyActor:
 
         self._cached_geo_location: Optional[Dict[str, Optional[Union[str, float]]]] = None
 
+        # Idle self-eviction state. Counts construction as "activity" so
+        # the actor is not killed before any worker has a chance to call it.
+        self._last_called_at: float = time.time()
+        self._idle_stop_event = threading.Event()
+        self._idle_thread = threading.Thread(
+            target=self._idle_check_loop,
+            name="bioengine-proxy-idle-check",
+            daemon=True,
+        )
+        self._idle_thread.start()
+
         logger.info(f"ClusterState initialized with GCS address: {self.gcs_address}")
         logger.info(f"BioEngine version: {self.bioengine_version}")
 
-    def get_bioengine_version(self) -> Optional[str]:
-        """Return the BioEngine version recorded when this actor was constructed.
-
-        Used by workers attaching to an existing detached actor: if the
-        returned version does not match the worker's local
-        ``bioengine.__version__``, the worker kills this actor and creates
-        a fresh one so the code matches.
-        """
+    @_touch_on_call
+    def get_bioengine_version(self) -> str:
+        """Return the BioEngine version recorded when this actor was constructed."""
         return self.bioengine_version
 
+    def _idle_check_loop(self) -> None:
+        """Background thread loop that self-evicts the actor after long idleness.
+
+        Runs in a daemon thread (so it dies with the actor process). Wakes
+        every ``IDLE_CHECK_INTERVAL_SECONDS`` and, if no public method has
+        been called for ``IDLE_EVICTION_SECONDS``, calls
+        ``ray.actor.exit_actor()`` which terminates the actor gracefully
+        and frees the named slot so a future worker can construct a fresh
+        one. ``max_restarts`` does not apply to ``exit_actor`` exits.
+        """
+        while not self._idle_stop_event.wait(self.IDLE_CHECK_INTERVAL_SECONDS):
+            try:
+                idle_seconds = time.time() - self._last_called_at
+                if idle_seconds >= self.IDLE_EVICTION_SECONDS:
+                    logger.warning(
+                        f"BioEngineProxyActor (version {self.bioengine_version}) "
+                        f"idle for {idle_seconds / 3600:.1f} h "
+                        f"(threshold {self.IDLE_EVICTION_SECONDS / 3600:.1f} h); "
+                        f"self-evicting."
+                    )
+                    ray.actor.exit_actor()
+                    return
+            except Exception as e:
+                logger.error(f"Idle-check loop error (continuing): {e}", exc_info=True)
+
+    @_touch_on_call
     def get_geo_location(self) -> Dict[str, Optional[Union[str, float]]]:
         """Return the head node's geographic location, fetched from the actor's egress IP.
 
@@ -345,6 +408,7 @@ class BioEngineProxyActor:
 
         return per_node_gpu_memory, True
 
+    @_touch_on_call
     def get_cluster_state(self) -> Dict[str, Any]:
         """
         Get comprehensive cluster resource information including per-node breakdown.
@@ -503,6 +567,7 @@ class BioEngineProxyActor:
 
         return cluster_state
 
+    @_touch_on_call
     def get_deployment_replicas(
         self, application_id: str, deployment_name: str
     ) -> Dict[str, str]:
@@ -538,6 +603,7 @@ class BioEngineProxyActor:
         }
         return replica_info
 
+    @_touch_on_call
     def register_serve_replica(
         self,
         application_id: str,
@@ -613,6 +679,7 @@ class BioEngineProxyActor:
             f"deployment '{deployment_name}' with actor ID '{actor_id}' (replica timezone: {timezone})."
         )
 
+    @_touch_on_call
     def clear_application_replicas(self, application_id: str) -> None:
         """
         Clear all registered replicas for a specific application.
@@ -628,6 +695,7 @@ class BioEngineProxyActor:
             f"Cleared all registered replicas for application '{application_id}'."
         )
 
+    @_touch_on_call
     def get_actor_logs(
         self,
         actor_id: str,
@@ -699,6 +767,7 @@ class BioEngineProxyActor:
 
         return logs
 
+    @_touch_on_call
     def get_deployment_logs(
         self,
         application_id: str,

--- a/bioengine/cluster/ray_cluster.py
+++ b/bioengine/cluster/ray_cluster.py
@@ -726,6 +726,59 @@ class RayCluster:
         )
         self.logger.info(f"Ray Serve HTTP URL: {self.serve_http_url}")
 
+    async def _evict_stale_proxy_actor(self) -> None:
+        """Kill an existing proxy actor whose BioEngine version differs from ours.
+
+        The proxy actor is a ``lifetime="detached"`` actor that survives across
+        worker pod restarts. After a BioEngine upgrade, the new worker pod
+        re-attaches to the old actor (which still runs the previous version's
+        code), so bug fixes never reach callers until the actor is replaced.
+
+        This method:
+          1. Attempts to attach to the existing actor by name.
+          2. Reads its ``bioengine_version`` (the version it was constructed with).
+          3. If the version differs from the local ``bioengine.__version__``,
+             kills the actor so the subsequent ``get_if_exists=True`` creation
+             produces a fresh one with the current code.
+
+        Old actors that predate the ``get_bioengine_version`` method are
+        treated as stale and replaced. Missing actor: no-op.
+        """
+        from bioengine import __version__ as local_version
+
+        try:
+            existing = ray.get_actor(name=self.proxy_actor_name, namespace="bioengine")
+        except ValueError:
+            return  # no existing actor; nothing to evict
+
+        try:
+            existing_version = await asyncio.wait_for(
+                existing.get_bioengine_version.remote(), timeout=10.0
+            )
+            if existing_version == local_version:
+                return  # version matches; keep using it
+            reason = (
+                f"BioEngine version mismatch: actor reports "
+                f"{existing_version}, local is {local_version}"
+            )
+        except Exception as e:
+            reason = (
+                f"could not read bioengine_version from existing actor "
+                f"(likely pre-versioning release): {type(e).__name__}: {e}"
+            )
+
+        self.logger.warning(
+            f"Killing stale '{self.proxy_actor_name}' detached actor — {reason}."
+        )
+        try:
+            ray.kill(existing, no_restart=True)
+        except Exception as e:
+            self.logger.warning(
+                f"ray.kill failed for stale '{self.proxy_actor_name}' "
+                f"(continuing — get_if_exists will replace it): "
+                f"{type(e).__name__}: {e}"
+            )
+
     async def _connect_to_cluster(self) -> ray.client_builder.ClientContext:
         """Connect to the Ray cluster using the configured head node address.
 
@@ -778,6 +831,13 @@ class RayCluster:
             else:
                 dashboard_port = self.ray_cluster_config["ports"]["dashboard"]
                 dashboard_url = f"http://127.0.0.1:{dashboard_port}"
+
+            # If a stale proxy actor from a previous BioEngine version is
+            # still attached to this Ray cluster, kill it so the new code
+            # path runs. Without this, an upgrade rolls the worker pod but
+            # the detached actor (created by the previous pod) keeps
+            # serving requests with the older method implementations.
+            await self._evict_stale_proxy_actor()
 
             # Reuse a stable detached proxy actor across worker restarts
             # If it does not exist yet, create it

--- a/bioengine/cluster/ray_cluster.py
+++ b/bioengine/cluster/ray_cluster.py
@@ -179,7 +179,11 @@ class RayCluster:
         self.address = None
         self.serve_http_url = None
         self.proxy_actor_handle = None
-        self.proxy_actor_name = "BIOENGINE_PROXY_ACTOR"
+        # Version-suffix the actor name so workers on different BioEngine
+        # versions get their own detached actor — they don't fight over the
+        # same one. Strip characters that aren't safe in a Ray actor name.
+        _safe_version = re.sub(r"[^a-zA-Z0-9_]", "_", bioengine.__version__ or "unknown")
+        self.proxy_actor_name = f"BIOENGINE_PROXY_ACTOR_{_safe_version}"
         self.cluster_status_history = OrderedDict()
         self.max_status_history_length = 100
         self.is_ready = asyncio.Event()
@@ -726,59 +730,6 @@ class RayCluster:
         )
         self.logger.info(f"Ray Serve HTTP URL: {self.serve_http_url}")
 
-    async def _evict_stale_proxy_actor(self) -> None:
-        """Kill an existing proxy actor whose BioEngine version differs from ours.
-
-        The proxy actor is a ``lifetime="detached"`` actor that survives across
-        worker pod restarts. After a BioEngine upgrade, the new worker pod
-        re-attaches to the old actor (which still runs the previous version's
-        code), so bug fixes never reach callers until the actor is replaced.
-
-        This method:
-          1. Attempts to attach to the existing actor by name.
-          2. Reads its ``bioengine_version`` (the version it was constructed with).
-          3. If the version differs from the local ``bioengine.__version__``,
-             kills the actor so the subsequent ``get_if_exists=True`` creation
-             produces a fresh one with the current code.
-
-        Old actors that predate the ``get_bioengine_version`` method are
-        treated as stale and replaced. Missing actor: no-op.
-        """
-        from bioengine import __version__ as local_version
-
-        try:
-            existing = ray.get_actor(name=self.proxy_actor_name, namespace="bioengine")
-        except ValueError:
-            return  # no existing actor; nothing to evict
-
-        try:
-            existing_version = await asyncio.wait_for(
-                existing.get_bioengine_version.remote(), timeout=10.0
-            )
-            if existing_version == local_version:
-                return  # version matches; keep using it
-            reason = (
-                f"BioEngine version mismatch: actor reports "
-                f"{existing_version}, local is {local_version}"
-            )
-        except Exception as e:
-            reason = (
-                f"could not read bioengine_version from existing actor "
-                f"(likely pre-versioning release): {type(e).__name__}: {e}"
-            )
-
-        self.logger.warning(
-            f"Killing stale '{self.proxy_actor_name}' detached actor — {reason}."
-        )
-        try:
-            ray.kill(existing, no_restart=True)
-        except Exception as e:
-            self.logger.warning(
-                f"ray.kill failed for stale '{self.proxy_actor_name}' "
-                f"(continuing — get_if_exists will replace it): "
-                f"{type(e).__name__}: {e}"
-            )
-
     async def _connect_to_cluster(self) -> ray.client_builder.ClientContext:
         """Connect to the Ray cluster using the configured head node address.
 
@@ -832,15 +783,10 @@ class RayCluster:
                 dashboard_port = self.ray_cluster_config["ports"]["dashboard"]
                 dashboard_url = f"http://127.0.0.1:{dashboard_port}"
 
-            # If a stale proxy actor from a previous BioEngine version is
-            # still attached to this Ray cluster, kill it so the new code
-            # path runs. Without this, an upgrade rolls the worker pod but
-            # the detached actor (created by the previous pod) keeps
-            # serving requests with the older method implementations.
-            await self._evict_stale_proxy_actor()
-
-            # Reuse a stable detached proxy actor across worker restarts
-            # If it does not exist yet, create it
+            # Each BioEngine version gets its own detached proxy actor (the
+            # name is version-suffixed in ``__init__``). Workers on the same
+            # version share an actor; workers on different versions never
+            # collide. Older actors self-evict after a long idle period.
             proxy_actor = BioEngineProxyActor.options(
                 name=self.proxy_actor_name,
                 namespace="bioengine",
@@ -848,6 +794,7 @@ class RayCluster:
                 get_if_exists=True,
             )
             self.proxy_actor_handle = proxy_actor.remote(
+                bioengine_version=bioengine.__version__,
                 exclude_head_node=exclude_head_node,
                 check_pending_resources=check_pending_resources,
                 dashboard_url=dashboard_url,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.10.3"
+version = "0.10.4"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Problem

`BioEngineProxyActor` is a Ray `lifetime="detached"` actor that survives across worker pod restarts. The worker attaches via `get_if_exists=True`, so an existing actor is reused rather than recreated. This is correct for the same-version restart case, but has two real failure modes today:

1. **Code drift across BioEngine versions.** Old pod (version N) creates the detached actor with N's code. Pod restarts on version N+1. New pod re-attaches to the existing actor — but that actor's Python process still runs N's code. Any fix shipped in N+1 doesn't reach callers until someone manually `ray.kill`s the actor. This has bitten us repeatedly during rollouts (missing memory-rollup keys, missing methods, changed status payload shapes).

2. **Workers on different BioEngine versions sharing one Ray cluster.** A naive "detect mismatch and kill" handshake ping-pongs: worker A on N attaches, then worker B on N+1 kills and recreates, then worker A reattaches and kills again, and so on every reconnect.

## Why a simpler version-check inside the actor doesn't work

The actor cannot rely on `importlib.metadata` to read its own version. BioEngine reaches the cluster via Ray's `py_modules` upload, which adds the source directory to the actor process's `sys.path` *without* installing the package's `.dist-info`. So a self-introspected `bioengine.__version__` inside the actor is always `None`, which means any "actor reports version X, worker is Y, kill if X ≠ Y" check would evict on every attach.

## Fix

Three changes that, together, eliminate both failure modes:

### 1. Version-suffixed actor name

Each BioEngine version gets its own detached actor:

```python
self.proxy_actor_name = f"BIOENGINE_PROXY_ACTOR_{_safe_version}"
```

Workers on the same version share an actor and benefit from detached persistence as before. Workers on different versions land on different actors and never collide. The kill-and-recreate flow is gone.

### 2. Version passed by the worker, not introspected by the actor

The worker reads its own `bioengine.__version__` locally (where the package is properly pip-installed) and passes it in at construction:

```python
proxy_actor.remote(bioengine_version=bioengine.__version__, ...)
```

`BioEngineProxyActor.get_bioengine_version` returns the value the worker passed. Sidesteps the `py_modules` / `importlib.metadata` problem entirely.

### 3. Idle self-eviction

A daemon thread in the actor wakes every 10 minutes; if no public method has been called for 24 hours, the actor terminates via `ray.actor.exit_actor()` and its named slot becomes free for a future worker to use. Workers heartbeat through `get_cluster_state()` on their monitor tick, so under normal use the timer is always reset well within the window. The threshold is reached only when every worker that was using this version has stopped using it for an extended period (e.g. all upgraded to a different version).

A small `_touch_on_call` decorator wraps every public method to update the idle timer. Internal helpers (names starting with `_`) are not wrapped — they are called only from public methods that already touched the timer at the boundary.

## Files changed

- `bioengine/cluster/proxy_actor.py` — new `bioengine_version` constructor parameter; `_touch_on_call` decorator applied to every public method; daemon-thread idle-check loop with class constants `IDLE_EVICTION_SECONDS = 24 h` and `IDLE_CHECK_INTERVAL_SECONDS = 10 min`; `ray.actor.exit_actor()` on idle expiry.
- `bioengine/cluster/ray_cluster.py` — `self.proxy_actor_name` is now version-suffixed; `bioengine_version` is passed when constructing the actor; the previous-iteration `_evict_stale_proxy_actor` method and its call in `_connect_to_cluster` are removed.
- `pyproject.toml` — `0.10.3 → 0.10.4`.

## Test plan

- [x] Syntax check on both modified files.
- [ ] CI on this PR — `docker-publish.yml` builds and pushes `ghcr.io/aicell-lab/bioengine-worker:0.10.4`.
- [ ] After merge: roll one worker from 0.10.3 to 0.10.4 without any manual actor-kill step. Verify the new worker creates `BIOENGINE_PROXY_ACTOR_0_10_4` and its `get_status()` payload reflects 0.10.4 behaviour (e.g. the cluster-level memory keys from PR #85 remain present without needing a stale-actor kill).
- [ ] Run a second worker on a different version against the same Ray cluster (e.g. the local TÜBİTAK harness on 0.10.3 plus an upgraded one on 0.10.4) and verify both register correctly under their own actors and neither evicts the other.
- [ ] Same-version restart: bounce a worker without changing the image tag. Verify the existing actor is reused (no warning logs, no extra latency, no new GCS package uploads beyond what Ray's cache already has).

🤖 Generated with [Claude Code](https://claude.com/claude-code)