### PR TITLE
fix(apps): preserve frontend_entry across worker pod restart

### DIFF
--- a/bioengine/apps/builder.py
+++ b/bioengine/apps/builder.py
@@ -1592,6 +1592,7 @@ class AppBuilder:
                 ),
                 "auto_redeploy": auto_redeploy,
                 "debug": debug,
+                "frontend_entry": manifest.get("frontend_entry"),
             }
 
             app = proxy_deployment.bind(

--- a/bioengine/apps/manager.py
+++ b/bioengine/apps/manager.py
@@ -889,6 +889,13 @@ class AppsManager:
                     timeout=10.0,
                 )
 
+                static_site_url = None
+                if app_data.get("frontend_entry"):
+                    static_site_url = get_static_site_url(
+                        artifact_id=app_data["artifact_id"],
+                        server_url=self.server.config.public_base_url,
+                    )
+
                 self._deployed_applications[application_id] = {
                     "display_name": app_data["display_name"],
                     "description": app_data["description"],
@@ -902,6 +909,7 @@ class AppsManager:
                     "application_resources": app_data["application_resources"],
                     "authorized_users": updated_authorized_users,
                     "available_methods": app_data["available_methods"],
+                    "static_site_url": static_site_url,
                     "started_at": app_data["started_at"],
                     "last_updated_at": app_data["last_updated_at"],
                     "last_updated_by": app_data["last_updated_by"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.10.8"
+version = "0.10.9"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Summary

Apps with `frontend_entry` in their manifest lose `static_site_url` after a worker pod restart, which makes the bioimage.io dashboard's "Open UI" button disappear for every such running app. The recovery flow rebuilds `_deployed_applications` from the `ProxyDeployment` actor's `app_data`, but `frontend_entry` was never persisted in `app_data` — only on a transient `app.metadata` dict that exists during the fresh-deploy code path. Recovery saw `frontend_entry=None`, skipped the `static_site_url` computation, and downstream UI broke.

## Reproduction

1. Deploy any app with `frontend_entry: "..."` in its manifest.
2. `worker.get_app_status` returns `static_site_url` populated correctly; the dashboard renders the button.
3. The worker pod restarts (KubeRay rolling update, helm upgrade, OOM kill, etc.). The Ray Serve replicas keep running on the Ray cluster.
4. The new worker recovers the existing apps via `recover_deployed_applications`. `worker.get_app_status` now returns `static_site_url: None` for every recovered app, even though the artifact manifest still has `frontend_entry`.
5. Dashboard button disappears.

## Fix

Two coupled edits, ~9 lines total:

**`bioengine/apps/builder.py`** — `AppBuilder.build`: include `frontend_entry` in the `app_data` dict that gets stored on the `ProxyDeployment` actor.

```python
app_data = {
    ...existing keys...
    "frontend_entry": manifest.get("frontend_entry"),
}
```

**`bioengine/apps/manager.py`** — `recover_deployed_applications`: compute `static_site_url` from `app_data.get("frontend_entry")` and `app_data["artifact_id"]`, store it in the recovered entry. Mirrors the fresh-deploy branch's logic exactly.

```python
static_site_url = None
if app_data.get("frontend_entry"):
    static_site_url = get_static_site_url(
        artifact_id=app_data["artifact_id"],
        server_url=self.server.config.public_base_url,
    )

self._deployed_applications[application_id] = {
    ...
    "static_site_url": static_site_url,
    ...
}
```

## Why this approach over the alternatives

Two other approaches considered and rejected:

| Approach | Cost | Issue |
|---|---|---|
| Re-fetch manifest via `artifact_manager.read(artifact_id, version)` on recovery | One extra RPC per recovered app at worker startup | Risks pulling a manifest that diverged from what was actually deployed — would chase the artifact's latest `frontend_entry` instead of preserving the deployed snapshot |
| Compute `static_site_url` on every `get_app_status` call | One artifact_manager.read per status call (frequent) | Same divergence risk; also adds latency to every dashboard refresh |
| **This PR: persist `frontend_entry` in `app_data`** | Zero extra RPC | Same semantic the worker already uses for every other deployed-app field — `app_data` is the frozen snapshot of what was deployed |

Recovery becomes a structural mirror of the fresh-deploy path, with no asymmetric "extra work on recovery".

## Backward compatibility

Apps deployed under earlier worker versions have `app_data` without the `frontend_entry` key. On recovery, `app_data.get("frontend_entry")` returns `None`, the recovered entry has `static_site_url=None` — same as today's bug, no regression. These self-heal on next redeploy under the fixed worker.

## Verification

Built the worker image locally from this branch, ran single-machine mode, deployed `bioimage-io/demo-app` (manifest has `frontend_entry: "frontend/index.html"`). Confirmed `get_app_status` returns:

```
static_site_url = 'https://hypha.aicell.io/bioimage-io/view/demo-app/?server=https://hypha.aicell.io&ws_service_id=ws-user-github|49943582/bioengine-worker-smoke-ldh4v574:recovery-smoke&webrtc_service_id=ws-user-github|49943582/bioengine-worker-smoke-ldh4v574:recovery-smoke-rtc'
```

Single-machine mode tears the Ray cluster down with the container, so the recovery branch itself can only be exercised on an external-cluster setup (KubeRay). The recovery code is a one-to-one mirror of the verified fresh-deploy code and only adds: read `app_data.get("frontend_entry")`, call the same helper that fresh-deploy calls.

The next KubeRay rolling restart of the KTH worker — where `smart-microscopy-qc` (with `frontend_entry`) and any future frontend-bearing app are deployed — will exercise the recovery path against production traffic; this PR will be visible in that scenario by the dashboard button continuing to display.

## File-level summary

- `bioengine/apps/builder.py` — add `frontend_entry` to `app_data` dict in `AppBuilder.build`.
- `bioengine/apps/manager.py` — compute `static_site_url` in `recover_deployed_applications` from the now-persisted `frontend_entry`, and store it in the recovered `_deployed_applications` entry.
