### PR TITLE
feat(model-runner): expose artifact version, fold into test-cache invalidation

### DIFF
--- a/apps/model-runner/entry_deployment.py
+++ b/apps/model-runner/entry_deployment.py
@@ -1167,12 +1167,11 @@ class EntryDeployment:
 
     def _get_bioimageio_versions(self) -> Dict[str, str]:
         """
-        Return installed versions of bioimageio packages used by this deployment.
+        Return identities the test cache invalidates on.
 
-        Returns:
-            Dictionary containing package versions for:
-            - bioimageio.core
-            - bioimageio.spec
+        Includes installed versions of the bioimageio packages and the
+        model-runner artifact's own version — so the existing env-mismatch
+        check in ``test()`` re-runs when the runner itself is upgraded.
         """
         from importlib.metadata import PackageNotFoundError, version
 
@@ -1185,38 +1184,57 @@ class EntryDeployment:
             except PackageNotFoundError:
                 versions[package_name] = "not-installed"
 
+        versions["bioimage-io/model-runner"] = os.environ.get(
+            "HYPHA_ARTIFACT_VERSION", "unknown"
+        )
+
         logger.debug(f"📦 Bioimage.io package versions: {versions}")
         return versions
 
-    def _ensure_bioengine_in_test_env(self, test_report: dict) -> dict:
-        """Ensure test_report['env'] contains the current BioEngine version row."""
+    def _stamp_runtime_versions_in_test_env(self, test_report: dict) -> dict:
+        """Upsert runtime-identity rows in ``test_report['env']``.
+
+        The test cache invalidation in ``test()`` reuses this env list to
+        detect when a stored report was produced under different runtime
+        versions; downstream consumers (e.g. bioimage.io CI) also read it
+        from the published report to drive their own cache keys.
+        """
+        rows = [
+            ("bioengine", __version__),
+            (
+                "bioimage-io/model-runner",
+                os.environ.get("HYPHA_ARTIFACT_VERSION", "unknown"),
+            ),
+        ]
+
         env = test_report.get("env")
         if not isinstance(env, list):
             env = []
         else:
             env = list(env)
 
-        bioengine_row_index: Optional[int] = None
-        for i, row in enumerate(env):
-            if (
-                isinstance(row, (list, tuple))
-                and len(row) >= 1
-                and str(row[0]) == "bioengine"
-            ):
-                bioengine_row_index = i
-                break
+        for name, version_value in rows:
+            row_index: Optional[int] = None
+            for i, row in enumerate(env):
+                if (
+                    isinstance(row, (list, tuple))
+                    and len(row) >= 1
+                    and str(row[0]) == name
+                ):
+                    row_index = i
+                    break
 
-        bioengine_row = ["bioengine", __version__, "", ""]
-        if bioengine_row_index is None:
-            env.append(bioengine_row)
-        else:
-            existing_row = env[bioengine_row_index]
-            if isinstance(existing_row, tuple):
-                existing_row = list(existing_row)
-            while len(existing_row) < 4:
-                existing_row.append("")
-            existing_row[1] = __version__
-            env[bioengine_row_index] = existing_row
+            new_row = [name, version_value, "", ""]
+            if row_index is None:
+                env.append(new_row)
+            else:
+                existing_row = env[row_index]
+                if isinstance(existing_row, tuple):
+                    existing_row = list(existing_row)
+                while len(existing_row) < 4:
+                    existing_row.append("")
+                existing_row[1] = version_value
+                env[row_index] = existing_row
 
         test_report["env"] = env
         return test_report
@@ -1341,6 +1359,20 @@ class EntryDeployment:
 
     # === Exposed BioEngine App Methods - all methods decorated with @schema_method will be exposed as API endpoints ===
     # Note: Parameter type hints and docstrings will be used to generate the API documentation.
+
+    @schema_method
+    async def get_version(self) -> Dict[str, str]:
+        """Return the artifact identity this replica was deployed from.
+
+        Callers (e.g. bioimage.io CI cache invalidation) use this to detect
+        when a stored test report was produced under a different runner
+        version and should be re-tested.
+        """
+        return {
+            "artifact_id": os.environ.get("HYPHA_ARTIFACT_ID", "unknown"),
+            "version": os.environ.get("HYPHA_ARTIFACT_VERSION", "unknown"),
+            "bioengine_version": __version__,
+        }
 
     @schema_method
     async def search_models(
@@ -1753,8 +1785,7 @@ class EntryDeployment:
                         f"⚠️ Generated fallback test report for '{model_id}' due to test error."
                     )
 
-                # Add BioEngine version to the test report environment
-                test_report = self._ensure_bioengine_in_test_env(test_report)
+                test_report = self._stamp_runtime_versions_in_test_env(test_report)
 
                 # Add tested_at timestamp to the test report so the report is self-contained.
                 test_report["tested_at"] = tested_at

--- a/apps/model-runner/manifest.yaml
+++ b/apps/model-runner/manifest.yaml
@@ -14,7 +14,7 @@ maintainers: []
 name: Model Runner
 tags: []
 type: ray-serve
-version: 1.0.6
+version: 1.0.7
 deployments:
   - entry_deployment:EntryDeployment
   - runtime_deployment:RuntimeDeployment

--- a/bioengine/apps/builder.py
+++ b/bioengine/apps/builder.py
@@ -298,6 +298,7 @@ class AppBuilder:
         non_secret_env_vars: Dict[str, str],
         secret_env_vars: Dict[str, str],
         artifact_id: str,
+        version: str,
     ) -> serve.Deployment:
         """
         Configure the Ray runtime environment for BioEngine deployments.
@@ -329,6 +330,7 @@ class AppBuilder:
             non_secret_env_vars: Environment variables to set directly
             secret_env_vars: Environment variables with sensitive values
             artifact_id: Artifact identifier like "my-workspace/my-app" added as env var 'HYPHA_ARTIFACT_ID'
+            version: Resolved artifact version added as env var 'HYPHA_ARTIFACT_VERSION'
 
         Returns:
             Enhanced deployment with BioEngine runtime environment configured
@@ -387,6 +389,7 @@ class AppBuilder:
         env_vars["HYPHA_SERVER_URL"] = self.server.config.public_base_url
         env_vars["HYPHA_WORKSPACE"] = self.server.config.workspace
         env_vars["HYPHA_ARTIFACT_ID"] = artifact_id
+        env_vars["HYPHA_ARTIFACT_VERSION"] = version
 
         env_vars["BIOENGINE_WORKER_SERVICE_ID"] = self.worker_service_id
 
@@ -1215,6 +1218,7 @@ class AppBuilder:
                 non_secret_env_vars=non_secret_env_vars,
                 secret_env_vars=secret_env_vars,
                 artifact_id=artifact_id,
+                version=version,
             )
 
             # Update the deployment class methods

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.10.7"
+version = "0.10.8"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Summary

Expose the deployed artifact's resolved version as an env var on every Ray Serve replica, and use it in model-runner so test reports are stamped with the runner version and the local test cache invalidates on a runner-version change.

## Motivation

Downstream consumers (bioimage.io CI cache invalidation, future analytics, multi-cluster diff tooling) need to know which model-runner artifact version produced any given test report. Today the worker injects `HYPHA_ARTIFACT_ID` into deployment env vars but not the version, even though the resolved version is already in scope at the injection site (`AppBuilder._load_manifest` returns it).

Model-runner's `.test_cache.json` validator already checks env-version match for `bioimageio.core` / `bioimageio.spec`; adding the runner identity to that check naturally invalidates the cache when the runner is upgraded, with no new validator code path.

## Changes

### `bioengine/apps/builder.py`

`_update_ray_actor_options` now takes `version: str` and injects `env_vars["HYPHA_ARTIFACT_VERSION"] = version` alongside `HYPHA_ARTIFACT_ID`. The call site in `_load_deployment` passes the already-resolved version (the same value returned by `_load_manifest`). No app-spec field, no manifest change — generic enough that every BioEngine app can read `os.environ["HYPHA_ARTIFACT_VERSION"]`.

### `apps/model-runner/entry_deployment.py`

1. New `get_version()` schema method:
   ```python
   @schema_method
   async def get_version(self) -> Dict[str, str]:
       return {
           "artifact_id": os.environ.get("HYPHA_ARTIFACT_ID", "unknown"),
           "version": os.environ.get("HYPHA_ARTIFACT_VERSION", "unknown"),
           "bioengine_version": __version__,
       }
   ```

2. `_get_bioimageio_versions()` now also returns the runner identity:
   ```python
   versions["bioimage-io/model-runner"] = os.environ.get("HYPHA_ARTIFACT_VERSION", "unknown")
   ```
   The existing env-mismatch loop in `test()` automatically invalidates `.test_cache.json` on runner-version mismatch, with the same `🔄 Cached test env mismatch` log line.

3. `_ensure_bioengine_in_test_env()` renamed to `_stamp_runtime_versions_in_test_env()` and generalised to upsert multiple identity rows. Adds a `["bioimage-io/model-runner", <version>, "", ""]` row alongside the existing `["bioengine", <version>, "", ""]` row in `test_report["env"]`. The artifact's `test_summary["env"]` propagates both rows automatically.

## Verification

Built the worker image locally from this branch, ran a single-machine deployment on Europa, deployed `bioimage-io/demo-app` from a local artifact path, called `get_app_status` and inspected `application_env_vars`:

```
class 'DemoDeployment' env vars:
  BIOENGINE_WORKER_SERVICE_ID = 'ws-user-github|49943582/bioengine-worker-smoke:bioengine-worker'
  HYPHA_ARTIFACT_ID = 'bioimage-io/demo-app'
  HYPHA_ARTIFACT_VERSION = '1.0.0'
  HYPHA_SERVER_URL = 'https://hypha.aicell.io'
  HYPHA_WORKSPACE = 'ws-user-github|49943582'
```

The resolved version (`1.0.0`) reached the deployment's process env correctly.

## Rollout sequence

1. This PR merges → `docker-publish-worker.yml` builds and publishes the next `bioengine-worker:X.Y.Z` with the env-var injection.
2. Roll the new worker image to KTH (and other deployment targets via sibling sessions).
3. Bump `apps/model-runner/manifest.yaml` version (separate `apps/**` commit, no worker rebuild) and publish the new model-runner artifact.
4. Re-deploy model-runner with the new version on each worker (`worker.deploy_app("bioimage-io/model-runner", application_id="model-runner", version="X.Y.Z")`).

Backward compatibility: `get_version()` falls back to `"unknown"` if the env vars are missing (e.g. legacy worker versions that haven't been bumped yet). bioimage.io's CI fallback catches `AttributeError` if `get_version()` itself isn't yet exposed and treats the version as `None` → uses existing cache rules. No version of the system regresses.

## Test plan

- [ ] CI builds the new worker image successfully.
- [ ] After rollout, `worker.get_app_status(application_ids=["model-runner"])["model-runner"]["application_env_vars"]` shows `HYPHA_ARTIFACT_VERSION` populated for the `EntryDeployment` class.
- [ ] `await runner.get_version()` returns the expected `{artifact_id, version, bioengine_version}` triple.
- [ ] After a `test()` call, the resulting `test_report["env"]` contains a `["bioimage-io/model-runner", <version>, "", ""]` row in addition to the `["bioengine", <version>, "", ""]` row.
- [ ] A second `test()` call against the same model with the runner deliberately downgraded triggers the env-mismatch log line and re-runs the test.

## File-level summary

- `bioengine/apps/builder.py` — extend `_update_ray_actor_options` signature with `version`, inject `HYPHA_ARTIFACT_VERSION` env var, pass `version` from the existing `_load_deployment` call site.
- `apps/model-runner/entry_deployment.py` — add `get_version()` schema method, extend `_get_bioimageio_versions()` to include the runner identity, generalise the env-stamping helper to upsert both bioengine + model-runner rows.
