### PR TITLE
feat(smart-microscopy-qc): new VLM-backed real-time microscopy QC app

### DIFF
--- a/apps/smart-microscopy-qc/README.md
+++ b/apps/smart-microscopy-qc/README.md
@@ -1,0 +1,156 @@
+# Smart Microscopy QC
+
+Real-time visual quality-control inspector for live microscopy. A microscope (or any client) submits an acquired frame together with a free-text instruction describing the QC metrics to check, and a vision-language model returns a textual description of what it sees relative to that instruction.
+
+## Method
+
+| | |
+|---|---|
+| Model | `Qwen/Qwen2.5-VL-3B-Instruct` |
+| License | Apache 2.0 |
+| Engine | HuggingFace `transformers` 4.51.3 + `torch==2.5.1` |
+| Precision | FP16 |
+| Hardware | 1× NVIDIA A40-16C vGPU slice per replica (Ampere sm_86, 16 GB framebuffer, time-shared with co-tenants on the host A40) |
+| Image budget | server-side downscale to ≤ `1280 × 28 × 28` pixels and ≤ 2048 longest side, with a hard reject above 200 MP |
+
+### Why Qwen2.5-VL-3B-Instruct (FP16)
+
+- Apache 2.0 license — usable in any deployment.
+- 3B FP16 weights (~6 GB) + Qwen's vision encoder + KV cache fit comfortably in one A40-16C vGPU slice with substantial headroom for activations.
+- Loaded directly via `transformers.Qwen2_5_VLForConditionalGeneration.from_pretrained(...)` — no quantisation kernel in the path.
+- Dynamic input resolution via Qwen's processor — works with arbitrary microscopy frame sizes once the server-side downscale step has bounded them.
+- Returns coherent multi-bullet QC reports (focus, illumination uniformity, object count, contamination, etc.) on real fluorescence-microscopy frames; see Operating characteristics below for measured behaviour.
+
+### Why not the 7B AWQ variant (initial target)
+
+7B-AWQ would be the higher-quality choice but no AWQ kernel stack currently serves Qwen2.5-VL on this cluster:
+
+- **vLLM 0.10.x** — V0 multimodal input-prep raises `InputProcessingError: list index out of range` on every prompt shape; V1 engine refuses to initialise from a Ray Serve actor thread.
+- **vLLM 0.9.x** — model-registry subprocess fails to inspect `Qwen2_5_VLForConditionalGeneration` and swallows the underlying error.
+- **vLLM 0.7.x** — transitively pins an older Ray than the host pod, which Ray refuses to load.
+- **autoawq Triton kernel** — bundled `awq_gemm_triton` doesn't compile against the Triton shipped with current torch.
+- **autoawq-kernels CUDA path** — `awq_ext.gemm_forward_cuda` raises `expected scalar type Int but found Half` on the `lm_head` linear for `Qwen2.5-VL-7B-Instruct-AWQ` (known upstream issue, fix sits in autoawq 0.2.8 which itself caps `transformers <= 4.47.1` — older than the 4.49 minimum Qwen2.5-VL needs).
+
+3B FP16 lands on this cluster as-is. Revisit 7B-AWQ when any of the upstream stacks above unblocks.
+
+## Image and instruction limits
+
+| Limit | Value | Where enforced |
+|---|---|---|
+| Image file size | 25 MB | Streamed download; raises if exceeded mid-stream |
+| Image pixel count | ≤ 1280 × 28 × 28 (≈ 1.0 MP) AND longest side ≤ 2048 | Server-side downscale in `_download_image` (PIL `Image.resize` with LANCZOS) |
+| Image hard reject | 200 MP (≈ 14000 × 14000) | Raises `ValueError` before downscale |
+| Instruction length | 4000 characters | Server-side `ValueError` (also mirrored in the browser UI which clips the textarea) |
+| Generation timeout | 120 s per `_run_vlm` call | `asyncio.wait_for` |
+
+If the server downscales, the response carries `downscaled_from: [W, H]` and a `downscale_note` so callers can see whether the QC verdict was rendered on the original or a resized version.
+
+## API
+
+### `inspect(image_ref, instruction, max_new_tokens=512) -> dict`
+
+| Parameter | Type | Description |
+|---|---|---|
+| `image_ref` | `str` | Either an `https://...` URL (public or presigned) **or** a Hypha artifact reference `<workspace>/<alias>:<file_path>` (e.g. `ws-user-github\|49943582/qc-samples:images/frame_001.tif`). |
+| `instruction` | `str` | Free-text QC question. Max 4000 chars. |
+| `max_new_tokens` | `int` | Response token budget. Default 512, range 1–1024. |
+
+**Returns:**
+
+```json
+{
+  "description": "- Focus: in focus, clear outlines …",
+  "image_size": [1024, 1024],
+  "source_url": "https://hypha.aicell.io/s3/…",
+  "model": "Qwen/Qwen2.5-VL-3B-Instruct",
+  "tokens_generated": 66,
+  "generation_time_s": 2.55,
+  "tokens_per_second": 25.9,
+  "processing_time_s": 3.0,
+  "downscaled_from": [4096, 4096],
+  "downscale_note": "Image downscaled from 4096x4096 to 980x980 before VLM. The QC verdict applies to the resized image."
+}
+```
+
+`downscaled_from` and `downscale_note` are only present when the server resized the image.
+
+### `ping() -> dict`
+
+Liveness probe returning `{status, model, uptime_s}`.
+
+### `get_model_info() -> dict`
+
+Describes the served model and the input/output contract:
+
+```json
+{
+  "model": "Qwen/Qwen2.5-VL-3B-Instruct",
+  "task": "vision-language",
+  "engine": "huggingface-transformers",
+  "dtype": "float16",
+  "device": "cuda:0",
+  "max_image_bytes": 26214400,
+  "max_instruction_chars": 4000,
+  "max_pixels": 1003520,
+  "max_long_side": 2048,
+  "hard_reject_pixels": 209715200,
+  "license": "Qwen2.5-VL Apache 2.0 weights"
+}
+```
+
+## Operating characteristics (measured on KTH A40-16C vGPU)
+
+10 back-to-back `inspect()` calls, same 512×512 HPA RGB image, identical 200-char QC instruction, `max_new_tokens=192`, 66 generated tokens each:
+
+| Metric | min | median | mean | max | std | spread |
+|---|---:|---:|---:|---:|---:|---:|
+| tok/s | 20.4 | 24.5 | 24.1 | 26.3 | 1.8 | 5.9 |
+| e2e seconds | 2.79 | 3.13 | 3.30 | 4.26 | — | 1.47 |
+
+The vGPU profile time-shares the underlying A40 with other tenants; the tight ~2 tok/s standard deviation indicates contention is currently mild.
+
+VRAM is not exposed directly via the Hypha service. The model load reports ~6 GB for weights at FP16; with KV cache, activations, and the vision encoder, the steady-state working set is well within the 16 GB framebuffer.
+
+## Browser UI
+
+`frontend/index.html` ships as the artifact's `frontend_entry`, so once the artifact is uploaded it is reachable at:
+
+```
+https://hypha.aicell.io/{workspace}/view/{artifact-id}/
+```
+
+The page:
+
+1. Prompts the user to sign in to Hypha (the user's own token, never the worker's).
+2. Accepts a drag-dropped or file-picked image.
+3. Takes a QC instruction (UI mirrors the 4000-char server cap with a live counter).
+4. Uploads the image to a `smart-microscopy-qc-scratch-<random>` artifact in the user's workspace.
+5. Calls `inspect(...)`.
+6. Displays the response with token/throughput metadata.
+7. **Always** deletes the scratch artifact in a `finally` block, success or failure.
+
+The page expects the QC service ID via `?ws_service_id=<full-id>&server=<hypha-url>` URL params; without them it falls back to the short artifact form `bioimage-io/smart-microscopy-qc`.
+
+## Usage example (Python)
+
+```python
+from hypha_rpc import connect_to_server
+
+server = await connect_to_server({
+    "server_url": "https://hypha.aicell.io",
+    "token": HYPHA_TOKEN,
+})
+worker  = await server.get_service("bioimage-io/bioengine-worker-kth-...:bioengine-worker")
+status  = await worker.get_app_status(["smart-microscopy-qc"])
+ws_sid  = status["smart-microscopy-qc"]["service_ids"]["websocket_service_id"]
+qc      = await server.get_service(ws_sid)
+
+result = await qc.inspect(
+    image_ref="https://example.org/scan.tif",
+    instruction=(
+        "Assess focus quality, illumination uniformity, and the approximate "
+        "number of cells. Flag any dark spots or contamination."
+    ),
+)
+print(result["description"])
+```

--- a/apps/smart-microscopy-qc/frontend/index.html
+++ b/apps/smart-microscopy-qc/frontend/index.html
@@ -1,0 +1,335 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Smart Microscopy QC</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: system-ui, -apple-system, sans-serif; background: #0f172a; color: #e2e8f0;
+         min-height: 100vh; display: flex; flex-direction: column; align-items: center;
+         padding: 2rem 1rem; }
+  header { text-align: center; margin-bottom: 1.5rem; }
+  header h1 { font-size: 1.75rem; color: #38bdf8; font-weight: 700; }
+  header p  { color: #94a3b8; margin-top: 0.25rem; font-size: 0.9rem; }
+  .card { background: #1e293b; border: 1px solid #334155; border-radius: 0.75rem;
+          padding: 1.25rem; width: 100%; max-width: 720px; margin-bottom: 1rem; }
+  .card h2 { font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.08em;
+             color: #64748b; margin-bottom: 0.75rem; }
+  .row { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; }
+  .btn { background: #0284c7; color: #fff; border: none; border-radius: 0.5rem;
+         padding: 0.5rem 1rem; cursor: pointer; font-size: 0.875rem; font-weight: 600; }
+  .btn:hover { background: #0369a1; }
+  .btn:disabled { background: #334155; color: #64748b; cursor: not-allowed; }
+  .btn.secondary { background: #475569; }
+  .btn.secondary:hover { background: #64748b; }
+  .status-dot { display: inline-block; width: 0.6rem; height: 0.6rem; border-radius: 50%;
+                margin-right: 0.4rem; background: #64748b; vertical-align: middle; }
+  .status-dot.ok    { background: #22c55e; }
+  .status-dot.busy  { background: #f59e0b; }
+  .status-dot.error { background: #ef4444; }
+  .small { font-size: 0.8rem; color: #94a3b8; }
+  textarea { width: 100%; background: #0f172a; color: #e2e8f0; border: 1px solid #334155;
+             border-radius: 0.5rem; padding: 0.5rem; font-family: inherit; font-size: 0.875rem;
+             min-height: 6rem; resize: vertical; outline: none; }
+  textarea:focus { border-color: #38bdf8; }
+  .counter { font-variant-numeric: tabular-nums; }
+  .counter.over { color: #ef4444; font-weight: 700; }
+  .dropzone { border: 2px dashed #334155; border-radius: 0.5rem; padding: 1.5rem;
+              text-align: center; color: #94a3b8; cursor: pointer; transition: 0.15s; }
+  .dropzone:hover, .dropzone.drag { border-color: #38bdf8; background: #0c1a2e; color: #38bdf8; }
+  .preview { margin-top: 0.75rem; text-align: center; }
+  .preview img { max-width: 100%; max-height: 280px; border-radius: 0.5rem; border: 1px solid #334155; }
+  .preview .meta { font-size: 0.75rem; color: #64748b; margin-top: 0.25rem; }
+  .result-block { background: #0f172a; border-radius: 0.5rem; padding: 0.75rem;
+                  font-size: 0.85rem; color: #e2e8f0; white-space: pre-wrap; word-break: break-word;
+                  min-height: 2rem; max-height: 32rem; overflow-y: auto; }
+  .log { background: #0f172a; border-radius: 0.5rem; padding: 0.5rem 0.75rem;
+         font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.72rem;
+         color: #94a3b8; min-height: 1.5rem; max-height: 10rem; overflow-y: auto;
+         border: 1px solid #334155; }
+  .log .ts { color: #64748b; }
+  .log .err { color: #fca5a5; }
+  .log .ok { color: #86efac; }
+  .meta-pill { display: inline-block; padding: 0.15rem 0.5rem; border-radius: 0.5rem;
+               background: #0f172a; color: #94a3b8; font-size: 0.7rem; margin-right: 0.4rem;
+               margin-top: 0.4rem; }
+  .meta-pill strong { color: #e2e8f0; }
+  hr.subdivider { border: 0; border-top: 1px solid #334155; margin: 0.75rem 0; }
+</style>
+</head>
+<body>
+
+<header>
+  <h1>🔬 Smart Microscopy QC</h1>
+  <p>Drag-and-drop a microscopy image, write a QC question, get a VLM verdict.</p>
+</header>
+
+<div class="card">
+  <h2>1 — Sign in to Hypha</h2>
+  <div class="row">
+    <button class="btn" id="loginBtn">Sign in</button>
+    <span><span class="status-dot" id="loginDot"></span><span id="loginStatus">Not signed in</span></span>
+  </div>
+  <div class="small" style="margin-top: 0.5rem;">
+    Scratch artifacts will be created in <code id="userWs">(your workspace)</code> and deleted
+    after the call. The QC service runs in the <code>bioimage-io</code> workspace.
+  </div>
+</div>
+
+<div class="card">
+  <h2>2 — Image</h2>
+  <div id="dropzone" class="dropzone">
+    Drag a microscopy image here, or click to pick a file.<br>
+    <span class="small">Max 25 MB on the wire. PNG / JPG / TIFF accepted.</span>
+  </div>
+  <input type="file" id="fileInput" accept="image/*,.tif,.tiff" style="display:none" />
+  <div id="preview" class="preview" hidden>
+    <img id="previewImg" alt="image preview" />
+    <div class="meta" id="previewMeta"></div>
+  </div>
+</div>
+
+<div class="card">
+  <h2>3 — QC Instruction</h2>
+  <textarea id="instruction" placeholder="e.g. Evaluate focus, illumination uniformity, and approximate cell count. Flag any contamination."></textarea>
+  <div class="small" style="margin-top: 0.35rem; display:flex; justify-content:space-between;">
+    <span>Free-text question about what the VLM should look for.</span>
+    <span><span id="charCount" class="counter">0</span> / <span id="charCap">4000</span></span>
+  </div>
+</div>
+
+<div class="card">
+  <h2>4 — Inspect</h2>
+  <div class="row">
+    <button class="btn" id="inspectBtn" disabled>Run inspect()</button>
+    <span><span class="status-dot" id="runDot"></span><span id="runStatus">Idle</span></span>
+  </div>
+  <hr class="subdivider">
+  <div id="metaRow" class="small"></div>
+  <div class="result-block" id="resultBlock">—</div>
+</div>
+
+<div class="card">
+  <h2>Log</h2>
+  <div id="log" class="log">Ready.</div>
+</div>
+
+<script type="module">
+import { login, connectToServer }
+  from "https://cdn.jsdelivr.net/npm/hypha-rpc@0.20.54/dist/hypha-rpc-websocket.mjs";
+
+// URL params: ?server=<hypha-server>&ws_service_id=<full-qc-service-id>
+const params     = new URLSearchParams(window.location.search);
+const SERVER_URL = params.get("server")        || "https://hypha.aicell.io";
+const SERVICE_ID = params.get("ws_service_id") || "";
+const QC_FALLBACK = "bioimage-io/smart-microscopy-qc";   // short form (proxy WebRTC offer endpoint)
+
+const MAX_INSTRUCTION_CHARS = 4000;   // must match _MAX_INSTRUCTION_CHARS in main.py
+const MAX_IMAGE_BYTES       = 25 * 1024 * 1024;
+
+document.getElementById("charCap").textContent = MAX_INSTRUCTION_CHARS;
+
+let server = null, qcSvc = null, artMgr = null, userWorkspace = null;
+let pickedFile = null;
+
+const $ = id => document.getElementById(id);
+
+function log(msg, kind = "") {
+  const ts = new Date().toLocaleTimeString();
+  const cls = kind ? `class="${kind}"` : "";
+  $("log").innerHTML += `\n<span class="ts">[${ts}]</span> <span ${cls}>${msg}</span>`;
+  $("log").scrollTop = $("log").scrollHeight;
+}
+
+function setLogin(state, msg) {
+  $("loginDot").className = "status-dot " + (state || "");
+  $("loginStatus").textContent = msg;
+}
+function setRun(state, msg) {
+  $("runDot").className = "status-dot " + (state || "");
+  $("runStatus").textContent = msg;
+}
+
+function refreshInspectEnabled() {
+  const ready = !!qcSvc && !!pickedFile
+    && $("instruction").value.trim().length > 0
+    && $("instruction").value.length <= MAX_INSTRUCTION_CHARS;
+  $("inspectBtn").disabled = !ready;
+}
+
+// --- Login --------------------------------------------------------------
+
+$("loginBtn").addEventListener("click", async () => {
+  $("loginBtn").disabled = true;
+  setLogin("busy", "Opening Hypha login…");
+  log("Login: opening Hypha auth flow");
+  try {
+    const token = await login({ server_url: SERVER_URL });
+    server = await connectToServer({ server_url: SERVER_URL, token });
+    userWorkspace = server.config.workspace;
+    $("userWs").textContent = userWorkspace;
+    setLogin("ok", `Signed in (${userWorkspace})`);
+    log(`Login OK as workspace=${userWorkspace}`, "ok");
+    artMgr = await server.getService("public/artifact-manager", { _rkwargs: true });
+    const sid = SERVICE_ID || QC_FALLBACK;
+    log(`Resolving QC service: ${sid}`);
+    qcSvc = await server.getService(sid, { _rkwargs: true });
+    log("QC service handle ready.", "ok");
+    refreshInspectEnabled();
+  } catch (err) {
+    setLogin("error", "Login failed");
+    log("Login error: " + err.message, "err");
+    $("loginBtn").disabled = false;
+  }
+});
+
+// --- Image picker -------------------------------------------------------
+
+const dropzone = $("dropzone");
+dropzone.addEventListener("click", () => $("fileInput").click());
+["dragenter", "dragover"].forEach(ev => dropzone.addEventListener(ev, e => {
+  e.preventDefault(); dropzone.classList.add("drag");
+}));
+["dragleave", "drop"].forEach(ev => dropzone.addEventListener(ev, e => {
+  e.preventDefault(); dropzone.classList.remove("drag");
+}));
+dropzone.addEventListener("drop", e => {
+  if (e.dataTransfer.files && e.dataTransfer.files[0]) handleFile(e.dataTransfer.files[0]);
+});
+$("fileInput").addEventListener("change", e => {
+  if (e.target.files && e.target.files[0]) handleFile(e.target.files[0]);
+});
+
+function handleFile(file) {
+  if (file.size > MAX_IMAGE_BYTES) {
+    log(`File too large: ${(file.size / 1024 / 1024).toFixed(1)} MB > ${MAX_IMAGE_BYTES / 1024 / 1024} MB`, "err");
+    pickedFile = null;
+    $("preview").hidden = true;
+    refreshInspectEnabled();
+    return;
+  }
+  pickedFile = file;
+  $("previewMeta").textContent =
+    `${file.name} — ${(file.size / 1024).toFixed(1)} KB — ${file.type || "image"}`;
+  // TIFFs typically can't be rendered in <img>; show a placeholder.
+  const ext = (file.name.split(".").pop() || "").toLowerCase();
+  if (["tif", "tiff"].includes(ext)) {
+    $("previewImg").src = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyODAiIGhlaWdodD0iMTYwIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSIjMGYxNzJhIi8+PHRleHQgeD0iNTAlIiB5PSI1MCUiIGZpbGw9IiM2NDc0OGIiIGZvbnQtZmFtaWx5PSJzeXN0ZW0tdWkiIGZvbnQtc2l6ZT0iMTQiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGR5PSIuM2VtIj5USUZGIChubyBpbi1icm93c2VyIHByZXZpZXcpPC90ZXh0Pjwvc3ZnPg==";
+  } else {
+    const reader = new FileReader();
+    reader.onload = e => { $("previewImg").src = e.target.result; };
+    reader.readAsDataURL(file);
+  }
+  $("preview").hidden = false;
+  log(`Picked file: ${file.name} (${file.size} B)`);
+  refreshInspectEnabled();
+}
+
+// --- Instruction --------------------------------------------------------
+
+const instr = $("instruction");
+instr.addEventListener("input", () => {
+  const len = instr.value.length;
+  $("charCount").textContent = len;
+  $("charCount").className = "counter" + (len > MAX_INSTRUCTION_CHARS ? " over" : "");
+  if (len > MAX_INSTRUCTION_CHARS) {
+    // Hard cap: clip and warn (we ensure the server cap can't trip from this UI).
+    instr.value = instr.value.slice(0, MAX_INSTRUCTION_CHARS);
+    $("charCount").textContent = MAX_INSTRUCTION_CHARS;
+    log(`Instruction clipped to ${MAX_INSTRUCTION_CHARS} chars (UI mirror of server cap)`, "err");
+  }
+  refreshInspectEnabled();
+});
+
+// --- Inspect ------------------------------------------------------------
+
+function randomSuffix() {
+  return Math.random().toString(36).slice(2, 10);
+}
+
+async function uploadScratch(file) {
+  const alias = `smart-microscopy-qc-scratch-${randomSuffix()}`;
+  const artifactId = `${userWorkspace}/${alias}`;
+  const ext = (file.name.split(".").pop() || "bin").toLowerCase();
+  const remotePath = `image.${ext}`;
+  log(`Creating scratch artifact ${artifactId}`);
+  await artMgr.create({
+    alias,
+    type: "generic",
+    manifest: {
+      name: "Smart Microscopy QC scratch image",
+      description: "Single image uploaded from the smart-microscopy-qc browser UI. Auto-deleted after the call.",
+      type: "generic",
+    },
+    stage: true,
+    _rkwargs: true,
+  });
+  log(`  → put_file ${remotePath}`);
+  const putUrl = await artMgr.put_file({ artifact_id: artifactId, file_path: remotePath, _rkwargs: true });
+  const buf = await file.arrayBuffer();
+  const resp = await fetch(putUrl, { method: "PUT", body: buf });
+  if (!resp.ok) throw new Error(`PUT failed: ${resp.status} ${resp.statusText}`);
+  await artMgr.commit({ artifact_id: artifactId, _rkwargs: true });
+  log(`  ✓ scratch artifact committed`, "ok");
+  return { artifactId, remotePath };
+}
+
+async function deleteScratch(artifactId) {
+  if (!artifactId) return;
+  try {
+    await artMgr.delete({ artifact_id: artifactId, delete_files: true, recursive: true, _rkwargs: true });
+    log(`Cleaned up scratch artifact ${artifactId}`, "ok");
+  } catch (err) {
+    log(`Cleanup FAILED for ${artifactId}: ${err.message}`, "err");
+  }
+}
+
+$("inspectBtn").addEventListener("click", async () => {
+  if (!pickedFile || !qcSvc) return;
+  $("inspectBtn").disabled = true;
+  setRun("busy", "Uploading image…");
+  $("resultBlock").textContent = "";
+  $("metaRow").innerHTML = "";
+
+  const instruction = instr.value.trim();
+  let scratch = null;
+  const t0 = performance.now();
+
+  try {
+    scratch = await uploadScratch(pickedFile);
+    const imageRef = `${scratch.artifactId}:${scratch.remotePath}`;
+    setRun("busy", "Calling inspect()…");
+    log(`Calling inspect(image_ref=${imageRef})`);
+    const res = await qcSvc.inspect({
+      image_ref: imageRef,
+      instruction,
+      max_new_tokens: 512,
+      _rkwargs: true,
+    });
+    const wallMs = (performance.now() - t0).toFixed(0);
+    setRun("ok", `Done in ${(wallMs / 1000).toFixed(2)} s (server reports ${res.processing_time_s} s)`);
+
+    const pills = [];
+    pills.push(`<span class="meta-pill"><strong>model</strong> ${res.model}</span>`);
+    if (res.image_size) pills.push(`<span class="meta-pill"><strong>image</strong> ${res.image_size[0]}×${res.image_size[1]}</span>`);
+    if (typeof res.tokens_per_second === "number") pills.push(`<span class="meta-pill"><strong>tok/s</strong> ${res.tokens_per_second}</span>`);
+    if (typeof res.tokens_generated === "number") pills.push(`<span class="meta-pill"><strong>tokens</strong> ${res.tokens_generated}</span>`);
+    if (typeof res.generation_time_s === "number") pills.push(`<span class="meta-pill"><strong>gen</strong> ${res.generation_time_s} s</span>`);
+    if (res.downscaled_from) pills.push(`<span class="meta-pill"><strong>downscaled</strong> ${res.downscaled_from.join("×")} → ${res.image_size.join("×")}</span>`);
+    $("metaRow").innerHTML = pills.join(" ");
+    $("resultBlock").textContent = res.description || JSON.stringify(res, null, 2);
+    log(`inspect() returned ${res.tokens_generated || "?"} tokens`, "ok");
+  } catch (err) {
+    setRun("error", "Failed");
+    $("resultBlock").textContent = "Error: " + (err.message || String(err));
+    log("inspect() error: " + (err.message || String(err)), "err");
+  } finally {
+    await deleteScratch(scratch?.artifactId);
+    $("inspectBtn").disabled = false;
+    refreshInspectEnabled();
+  }
+});
+</script>
+</body>
+</html>

--- a/apps/smart-microscopy-qc/main.py
+++ b/apps/smart-microscopy-qc/main.py
@@ -1,0 +1,372 @@
+"""Smart Microscopy QC — VLM-backed real-time quality-control inspector.
+
+Accepts a microscopy image (Hypha artifact reference OR HTTPS URL) and a
+free-text instruction describing the QC metrics to evaluate, and returns the
+VLM's textual description of what it sees relative to that instruction.
+
+Backed by Qwen2.5-VL-3B-Instruct served via HuggingFace transformers on a
+single NVIDIA A40-16C vGPU slice (Ampere, sm_86; 16 GB framebuffer time-
+shared with co-tenants on the host A40). ~6 GB FP16 weights + Qwen's vision
+encoder + KV cache fit comfortably. KTH's Ray cluster exposes each A40 as a
+1-GPU-per-pod vGPU profile, so a single replica owns one slice.
+
+7B-AWQ was attempted first but every viable AWQ kernel path failed on this
+cluster: vLLM 0.10's V0 multimodal regression on Qwen2.5-VL, vLLM 0.9.2's
+inspector bug, autoawq + bundled Triton couldn't compile bf16 dot products,
+and autoawq-kernels' CUDA gemm raises `expected scalar type Int but found
+Half` on the lm_head linear. 3B FP16 lands cleanly without quantisation.
+"""
+
+import asyncio
+import logging
+import os
+import time
+from typing import Any, Optional
+
+from hypha_rpc.utils.schema import schema_method
+from pydantic import Field
+from ray import serve
+
+logger = logging.getLogger("ray.serve")
+
+_MODEL_ID = "Qwen/Qwen2.5-VL-3B-Instruct"
+_DEFAULT_SERVER_URL = "https://hypha.aicell.io"
+
+_MAX_IMAGE_BYTES = 25 * 1024 * 1024      # 25 MB
+_MAX_INSTRUCTION_CHARS = 4000
+# Downscale targets: Qwen's native processor cap of 1280 * 28 * 28 pixels
+# (≈ 1003520, about 1000×1000) is the largest tile the model will accept
+# without internal downsampling. Plus a longest-side guard so a 1×10000
+# strip is still reduced.
+_MAX_PIXELS = 1280 * 28 * 28
+_MAX_LONG_SIDE = 2048
+# Hard reject above ~14000² (200 megapixel). At that scale we'd be holding
+# 0.5+ GB of decoded pixels in RAM just to throw them away.
+_HARD_REJECT_PIXELS = 200 * 1024 * 1024
+_DOWNLOAD_TIMEOUT_S = 30
+_GENERATE_TIMEOUT_S = 120
+
+
+@serve.deployment(
+    ray_actor_options={
+        "num_cpus": 4,
+        "num_gpus": 1,
+        "memory": 12 * 1024**3,
+        "runtime_env": {
+            "pip": [
+                # Frozen versions. Any change forces a 5-15 min env rebuild.
+                # ray pinned to host: KTH Ray pod runs 2.55.1.
+                "ray[serve]==2.55.1",
+                # vLLM and AutoAWQ were both ruled out for serving
+                # Qwen2.5-VL-7B on this cluster (see module docstring).
+                # 3B FP16 uses the plain transformers loader and runs
+                # without any quantisation kernel.
+                "transformers==4.51.3",
+                "accelerate==1.6.0",
+                "torch==2.5.1",
+                "torchvision==0.20.1",
+                # numpy 1.26 keeps ABI in sync with the host Ray pod's pandas.
+                "numpy==1.26.4",
+                "pillow==10.4.0",
+                "httpx==0.27.2",
+                "hypha-rpc==0.20.54",
+            ],
+            "env_vars": {
+                # Triton's JIT cache wants a writable dir; runtime_env venv's
+                # default $HOME is read-only on this Ray pod.
+                "TRITON_CACHE_DIR": "/tmp/triton-cache",
+                "HF_HOME": "/tmp/hf-home",
+                "XDG_CACHE_HOME": "/tmp/xdg-cache",
+                "VLLM_LOGGING_LEVEL": "INFO",
+            },
+        },
+    },
+    max_ongoing_requests=4,
+    health_check_period_s=30.0,
+    health_check_timeout_s=600.0,
+    graceful_shutdown_timeout_s=120.0,
+)
+class SmartMicroscopyQC:
+    def __init__(self) -> None:
+        self.start_time = time.time()
+        self._engine = None
+        self._processor = None
+        self._server = None
+        self._artifact_manager = None
+
+    async def async_init(self) -> None:
+        """Load the VLM and connect to Hypha for artifact resolution."""
+        import os as _os
+        for d in ("/tmp/triton-cache", "/tmp/hf-home", "/tmp/xdg-cache"):
+            _os.makedirs(d, exist_ok=True)
+
+        from hypha_rpc import connect_to_server
+        from transformers import AutoProcessor, Qwen2_5_VLForConditionalGeneration
+        import torch
+
+        token = os.environ.get("HYPHA_TOKEN")
+        if not token:
+            raise RuntimeError("HYPHA_TOKEN environment variable is not set.")
+
+        logger.info("Connecting to Hypha for artifact-manager access...")
+        self._server = await connect_to_server({
+            "server_url": _DEFAULT_SERVER_URL,
+            "token": token,
+        })
+        self._artifact_manager = await self._server.get_service("public/artifact-manager")
+        logger.info("Hypha artifact-manager connected.")
+
+        logger.info("Loading Qwen2.5-VL processor (%s)...", _MODEL_ID)
+        self._processor = AutoProcessor.from_pretrained(_MODEL_ID)
+
+        logger.info("Loading Qwen2.5-VL-3B weights on cuda:0 (FP16)...")
+        self._engine = await asyncio.to_thread(
+            Qwen2_5_VLForConditionalGeneration.from_pretrained,
+            _MODEL_ID,
+            torch_dtype=torch.float16,
+            device_map="cuda:0",
+            low_cpu_mem_usage=True,
+        )
+        self._engine.eval()
+        logger.info("Qwen2.5-VL-7B-AWQ ready on %s.", next(self._engine.parameters()).device)
+
+    async def test_deployment(self) -> None:
+        """No-op smoke test.
+
+        The real first-request smoke happens lazily on the first inspect()
+        call. Keeping this trivial avoids two known frustrations during
+        BioEngine startup: (1) Qwen's processor rejects synthetic tiles
+        below min_pixels, and (2) vLLM's async generate path is sensitive
+        to the nested asyncio loop the BioEngine wrapper uses to launch
+        test_deployment.
+        """
+        return None
+
+    async def check_health(self) -> None:
+        if self._engine is None or self._processor is None:
+            raise RuntimeError("VLM not initialized.")
+        if self._artifact_manager is None:
+            raise RuntimeError("Hypha artifact-manager not connected.")
+
+    # ---------------------------------------------------------------- helpers
+
+    async def _resolve_to_url(self, image_ref: str) -> str:
+        """Map either an HTTPS URL or '<workspace>/<alias>:<path>' to a fetchable URL."""
+        if image_ref.startswith(("http://", "https://")):
+            return image_ref
+        if ":" not in image_ref or "/" not in image_ref.split(":", 1)[0]:
+            raise ValueError(
+                "image_ref must be 'https://...' or '<workspace>/<alias>:<path>' "
+                f"(got: {image_ref!r})"
+            )
+        artifact_id, file_path = image_ref.split(":", 1)
+        url = await self._artifact_manager.get_file(
+            artifact_id=artifact_id,
+            file_path=file_path,
+        )
+        if not url:
+            raise RuntimeError(
+                f"artifact-manager.get_file returned no URL for {image_ref!r}."
+            )
+        return url
+
+    async def _download_image(self, url: str) -> tuple["Image.Image", Optional[tuple[int, int]]]:
+        """Stream-download up to _MAX_IMAGE_BYTES, decode to RGB PIL image,
+        and downscale to ≤ _MAX_PIXELS / _MAX_LONG_SIDE.
+
+        Returns (image, original_size_or_none). original_size is None when no
+        downscale was applied; otherwise it carries the pre-downscale (w, h)
+        so callers can surface it.
+        """
+        import io
+        import httpx
+        from PIL import Image
+
+        buf = bytearray()
+        async with httpx.AsyncClient(timeout=_DOWNLOAD_TIMEOUT_S, follow_redirects=True) as client:
+            async with client.stream("GET", url) as resp:
+                resp.raise_for_status()
+                async for chunk in resp.aiter_bytes(chunk_size=64 * 1024):
+                    buf.extend(chunk)
+                    if len(buf) > _MAX_IMAGE_BYTES:
+                        raise ValueError(
+                            f"Image exceeds {_MAX_IMAGE_BYTES // (1024 * 1024)} MB limit."
+                        )
+
+        try:
+            img = Image.open(io.BytesIO(bytes(buf)))
+            img.load()
+        except Exception as e:
+            raise ValueError(f"Failed to decode image bytes ({len(buf)} B): {e}") from e
+
+        if img.mode != "RGB":
+            img = img.convert("RGB")
+
+        w, h = img.size
+        if w * h > _HARD_REJECT_PIXELS:
+            raise ValueError(
+                f"Image is {w}x{h} ({w * h / 1e6:.0f} MP) which exceeds the "
+                f"{_HARD_REJECT_PIXELS // 1024 // 1024} MP hard limit."
+            )
+
+        original_size = None
+        long_side = max(w, h)
+        needs_resize = (w * h > _MAX_PIXELS) or (long_side > _MAX_LONG_SIDE)
+        if needs_resize:
+            t_resize = time.time()
+            scale_pix  = (_MAX_PIXELS / (w * h)) ** 0.5 if w * h > _MAX_PIXELS else 1.0
+            scale_side = _MAX_LONG_SIDE / long_side if long_side > _MAX_LONG_SIDE else 1.0
+            scale = min(scale_pix, scale_side)
+            new_size = (max(1, int(w * scale)), max(1, int(h * scale)))
+            img = img.resize(new_size, Image.LANCZOS)
+            original_size = (w, h)
+            logger.info(
+                "Downscaled %sx%s -> %sx%s (ratio %.3f, %.1f ms)",
+                w, h, new_size[0], new_size[1], scale,
+                (time.time() - t_resize) * 1000,
+            )
+        return img, original_size
+
+    async def _run_vlm(
+        self, image: "Image.Image", instruction: str, max_new_tokens: int
+    ) -> tuple[str, int]:
+        import torch
+
+        messages = [{
+            "role": "user",
+            "content": [
+                {"type": "image", "image": image},
+                {"type": "text", "text": instruction},
+            ],
+        }]
+
+        def _generate():
+            prompt = self._processor.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True
+            )
+            inputs = self._processor(
+                text=[prompt],
+                images=[image],
+                return_tensors="pt",
+                padding=True,
+            )
+            inputs = {k: v.to("cuda:0") for k, v in inputs.items()}
+            in_len = int(inputs["input_ids"].shape[1])
+            with torch.inference_mode():
+                gen = self._engine.generate(
+                    **inputs,
+                    max_new_tokens=max_new_tokens,
+                    do_sample=False,
+                    temperature=None,
+                    top_p=None,
+                )
+            new_tokens = gen[:, in_len:]
+            text = self._processor.batch_decode(
+                new_tokens, skip_special_tokens=True, clean_up_tokenization_spaces=False
+            )[0].strip()
+            return text, int(new_tokens.shape[1])
+
+        return await asyncio.wait_for(
+            asyncio.to_thread(_generate),
+            timeout=_GENERATE_TIMEOUT_S,
+        )
+
+    # ---------------------------------------------------------------- public API
+
+    @schema_method
+    async def ping(self) -> dict:
+        """Liveness probe."""
+        return {
+            "status": "ok",
+            "model": _MODEL_ID,
+            "uptime_s": round(time.time() - self.start_time, 1),
+        }
+
+    @schema_method
+    async def get_model_info(self) -> dict:
+        """Describe the served model and the input/output contract."""
+        return {
+            "model": _MODEL_ID,
+            "task": "vision-language",
+            "engine": "huggingface-transformers",
+            "dtype": "float16",
+            "device": "cuda:0",
+            "max_image_bytes": _MAX_IMAGE_BYTES,
+            "max_instruction_chars": _MAX_INSTRUCTION_CHARS,
+            "max_pixels": _MAX_PIXELS,
+            "max_long_side": _MAX_LONG_SIDE,
+            "hard_reject_pixels": _HARD_REJECT_PIXELS,
+            "license": "Qwen2.5-VL Apache 2.0 weights",
+        }
+
+    @schema_method
+    async def inspect(
+        self,
+        image_ref: str = Field(
+            ...,
+            description=(
+                "Image to inspect. Either an HTTPS URL (public or presigned), "
+                "or a Hypha artifact reference '<workspace>/<alias>:<file_path>' "
+                "(e.g. 'ws-user-github|49943582/qc-samples:images/frame_001.tif'). "
+                "Maximum decoded file size: 25 MB."
+            ),
+        ),
+        instruction: str = Field(
+            ...,
+            description=(
+                "Free-text QC instruction telling the VLM what to look for "
+                "(sharpness, focus, illumination uniformity, dark/saturated regions, "
+                "object counts/shapes, contamination, etc.). Max 4000 characters."
+            ),
+        ),
+        max_new_tokens: int = Field(
+            512,
+            description="Maximum response tokens (1-1024).",
+            ge=1, le=1024,
+        ),
+    ) -> dict:
+        """Inspect a microscopy image and return a textual QC report.
+
+        Returns:
+          description     - VLM-generated text describing the image relative to instruction
+          image_size      - [width, height] of the (possibly downscaled) image fed to the VLM
+          source_url      - URL used to fetch the image
+          model           - Model ID used
+          tokens_generated, generation_time_s, tokens_per_second
+          processing_time_s
+        """
+        t0 = time.time()
+
+        if not isinstance(instruction, str) or not instruction.strip():
+            raise ValueError("instruction must be a non-empty string.")
+        if len(instruction) > _MAX_INSTRUCTION_CHARS:
+            raise ValueError(
+                f"instruction exceeds {_MAX_INSTRUCTION_CHARS}-char limit "
+                f"(got {len(instruction)})."
+            )
+
+        url = await self._resolve_to_url(image_ref)
+        image, original_size = await self._download_image(url)
+
+        t_gen0 = time.time()
+        description, n_tokens = await self._run_vlm(image, instruction, max_new_tokens)
+        gen_dt = time.time() - t_gen0
+
+        result = {
+            "description": description,
+            "image_size": list(image.size),
+            "source_url": url,
+            "model": _MODEL_ID,
+            "tokens_generated": n_tokens,
+            "generation_time_s": round(gen_dt, 2),
+            "tokens_per_second": round(n_tokens / gen_dt, 2) if gen_dt > 0 else None,
+            "processing_time_s": round(time.time() - t0, 2),
+        }
+        if original_size is not None:
+            result["downscaled_from"] = list(original_size)
+            result["downscale_note"] = (
+                f"Image downscaled from {original_size[0]}x{original_size[1]} "
+                f"to {image.size[0]}x{image.size[1]} before VLM. The QC verdict "
+                f"applies to the resized image."
+            )
+        return result

--- a/apps/smart-microscopy-qc/manifest.yaml
+++ b/apps/smart-microscopy-qc/manifest.yaml
@@ -1,0 +1,18 @@
+name: Smart Microscopy QC
+id: smart-microscopy-qc
+id_emoji: "🔬"
+description: "Real-time visual quality-control inspector for live microscopy. Accepts an image reference (Hypha artifact or HTTPS URL) and a free-text QC instruction, returns a Qwen2.5-VL-7B-Instruct description focused on the requested metrics (sharpness, focus, illumination uniformity, object counts/shapes, contamination, dark/saturated regions, etc.)."
+type: ray-serve
+format_version: 0.5.0
+version: 0.1.0
+authors:
+  - {name: "BioEngine Team", affiliation: "KTH Royal Institute of Technology"}
+license: MIT
+git_repo: "https://github.com/aicell-lab/bioengine/tree/main/apps/smart-microscopy-qc"
+documentation: "README.md"
+tags: [microscopy, quality-control, vision-language-model, vlm, qwen, real-time]
+deployments:
+  - main:SmartMicroscopyQC
+authorized_users:
+  - "*"
+frontend_entry: "frontend/index.html"


### PR DESCRIPTION
## Summary

New BioEngine app: **smart-microscopy-qc**, a vision-language QC inspector for live microscopy. A microscope client submits an acquired frame and a free-text instruction describing the QC metrics to look at (focus, illumination uniformity, object counts, contamination, …); the app returns a textual VLM verdict and per-call throughput metadata.

Ships with a browser drag-and-drop frontend at `frontend/index.html` (`frontend_entry` in the manifest), so the app is also exercisable from a web page once deployed.

## App contract

`inspect(image_ref, instruction, max_new_tokens=512) -> dict`

| Parameter | Type | Constraint |
|---|---|---|
| `image_ref` | `str` | HTTPS URL OR `<workspace>/<alias>:<file_path>` Hypha artifact reference |
| `instruction` | `str` | Max **4000 chars** (server-side `ValueError` above; UI mirrors the cap) |
| `max_new_tokens` | `int` | 1 – 1024 |

Image limits (server-side, all enforced before VLM call):

- Wire size: **25 MB** max (raises mid-stream above).
- Decoded pixel count: downscaled with PIL LANCZOS to ≤ `1280 × 28 × 28` AND longest side ≤ 2048. Aspect ratio preserved. Downscale logs one line and the response carries `downscaled_from` + `downscale_note` when it triggers.
- Hard reject: > 200 MP (≈ 14000²) — `ValueError`, no downscale attempt.

Also exposes `ping()` and `get_model_info()` for liveness / contract discovery.

## Model choice

`Qwen/Qwen2.5-VL-3B-Instruct` (Apache 2.0) served via HuggingFace `transformers` 4.51.3 + `torch==2.5.1`, FP16, no quantisation.

The original target was `Qwen/Qwen2.5-VL-7B-Instruct-AWQ` for higher visual reasoning quality. Every viable AWQ kernel stack currently fails to serve that model on this cluster — vLLM 0.10's V0 multimodal path raises `InputProcessingError: list index out of range`, vLLM 0.9.x's model inspector fails on `Qwen2_5_VLForConditionalGeneration`, autoawq's Triton kernel doesn't compile against current Triton, and `autoawq-kernels`' CUDA path raises `expected scalar type Int but found Half` on the `lm_head` linear (known autoawq issue; the fix lands in 0.2.8 which pins `transformers<=4.47.1`, older than Qwen2.5-VL's 4.49 requirement). The 3B FP16 path loads cleanly, gives a coherent baseline, and can be promoted to 7B when any of those upstream stacks unblocks. See README → "Why not the 7B AWQ variant" for the full table.

## Operating characteristics (measured)

KTH A40-16C vGPU slice (Ampere sm_86, 16 GB framebuffer, time-shared). 10 back-to-back `inspect()` calls on the same 512×512 HPA RGB image, 200-char QC instruction, `max_new_tokens=192`, 66 generated tokens each:

| | min | median | mean | max | std | spread |
|---|---:|---:|---:|---:|---:|---:|
| tok/s | 20.4 | 24.5 | 24.1 | 26.3 | 1.8 | 5.9 |
| e2e seconds | 2.79 | 3.13 | 3.30 | 4.26 | — | 1.47 |

A tight band — vGPU co-tenant contention is currently mild. Model load ~6 GB weights at FP16; full working set comfortably within the 16 GB slice.

## File-level summary

```
apps/smart-microscopy-qc/
├── manifest.yaml         # ray-serve app, format_version 0.5.0, frontend_entry set
├── main.py               # SmartMicroscopyQC deployment + inspect / ping / get_model_info
├── frontend/index.html   # drag-drop UI; signs in to Hypha, uploads scratch artifact,
│                         #   calls inspect, deletes scratch in finally
└── README.md             # method, API, limits, operating characteristics, browser UI usage
```

## Test plan

- [x] Hypha artifact reference (public): `inspect()` returns a coherent QC bullet list.
- [x] Hypha artifact reference (private): same, with auth flowing through the app's token.
- [x] HTTPS presigned URL: same response shape.
- [x] Instruction > 4000 chars: raises `ValueError`.
- [x] Image size 512×512: no downscale, `downscaled_from` absent.
- [x] Image size 3000×3000: downscale triggers, `downscaled_from=[3000,3000]`, new size ≤ Qwen budget and ≤ 2048 longest side.
- [x] `get_model_info()` returns the full input/output contract.
- [x] Frontend served at `https://hypha.aicell.io/bioimage-io/view/smart-microscopy-qc/`.
- [x] Spread benchmark (10 runs, same image + prompt): tok/s std 1.8.
- [x] Live on KTH `bioengine-worker-kth-*:bioengine-worker` as `smart-microscopy-qc`.