### PR TITLE
fix(worker): apt-get --no-install-recommends

### DIFF
--- a/docker/worker.Dockerfile
+++ b/docker/worker.Dockerfile
@@ -7,7 +7,7 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     build-essential \
     curl \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.10.6"
+version = "0.10.7"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Summary

Add `--no-install-recommends` to the system-deps `apt-get install` line in `docker/worker.Dockerfile` so `build-essential`'s recommended (but unused) tail does not enter the image.

## Motivation

The 2026-06-01 NeuVector scan of the post-0.10.6 worker pod surfaced 30 genuine (non-kernel-passthrough) High CVEs. 9 of them are concentrated in `binutils` — CVE-2017-13716 and adjacent IDs that Debian marks `N/A` (acknowledged, will not backport). The package is not directly installed; it enters via `build-essential → Recommends: dpkg-dev, g++, manpages-dev, ...` which Debian's apt installs unless `--no-install-recommends` is passed.

Dropping the recommends removes binutils and the man-page / dpkg-dev tail without losing the functional bits (`gcc`, `make`, `libc6-dev`) that `build-essential → Depends:` still pulls in.

## Verification

Local smoke test against the rolling `python:3.11-slim` base:

| Check | Result |
|---|---|
| `docker build -f docker/worker.Dockerfile -t bioengine-worker-local:no-recommends .` | succeeds |
| Worker boot in `--mode single-machine` (CPU only) | registers on Hypha within ~17 s |
| `get_status()` → `is_ready` | `True` |
| `run_code(2+2)` on a Ray task | returns `4` |
| `run_code(httpx.get https://hypha.aicell.io/health)` | returns `200` |
| `gcc --version` inside a Ray task (regression guard for build-essential) | `gcc (Debian 14.2.0-19) 14.2.0` |

The gcc check is the critical guard — `--no-install-recommends` would silently break C-extension pip installs (in apps' `runtime_env.pip`) if it accidentally pruned the compiler. It did not.

## Expected effect

Next NeuVector scan should show the 9 binutils Highs cleared. The remaining ~21 worker Highs (glibc, patch, openldap, krb5, git, expat) are upstream Debian package-tracker entries that won't move without a base-image refresh — separate from this PR.

## File-level summary

- `docker/worker.Dockerfile` — one-word addition to the existing `apt-get install` line.

## Test plan

- [ ] CI builds 0.10.x against the new Dockerfile.
- [ ] Rollout to KTH worker; `get_status` returns `is_ready: true`.
- [ ] Re-run NeuVector scan; confirm binutils Highs gone, gcc still present in the image (`docker run --rm <image> gcc --version`).
