### PR TITLE
fix(worker): inject USER + LOGNAME env vars into deployment actors

### DIFF
--- a/bioengine/apps/builder.py
+++ b/bioengine/apps/builder.py
@@ -386,6 +386,12 @@ class AppBuilder:
         env_vars["TEMP"] = tmp_dir
         env_vars["TMP"] = tmp_dir
 
+        # Prevents getpass.getuser() falling through to pwd lookup, which raises
+        # KeyError when the actor's uid has no /etc/passwd entry (torch._dynamo
+        # hits this at import time in containers run with --user $(id -u)).
+        env_vars.setdefault("USER", "bioengine")
+        env_vars.setdefault("LOGNAME", "bioengine")
+
         env_vars["HYPHA_SERVER_URL"] = self.server.config.public_base_url
         env_vars["HYPHA_WORKSPACE"] = self.server.config.workspace
         env_vars["HYPHA_ARTIFACT_ID"] = artifact_id


### PR DESCRIPTION
## Summary

Inject `USER` + `LOGNAME` into every Ray Serve deployment actor's `runtime_env.env_vars` so `getpass.getuser()` resolves without falling through to a `pwd.getpwuid()` lookup that fails inside slim-image containers running with `--user $(id -u):$(id -g)`.

## Motivation

`torch._dynamo.DiskDynamoCache` (added in torch 2.5) runs `getpass.getuser()` at module load time. `getpass.getuser()` checks `$USER` / `$LOGNAME` first and falls through to `pwd.getpwuid(os.getuid())` only when both are unset. If the actor's uid has no `/etc/passwd` entry — which is the case in every slim-image worker started with `--user $(id -u):$(id -g)` against an arbitrary host uid — `pwd` raises `KeyError`, torch import crashes, the deployment's `async_init` never runs, the replica reports unhealthy, Ray Serve restarts it into the same loop, and no actionable error is surfaced beyond the cryptic traceback in the actor logs.

Concrete reproducer: a bioengine-paper subagent ran cellpose-finetuning 0.1.0 on a single-machine worker started on Europa with `--user 1008:1008`. The worker container's `python:3.11-slim` base has no `/etc/passwd` entry for uid 1008. Every `infer` and `start_training` call crashed with `KeyError: 'getpwuid(): uid not found: 1008'` from torch._dynamo. Workarounds attempted but failed: `--env USER=bioengine` to `bioengine apps run` is silently dropped by the app builder; the immediate fix on the live worker required bind-mounting `/etc/passwd` + `/etc/group` from the host, which then required overriding `HOME` because the resolved username's home was no longer inside the container.

## Fix

Two lines in `AppBuilder._update_ray_actor_options`, alongside the existing `HOME`, `TMPDIR`, `HYPHA_ARTIFACT_ID`, etc. injection:

```python
env_vars.setdefault("USER", "bioengine")
env_vars.setdefault("LOGNAME", "bioengine")
```

`setdefault` preserves any caller-provided override (a deployment that genuinely needs a different `USER` value can still set it via the deploy-time env-vars dict).

## Verification

Smoke-tested locally:

1. Built the patched worker image: `docker build -f docker/worker.Dockerfile -t bioengine-worker-local:user-env-fix .`
2. Ran a single-machine worker with `--user $(id -u):$(id -g)` (uid 1008, absent from the container's `/etc/passwd`), **without** any `/etc/passwd` bind-mount or `-e USER=...` workaround.
3. Deployed `bioimage-io/demo-app` from a local artifact path.
4. Verified `get_app_status` reports the deployment's `application_env_vars`:

```
deployment class 'DemoDeployment' env vars:
  HOME = '/.bioengine/.bioengine/apps/env-probe'
  LOGNAME = 'bioengine'
  USER = 'bioengine'
  HYPHA_ARTIFACT_ID = 'bioimage-io/demo-app'
  HYPHA_ARTIFACT_VERSION = '1.0.0'
  HYPHA_SERVER_URL = 'https://hypha.aicell.io'
  HYPHA_WORKSPACE = 'ws-user-github|49943582'
```

5. Demo-app's deployment booted to RUNNING/HEALTHY without errors. Apps that subsequently import torch (model-runner, cellpose-finetuning, smart-microscopy-qc) get the same env vars and resolve `getpass.getuser()` cleanly.

## Effect on existing deployments

- New deployments after rollout: get USER + LOGNAME automatically. No code change needed in any app.
- Apps deployed under earlier worker versions: stored `app_data` doesn't carry these env vars; on recovery after a worker pod restart, the env vars are NOT re-injected (the recovery branch reads stored `app_data` rather than re-running the builder). To self-heal, redeploy the app once under the patched worker; from then on, the env vars are persisted in `app_data`. Same backward-compat pattern as PR #95's `frontend_entry` fix.
- The `/etc/passwd` bind-mount workaround currently applied to the europa paper worker (`bioengine-worker-paper`) becomes unnecessary after this ships — that container can be restarted without the bind-mount once it's running 0.10.10.

## File-level summary

- `bioengine/apps/builder.py` — `_update_ray_actor_options` adds two `env_vars.setdefault` calls for `USER` and `LOGNAME` next to the existing `HOME`/`TMPDIR`/`HYPHA_*` injections.
