### PR TITLE
ci: split docker-publish into worker + datasets workflows

### DIFF
--- a/.github/workflows/docker-publish-datasets.yml
+++ b/.github/workflows/docker-publish-datasets.yml
@@ -1,14 +1,13 @@
-name: Build and Publish Docker Images
+name: Build and Publish Datasets Image
 
 on:
   push:
     branches:
       - main
     paths:
-      - 'bioengine/**'
-      - 'requirements*.txt'
-      - 'pyproject.toml'
-      - 'docker/**'
+      - 'bioengine/datasets/**'
+      - 'requirements-datasets.txt'
+      - 'docker/datasets.Dockerfile'
       - '.dockerignore'
   workflow_dispatch:
 
@@ -50,7 +49,7 @@ jobs:
             sudo apt-get update && sudo apt-get install -y skopeo
         fi
 
-        IMAGE="docker://ghcr.io/aicell-lab/bioengine-worker"
+        IMAGE="docker://ghcr.io/aicell-lab/bioengine-datasets"
         echo "🔍 Fetching tags for $IMAGE..."
 
         if ! skopeo list-tags "$IMAGE" > /dev/null 2>&1; then
@@ -60,17 +59,14 @@ jobs:
 
         TAGS=$(skopeo list-tags "$IMAGE" | jq -r '.Tags[]')
 
-        # Canonical X.Y.Z tags only — this is what this workflow publishes.
-        # Excludes manually-pushed rc tags (0.9.1-rcN) and external-cluster
-        # overlays (0.9.1-rcN-rayX.Y.Z), neither of which CI ever produces.
         LATEST_VERSION=$(echo "$TAGS" \
           | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
           | sort -V \
           | tail -n1)
 
         if [ -z "$LATEST_VERSION" ]; then
-          echo "❌ No version tags found for $IMAGE."
-          exit 1
+          echo "ℹ️  No prior version tags found for $IMAGE — first publish."
+          LATEST_VERSION="0.0.0"
         fi
 
         echo "📦 Latest published version: $LATEST_VERSION"
@@ -92,21 +88,6 @@ jobs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
-
-    - name: Build and push worker image
-      uses: docker/build-push-action@v5
-      with:
-        context: .
-        file: docker/worker.Dockerfile
-        platforms: linux/amd64,linux/arm64
-        push: true
-        tags: |
-          ghcr.io/aicell-lab/bioengine-worker:latest
-          ghcr.io/aicell-lab/bioengine-worker:${{ env.VERSION }}
-        labels: |
-          org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-        cache-from: type=gha,scope=worker
-        cache-to: type=gha,mode=max,scope=worker
 
     - name: Build and push datasets image
       uses: docker/build-push-action@v5

--- a/.github/workflows/docker-publish-worker.yml
+++ b/.github/workflows/docker-publish-worker.yml
@@ -6,8 +6,8 @@ on:
       - main
     paths:
       - 'bioengine/**'
+      - '!bioengine/datasets/**'
       - 'requirements-worker.txt'
-      - 'pyproject.toml'
       - 'docker/worker.Dockerfile'
       - 'docker/worker-ray-overlay.Dockerfile'
       - '.dockerignore'

--- a/.github/workflows/docker-publish-worker.yml
+++ b/.github/workflows/docker-publish-worker.yml
@@ -1,0 +1,110 @@
+name: Build and Publish Worker Image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'bioengine/**'
+      - 'requirements-worker.txt'
+      - 'pyproject.toml'
+      - 'docker/worker.Dockerfile'
+      - 'docker/worker-ray-overlay.Dockerfile'
+      - '.dockerignore'
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 2
+
+    - name: Extract current version from pyproject.toml
+      run: |
+        VERSION=$(grep -E '^version\s*=' pyproject.toml | sed -E 's/version\s*=\s*"(.*)"/\1/')
+        if [ -z "$VERSION" ]; then
+          echo "❌ Could not extract version from pyproject.toml"
+          exit 1
+        fi
+        echo "📦 Extracted version: $VERSION"
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Get latest version from container registry
+      run: |
+        if ! command -v skopeo &> /dev/null; then
+            echo "skopeo could not be found, installing..."
+            sudo apt-get update && sudo apt-get install -y skopeo
+        fi
+
+        IMAGE="docker://ghcr.io/aicell-lab/bioengine-worker"
+        echo "🔍 Fetching tags for $IMAGE..."
+
+        if ! skopeo list-tags "$IMAGE" > /dev/null 2>&1; then
+          echo "❌ Could not list tags for $IMAGE."
+          exit 1
+        fi
+
+        TAGS=$(skopeo list-tags "$IMAGE" | jq -r '.Tags[]')
+
+        # Canonical X.Y.Z tags only — this is what this workflow publishes.
+        # Excludes manually-pushed rc tags (0.9.1-rcN) and external-cluster
+        # overlays (0.9.1-rcN-rayX.Y.Z), neither of which CI ever produces.
+        LATEST_VERSION=$(echo "$TAGS" \
+          | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+          | sort -V \
+          | tail -n1)
+
+        if [ -z "$LATEST_VERSION" ]; then
+          echo "❌ No version tags found for $IMAGE."
+          exit 1
+        fi
+
+        echo "📦 Latest published version: $LATEST_VERSION"
+        echo "PREVIOUS_VERSION=$LATEST_VERSION" >> $GITHUB_ENV
+
+    - name: Check that version is updated and newer
+      run: |
+        echo "📦 Previous version: $PREVIOUS_VERSION"
+        echo "📦 Current version:  $VERSION"
+        if [ "$VERSION" = "$PREVIOUS_VERSION" ]; then
+          echo "❌ Version has not been updated. Please bump the version in pyproject.toml."
+          exit 1
+        fi
+        if [ "$(printf '%s\n' "$PREVIOUS_VERSION" "$VERSION" | sort -V | head -n1)" = "$VERSION" ]; then
+          echo "❌ New version ($VERSION) is not greater than previous version ($PREVIOUS_VERSION)."
+          exit 1
+        fi
+        echo "✅ Version updated correctly."
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build and push worker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: docker/worker.Dockerfile
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: |
+          ghcr.io/aicell-lab/bioengine-worker:latest
+          ghcr.io/aicell-lab/bioengine-worker:${{ env.VERSION }}
+        labels: |
+          org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+        cache-from: type=gha,scope=worker
+        cache-to: type=gha,mode=max,scope=worker


### PR DESCRIPTION
## Summary

Split `docker-publish.yml` into two workflows with symmetric path filters: each image rebuilds only when its own component changes. Both keep `workflow_dispatch` for manual runs.

## Motivation

The single workflow rebuilt and republished both images on any change under `bioengine/**`, `requirements*.txt`, `docker/**`, or `pyproject.toml` — even when nothing relevant to that image had actually changed. Each unnecessary rebuild costs CI minutes and rotates the published digest for downstream pinners.

## Changes

| File | Trigger paths (push to `main`) | Image |
|---|---|---|
| `docker-publish-worker.yml` (renamed from `docker-publish.yml`) | `bioengine/**` (with `!bioengine/datasets/**` exclusion), `requirements-worker.txt`, `docker/worker.Dockerfile`, `docker/worker-ray-overlay.Dockerfile`, `.dockerignore` | `ghcr.io/aicell-lab/bioengine-worker` |
| `docker-publish-datasets.yml` (new) | `bioengine/datasets/**`, `requirements-datasets.txt`, `docker/datasets.Dockerfile`, `.dockerignore` | `ghcr.io/aicell-lab/bioengine-datasets` |

Both workflows:

- Listen for `workflow_dispatch` so either image can be manually rebuilt at any time.
- Run their own strict-greater check against their own registry's most recent canonical `X.Y.Z` tag (defence in depth on top of `version-check.yml`).
- The datasets workflow seeds `PREVIOUS_VERSION=0.0.0` when no prior tag exists so the first publish is not blocked.

`pyproject.toml` was dropped from both trigger lists. Its only effect on the published images is the `version` string (the bioengine package itself installs with `--no-deps` in both Dockerfiles, so extras and dep arrays don't propagate). A code change that needs a version bump triggers the right workflow via the code-change path; a release-only pyproject bump can be picked up via `workflow_dispatch`.

## Behaviour matrix

| PR diff includes… | Worker workflow | Datasets workflow |
|---|---|---|
| Only `apps/**`, `tests/**`, docs | skipped | skipped |
| Only `pyproject.toml` (no code change) | skipped | skipped |
| `bioengine/worker/*.py` + version bump | runs, publishes worker | skipped |
| `bioengine/datasets/*.py` + version bump | skipped | runs, publishes datasets |
| Both `bioengine/worker/*.py` AND `bioengine/datasets/*.py` | runs | runs |
| `requirements-worker.txt` | runs | skipped |
| `requirements-datasets.txt` | skipped | runs |
| `docker/worker.Dockerfile` | runs | skipped |
| `docker/datasets.Dockerfile` | skipped | runs |

`version-check.yml`'s relevant-paths regex still covers everything either workflow can trigger on (plus `pyproject.toml`), so PR-time enforcement of strict-greater is unchanged.

## Test plan

- [ ] Merge this PR. `version-check` posts green (no relevant files change in this PR; `.github/workflows/**` is outside both publish triggers and the version-check regex).
- [ ] On the merge to main: neither publish workflow fires (path filters exclude `.github/`).
- [ ] Next worker-only PR (e.g. `docker/worker.Dockerfile` edit + version bump): only worker workflow fires on merge.
- [ ] Next datasets-only PR (e.g. `docker/datasets.Dockerfile` edit + version bump): only datasets workflow fires on merge.
- [ ] Manual rebuild via Actions UI → "Build and Publish Datasets Image" → Run workflow → publishes datasets at the current pyproject version.

## File-level summary

- `.github/workflows/docker-publish.yml` → renamed to `.github/workflows/docker-publish-worker.yml`; trigger paths narrowed and `!bioengine/datasets/**` exclusion added; datasets build step removed.
- `.github/workflows/docker-publish-datasets.yml` — new file mirroring the worker workflow's shape for the datasets image.
