### PR TITLE
fix(worker): use rolling python:3.11-slim for fresh Debian security

### DIFF
--- a/docker/worker.Dockerfile
+++ b/docker/worker.Dockerfile
@@ -1,5 +1,5 @@
-# Use an official slim Python 3.11 image
-FROM python:3.11.9-slim
+# Rolling tag — each build picks up current Debian-slim security patches.
+FROM python:3.11-slim
 
 # Set environment variables for installation
 ENV PYTHONUNBUFFERED=1 \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.10.5"
+version = "0.10.6"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Summary

Switch the bioengine-worker base image from `python:3.11.9-slim` to the rolling `python:3.11-slim` tag so each Docker build picks up current Debian 12 security patches.

## Motivation

`python:3.11.9-slim` has not been republished since the 3.11.9 point release in April 2024, which freezes the underlying Debian 12 snapshot in the image. The Debian security team has since shipped point releases for `glibc`, `openssl`, `expat`, `binutils`, `git`, `krb5`, `openldap`, `dpkg`, `tiff`, `sqlite3`, `patch`, and `openssh-client` — none of which reach our image while the tag stays pinned.

A NeuVector scan of `bioengine-worker-kth` (0.10.4) on 2026-05-29 surfaced 891 CVEs against the pod. 667 are `linux-libc-dev` kernel-header passthrough (not exploitable in-container). Of the remaining 224, **62 are real Highs** concentrated in the packages above. Every one of them is already fixed in current `python:3.11-slim`.

## Change

```diff
- # Use an official slim Python 3.11 image
- FROM python:3.11.9-slim
+ # Use the rolling Python 3.11 slim tag so each image build picks up the
+ # latest Debian 12 security patches. Pinning a specific Python patch
+ # (e.g. 3.11.9-slim) freezes the underlying Debian snapshot too, which
+ # accumulates unfixed glibc/openssl/expat CVEs over time.
+ FROM python:3.11-slim
```

## Reproducibility

Rolling tags are non-deterministic at the *tag* level but fully reproducible at the *digest* level. `docker-publish.yml` publishes a specific `sha256:…` for each `bioengine-worker:X.Y.Z` release, and downstream Helm values pin that digest. Build-time non-determinism is the price of keeping the security base layer fresh.

The Ray install step (`pip install "ray[client,serve]==${RAY_VERSION}"`) is unchanged and remains deterministic.

## Test plan

- [ ] CI builds `ghcr.io/aicell-lab/bioengine-worker:<version>` against the rolling base.
- [ ] Pull the resulting image and confirm `ldd --version` reports `2.36-9+deb12u14` (or later) and `openssl version` reports a current 3.0.x.
- [ ] Worker comes up on Europa single-machine mode against the new image.
- [ ] Rollout to KTH (`bioengine-worker-kth`), confirm pod ready + `get_status` returns `is_ready: true`.
- [ ] Re-run NeuVector scan and confirm the 62 non-kernel High CVEs drop.

## File-level summary

- `docker/worker.Dockerfile` — one-line `FROM` change plus an inline comment explaining the choice.
