### PR TITLE
ci: align version-check with docker-publish and run on ready_for_review

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - main
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   check-version:
@@ -48,7 +49,7 @@ jobs:
         echo "Changed files:" && echo "$CHANGED_FILES" | sed 's/^/ - /'
 
         # Match original path filters
-        if echo "$CHANGED_FILES" | grep -E '^(bioengine/|requirements[^/]*\.txt$|pyproject\.toml$|Dockerfile$|\.dockerignore$)' >/dev/null; then
+        if echo "$CHANGED_FILES" | grep -E '^(bioengine/|docker/|requirements[^/]*\.txt$|pyproject\.toml$|\.dockerignore$)' >/dev/null; then
           echo "RELEVANT_CHANGE=true" >> $GITHUB_ENV
           echo "relevant=true" >> $GITHUB_OUTPUT
           echo "Relevant changes detected; version check will run."


### PR DESCRIPTION
## Summary

Two coupled fixes in `.github/workflows/version-check.yml`:

1. Listen for `ready_for_review` so the workflow fires when a draft PR is marked ready. Without this, the existing `if: github.event.pull_request.draft == false` guard plus the default `pull_request` event types (`opened`, `synchronize`, `reopened`) combine into a deadlock: a draft PR's full lifecycle can finish without `check-version` ever running, branch protection's required `check-version` status is then never posted, and the PR cannot be merged.
2. Replace the relevant-files regex `Dockerfile$` with `^docker/`. The old pattern matched a literal root-level file named `Dockerfile` (which does not exist in this repo) and missed every file under `docker/`. A PR that only edits `docker/worker.Dockerfile` was therefore marked "not relevant" and skipped the version check — even though `docker-publish.yml` would still trigger a new image build on the same paths and fail its strict-greater check at publish time. The new regex mirrors `docker-publish.yml`'s `paths:` block exactly.

## Behaviour after this change

For every PR targeting `main`:

| Diff contains… | `check-version` job |
|---|---|
| Only paths outside `bioengine/`, `docker/`, `requirements*.txt`, `pyproject.toml`, `.dockerignore` | Runs, prints "no relevant files changed", passes green |
| Any path under `bioengine/`, `docker/`, `requirements*.txt`, `pyproject.toml`, `.dockerignore` | Runs, enforces `pyproject.toml` `version` > `origin/main`'s |
| PR is still in draft | Skipped (existing `if:`) |
| PR transitions draft → ready for review | Runs (new event listener) |

Branch protection's "require `check-version`" rule now works uniformly: green for non-build PRs, enforced for build PRs, no merge-blocking gaps for the draft-then-ready workflow.

## Test plan

- [ ] Open this PR. The workflow runs on `opened`, sees no relevant files changed (`.github/workflows/**` is not in the build paths), prints the skip message, passes.
- [ ] After merge: rebase PR #88 onto `main`. The new workflow fires on `synchronize`, sees `docker/worker.Dockerfile` is relevant, validates 0.10.6 > 0.10.5, passes.
- [ ] Future draft PRs: open as draft, push the bump commit, mark ready — `ready_for_review` fires, the required status check is posted.

## File-level summary

- `.github/workflows/version-check.yml` — two edits: add `types: [...ready_for_review]`, fix relevant-paths regex.
