### PR TITLE
feat(packaging): publish bioengine to PyPI

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -13,9 +13,6 @@ on:
         options:
           - testpypi
           - pypi
-  push:
-    branches:
-      - feat/pypi-publish
 
 jobs:
   build:
@@ -57,7 +54,7 @@ jobs:
   publish-testpypi:
     name: Publish to TestPyPI
     needs: build
-    if: github.event_name == 'release' || github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi')
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi')
     runs-on: ubuntu-latest
     environment:
       name: testpypi

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -13,6 +13,9 @@ on:
         options:
           - testpypi
           - pypi
+  push:
+    branches:
+      - feat/pypi-publish
 
 jobs:
   build:
@@ -54,7 +57,7 @@ jobs:
   publish-testpypi:
     name: Publish to TestPyPI
     needs: build
-    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi')
+    if: github.event_name == 'release' || github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi')
     runs-on: ubuntu-latest
     environment:
       name: testpypi

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,91 @@
+name: Publish Python Package to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Index to publish to"
+        required: true
+        default: "testpypi"
+        type: choice
+        options:
+          - testpypi
+          - pypi
+
+jobs:
+  build:
+    name: Build sdist and wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade build twine
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Verify version matches tag (release only)
+        if: github.event_name == 'release'
+        run: |
+          PKG_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          TAG_NAME="${GITHUB_REF_NAME#v}"
+          echo "pyproject.toml version: $PKG_VERSION"
+          echo "release tag:            $TAG_NAME"
+          if [ "$PKG_VERSION" != "$TAG_NAME" ]; then
+            echo "Tag $GITHUB_REF_NAME does not match pyproject.toml version $PKG_VERSION" >&2
+            exit 1
+          fi
+
+      - name: Check distributions
+        run: python -m twine check --strict dist/*
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    needs: build
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi')
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/bioengine
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: build
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi')
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/bioengine
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="docs/assets/bioengine-icon.svg" alt="BioEngine Logo" width="200"/>
+  <img src="https://raw.githubusercontent.com/aicell-lab/bioengine/main/docs/assets/bioengine-icon.svg" alt="BioEngine Logo" width="200"/>
 
   # BioEngine
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.10.4"
+version = "0.10.5"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.10.3"
+version = "0.10.4"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [
-    {name = "Nils Mechtel", github = "nilsmechtel", affiliation = "KTH"}
+    {name = "Nils Mechtel", email = "nils.mech@gmail.com"}
 ]
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -82,9 +82,18 @@ include = [
 [tool.hatch.build.targets.wheel.sources]
 "bioengine" = "bioengine"
 
+[tool.hatch.build.targets.sdist]
+include = [
+    "/bioengine",
+    "/README.md",
+    "/LICENSE",
+    "/pyproject.toml",
+]
+
 [project.urls]
+"Homepage" = "https://github.com/aicell-lab/bioengine"
 "Repository" = "https://github.com/aicell-lab/bioengine"
-"Documentation" = "https://github.com/aicell-lab/bioengine/README.md"
+"Documentation" = "https://github.com/aicell-lab/bioengine#readme"
 "Bug Tracker" = "https://github.com/aicell-lab/bioengine/issues"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary

Prepare the `bioengine` package for PyPI distribution and add an automated publish workflow.

A first release of `bioengine 0.10.4` has been published to **TestPyPI**:
- Project: https://test.pypi.org/project/bioengine/0.10.4/
- Install: `pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ 'bioengine[cli]==0.10.4'`

The real PyPI release is **blocked** by an empty name squat on https://pypi.org/project/bioengine/ (zero releases, project status `active`). A PEP 541 reclaim request is the next step; the workflow is wired for both indices so a real-PyPI release becomes a single `workflow_dispatch` (or GitHub Release) once the name is available.

## What changed

**`pyproject.toml`**
- Bump `version` to `0.10.4`.
- Replace non-standard `authors` keys (`github`, `affiliation`) with PEP 621–compliant `email`.
- Add `Homepage` URL; correct `Documentation` URL to `#readme` anchor.
- Add `[tool.hatch.build.targets.sdist]` whitelist (`/bioengine`, `/README.md`, `/LICENSE`, `/pyproject.toml`). The previous sdist defaulted to the full repo and shipped ~6.7 MB including `apps/`, `docs/`, `tests/`, `docker/`, `CLAUDE.md` and multiple agent worktrees from `.dev/worktree/`. The new sdist is **147 KB**.

**`README.md`**
- Rewrite the logo `<img src>` from a relative `docs/assets/...` path to an absolute `raw.githubusercontent.com` URL so the PyPI project page renders.

**`.github/workflows/publish-pypi.yml`** (new)
- Triggers: GitHub Releases, plus `workflow_dispatch` with a `testpypi`/`pypi` choice.
- One `build` job (`python -m build` → `twine check --strict`) feeds two publish jobs gated on the trigger.
- Uses **PyPI Trusted Publishing (OIDC)** via `pypa/gh-action-pypi-publish@release/v1` and GitHub Environments named `testpypi` and `pypi`. No long-lived API tokens are stored in the repo.
- Release flow enforces `tag == pyproject version`.
- TestPyPI step uses `skip-existing: true` so re-runs of the same version do not fail.

## Build verification

- `python -m build` produces `bioengine-0.10.4-py3-none-any.whl` (165 KB, 42 files, `bioengine/**/*.py` only) and `bioengine-0.10.4.tar.gz` (147 KB).
- `twine check --strict dist/*` passes.
- Clean-venv install from the wheel imports `bioengine` and runs the `bioengine` CLI entry point (with `[cli]` extras).
- Clean-venv install from TestPyPI succeeds; `bioengine --version` reports `0.10.4`.

## Activation steps (after merge)

The workflow is ready to run, but trusted publishing requires one one-time configuration on each index. The repo maintainer needs to:

1. **TestPyPI** — at https://test.pypi.org/manage/project/bioengine/settings/publishing/, add a Trusted Publisher with:
   - Owner: `aicell-lab`
   - Repository: `bioengine`
   - Workflow filename: `publish-pypi.yml`
   - Environment name: `testpypi`
2. **PyPI** — once the `bioengine` name is available, register a *pending* Trusted Publisher at https://pypi.org/manage/account/publishing/ with the same fields but environment name `pypi`.
3. Create matching GitHub Environments (`testpypi`, `pypi`) under repository settings.

Until step 2 is possible, the `publish-pypi` job will fail if dispatched; the `publish-testpypi` job is fully functional once step 1 is done.

## Out of scope

- PEP 541 name reclaim for `pypi.org/project/bioengine/` — this is a manual filing at https://github.com/pypi/support and is independent of any code change.
- Real-PyPI first release — gated on the name being freed.
- A `bioengine-worker` interim name on real PyPI — not pursued in this PR.

## Test plan

- [ ] Configure the TestPyPI Trusted Publisher and the `testpypi` GitHub Environment per the steps above.
- [ ] Run `Publish Python Package to PyPI` via `workflow_dispatch` with `target=testpypi` against a version not yet on TestPyPI; verify the upload and a clean install via `pip install --index-url https://test.pypi.org/simple/ 'bioengine[cli]==<version>'`.
- [ ] (Once the PyPI name is available) Configure the PyPI pending publisher and `pypi` Environment; cut a GitHub Release at `v<version>` matching `pyproject.toml`; verify both jobs succeed and `pip install bioengine[cli]==<version>` works from real PyPI.

## File-level summary

| File | Change |
|------|--------|
| `pyproject.toml` | version bump, authors schema fix, sdist whitelist, URL polish |
| `README.md` | absolute logo URL for PyPI rendering |
| `.github/workflows/publish-pypi.yml` | new — build + TestPyPI + PyPI publish via OIDC |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
