### PR TITLE
fix(worker): multi-stage build to drop binutils + gcc from runtime image

### DIFF
--- a/docker/worker.Dockerfile
+++ b/docker/worker.Dockerfile
@@ -1,55 +1,50 @@
-# Rolling tag — each build picks up current Debian-slim security patches.
-FROM python:3.11-slim
+# Rolling tag — picks up current Debian-slim security patches each build.
+FROM python:3.11-slim AS builder
 
-# Set environment variables for installation
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PIP_NO_CACHE_DIR=1
 
-# Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git \
     build-essential \
-    curl \
+    git \
     && rm -rf /var/lib/apt/lists/*
 
-# Set environment variables for Hypha
-ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
-# Set up working directory
 WORKDIR /app
-
-# Copy requirements first — note: this file intentionally does NOT pin
-# Ray. Ray is installed as the very last step, controlled by the
-# RAY_VERSION build arg, so changing the Ray version doesn't invalidate
-# this layer (or any of the layers between here and the final Ray
-# install) on rebuild.
 COPY requirements-worker.txt /app/
-RUN pip install -U pip && \
-    pip install -r requirements-worker.txt
+RUN pip install -U pip && pip install -r requirements-worker.txt
 
-# Copy the rest of the application code
 COPY bioengine/ /app/bioengine/
 COPY pyproject.toml README.md LICENSE /app/
-
-# Install the bioengine package without dependencies — all runtime deps
-# (including ray's transitive deps that survive a version bump) are
-# already in requirements-worker.txt.
 RUN pip install --no-deps .
 
-# ---------------------------------------------------------------------------
-# Ray install — kept as the final step so RAY_VERSION can be overridden
-# at build time without invalidating any prior layer cache. The default
-# tracks the latest stable Ray release within the BioEngine-supported
-# range (>=2.33.0, <3.0.0). To build against a different Ray:
-#
-#   docker build --build-arg RAY_VERSION=2.54.1 \
-#                -f docker/worker.Dockerfile -t bioengine-worker:dev .
-# ---------------------------------------------------------------------------
+# Ray installed last so RAY_VERSION overrides don't invalidate earlier layers.
 ARG RAY_VERSION=2.55.1
 RUN pip install "ray[client,serve]==${RAY_VERSION}"
 
-# Surface the active Ray version inside the image for diagnostics
+# ---------------------------------------------------------------------------
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1 \
+    SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
+    PATH="/opt/venv/bin:$PATH"
+
+# curl: helm chart startup/liveness probe. git: runtime_env git_url installs.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /opt/venv /opt/venv
+
+ARG RAY_VERSION=2.55.1
 ENV BIOENGINE_RAY_VERSION=${RAY_VERSION}
+
+WORKDIR /app
 
 CMD [ "/bin/bash" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.10.9"
+version = "0.10.10"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Motivation

The 2026-06-03 NeuVector scan of `bioengine-worker-kth` shows 9 High-severity binutils CVEs (CVE-2026-6846, CVE-2025-69649, CVE-2025-69650, CVE-2025-66862–66866, CVE-2017-13716) on `binutils 2.44-3`. The previous remediation (0.10.7's `--no-install-recommends`) did not clear them because **binutils enters via Depends, not Recommends**:

```
build-essential  Depends:  gcc, g++, make, dpkg-dev, libc6-dev
gcc-14           Depends:  binutils (>= 2.43)
libc6-dev        Depends:  libc-dev-bin, libcrypt-dev
dpkg-dev         Depends:  binutils
```

`apt-get install --no-install-recommends build-essential` still pulls in the full Depends closure; binutils therefore remains in the published image. The clean way to remove it is to keep `build-essential` strictly in a builder stage and copy only the materialized Python venv into the runtime image.

## Change

`docker/worker.Dockerfile` is rewritten as a two-stage build:

- **Builder stage** (`python:3.11-slim AS builder`): installs `build-essential` + `git`, creates `/opt/venv`, runs `pip install -r requirements-worker.txt`, copies and installs the bioengine package, then `pip install ray[client,serve]==${RAY_VERSION}` as the last layer (preserving the cache-friendly Ray-last ordering).
- **Runtime stage** (`python:3.11-slim`): installs only `curl` (helm chart's startup/liveness probe) and `git` (Ray runtime_env `git_url`/`pip` git-source installs), copies `/opt/venv` from the builder, sets `PATH=\"/opt/venv/bin:\$PATH\"`, redeclares `ARG RAY_VERSION` so `ENV BIOENGINE_RAY_VERSION` resolves correctly.

Resulting runtime image:

| Package | Before | After |
|---|---|---|
| `binutils`, `binutils-common`, `binutils-x86-64-linux-gnu`, `libbinutils` | present (2.44-3) | absent |
| `build-essential`, `gcc-14`, `g++-14`, `cpp-14` | present | absent |
| `libc6-dev`, `dpkg-dev`, `make` | present | absent |
| `gcc-14-base`, `libgcc-s1` | present (base-image runtime support) | present (unchanged) |

`gcc-14-base` and `libgcc-s1` ship with `python:3.11-slim` itself and are runtime support libs (no compiler), unaffected by this change. They are not the source of the 9 binutils Highs.

## Risk and verification

The only at-risk consumer is a Ray Serve app whose `runtime_env.pip` falls through to a source-build at install time — that path needs gcc, which the new runtime image no longer has.

- **External-cluster mode (KTH production)**: runtime_env materialization happens on the Ray worker pods (`rayproject/ray:2.55.1-py311-gpu`), not the bioengine-worker image. This change has no effect on that path.
- **Single-machine mode**: the bioengine-worker container *is* the Ray worker, so a source-build would happen inside the new slim image.

Inspected the runtime_env setup logs of the KTH ray-cluster worker for the three live apps (`cellpose-finetuning`, `model-runner`, `smart-microscopy-qc`): no `Building wheel for …`, no `Running setup.py`, no `gcc`/`x86_64-linux-gnu-gcc` invocations. Every transitive dep (cellpose 4.0.7, torch 2.5.1, transformers 4.51.3, av, pylibsrtp, pydantic-core, etc.) resolves to a `cp311-…manylinux*.whl` or `py3-none-any.whl`. None of the three apps would source-build today.

Built the new image locally, ran it in single-machine mode on a 4-CPU host, deployed `bioimage-io/demo-app` (manifest has `frontend_entry: \"frontend/index.html\"`, runtime_env pip is just `pandas`):

- Worker registers on Hypha, `get_status` returns `is_ready: True`.
- `deploy_app` → app status `RUNNING`, both `DemoDeployment` and `ProxyDeployment` `HEALTHY`.
- `static_site_url` populated end-to-end (`https://hypha.aicell.io/bioimage-io/view/demo-app/?…&ws_service_id=…`).
- `ping()` over the registered WebSocket service returns `{status: ok, message: 'Hello from the DemoDeployment!', uptime: 241.77s}`.
- `pandas` installed cleanly into the runtime_env venv from a wheel (no gcc invocation needed).
- `stop_app` cleanly tears the deployment down.

Image size delta: roughly 60-80 MB smaller on the final layer set (build-essential + binutils + gcc + libc6-dev dropped from runtime).

## File-level summary

- `docker/worker.Dockerfile` — rewritten as builder + runtime stages; runtime contains only the venv, curl, git, ca-certificates from `python:3.11-slim`. Ray-last ordering, `BIOENGINE_RAY_VERSION` diagnostic env, and `SSL_CERT_FILE` are all preserved.