### PR TITLE
feat(apps): surface Ray node placement in get_app_status

### DIFF
--- a/bioengine/apps/manager.py
+++ b/bioengine/apps/manager.py
@@ -570,10 +570,21 @@ class AppsManager:
                 "status": deployment_info.status.value,
                 "message": deployment_info.message,
                 "replica_states": deployment_info.replica_states,
+                "nodes": [],
                 "logs": None,
             }
 
-            # Collect logs for all tracked actor IDs
+            try:
+                nodes = await self.ray_cluster.proxy_actor_handle.get_deployment_nodes.remote(
+                    application_id=application_id,
+                    deployment_name=deployment_name,
+                )
+                deployments_info[deployment_name]["nodes"] = nodes
+            except Exception as e:
+                self.logger.error(
+                    f"Error retrieving node placement for application '{application_id}', deployment '{deployment_name}': {e}"
+                )
+
             try:
                 deployment_logs = await self.ray_cluster.proxy_actor_handle.get_deployment_logs.remote(
                     application_id=application_id,
@@ -724,6 +735,14 @@ class AppsManager:
 
         service_ids = await self._get_application_service_ids(application_id)
 
+        seen_nodes = set()
+        app_nodes: List[str] = []
+        for dep in deployments.values():
+            for node_id in dep.get("nodes") or []:
+                if node_id and node_id not in seen_nodes:
+                    seen_nodes.add(node_id)
+                    app_nodes.append(node_id)
+
         # Build static site URL with runtime config params so the frontend
         # knows which Hypha server and service to connect to.
         base_static_url = application_info.get("static_site_url")
@@ -745,6 +764,7 @@ class AppsManager:
             "recovered_app": application_info["recovered_app"],
             "status": status,
             "message": message,
+            "nodes": app_nodes,
             "deployments": deployments,
             "application_kwargs": application_info["application_kwargs"],
             "application_env_vars": self._filter_secret_env_vars(

--- a/bioengine/apps/manager.py
+++ b/bioengine/apps/manager.py
@@ -557,10 +557,73 @@ class AppsManager:
         self._deployed_applications.pop(application_id, None)
         self.logger.info(f"Undeployment of application '{application_id}' completed.")
 
+    async def _get_serve_instance_details(self) -> Dict[str, Any]:
+        """Fetch the Serve controller's full instance details (one RPC for all apps).
+
+        Returns the dict form of `ServeInstanceDetails` — same data as
+        `serve.status()` but with per-replica `ReplicaDetails` populated
+        (`node_id`, `node_ip`, `node_instance_id`, `state`, `pid`,
+        `start_time_s`, etc.). Returns an empty dict on failure so callers
+        can fall back to the simplified `serve.status()` view.
+        """
+        import ray
+
+        def _fetch() -> Dict[str, Any]:
+            client = serve.context._get_global_client()
+            details = ray.get(client._controller.get_serve_instance_details.remote())
+            if hasattr(details, "model_dump"):
+                return details.model_dump()
+            if isinstance(details, dict):
+                return details
+            return {}
+
+        try:
+            return await self.ray_cluster.call_with_reconnect(_fetch)
+        except Exception as e:
+            self.logger.error(f"Error fetching Serve instance details: {e}")
+            return {}
+
+    def _replicas_for_deployment(
+        self,
+        instance_details: Dict[str, Any],
+        application_id: str,
+        deployment_name: str,
+    ) -> List[Dict[str, Any]]:
+        """Pick the fields the dashboard needs from each ReplicaDetails entry.
+
+        Keeps the payload small — `actor_id`, `worker_id`, `log_file_path`
+        are intentionally dropped since the dashboard does not need them.
+        """
+        try:
+            replicas = (
+                instance_details.get("applications", {})
+                .get(application_id, {})
+                .get("deployments", {})
+                .get(deployment_name, {})
+                .get("replicas", [])
+            )
+        except AttributeError:
+            return []
+        out = []
+        for r in replicas or []:
+            out.append(
+                {
+                    "replica_id": r.get("replica_id"),
+                    "node_id": r.get("node_id"),
+                    "node_ip": r.get("node_ip"),
+                    "node_instance_id": r.get("node_instance_id"),
+                    "state": r.get("state"),
+                    "pid": r.get("pid"),
+                    "start_time_s": r.get("start_time_s"),
+                }
+            )
+        return out
+
     async def _get_deployment_status(
         self,
         application_id: str,
         application_status: ApplicationDetails,
+        instance_details: Dict[str, Any],
         n_previous_replica: int,
         logs_tail: int,
     ) -> Dict[str, Dict[str, Any]]:
@@ -570,20 +633,11 @@ class AppsManager:
                 "status": deployment_info.status.value,
                 "message": deployment_info.message,
                 "replica_states": deployment_info.replica_states,
-                "nodes": [],
+                "replicas": self._replicas_for_deployment(
+                    instance_details, application_id, deployment_name
+                ),
                 "logs": None,
             }
-
-            try:
-                nodes = await self.ray_cluster.proxy_actor_handle.get_deployment_nodes.remote(
-                    application_id=application_id,
-                    deployment_name=deployment_name,
-                )
-                deployments_info[deployment_name]["nodes"] = nodes
-            except Exception as e:
-                self.logger.error(
-                    f"Error retrieving node placement for application '{application_id}', deployment '{deployment_name}': {e}"
-                )
 
             try:
                 deployment_logs = await self.ray_cluster.proxy_actor_handle.get_deployment_logs.remote(
@@ -688,6 +742,7 @@ class AppsManager:
         self,
         application_id: str,
         serve_status: ServeStatus,
+        instance_details: Dict[str, Any],
         n_previous_replica: int,
         logs_tail: int,
     ) -> Dict[str, Any]:
@@ -717,6 +772,7 @@ class AppsManager:
             deployments = await self._get_deployment_status(
                 application_id=application_id,
                 application_status=application_status,
+                instance_details=instance_details,
                 n_previous_replica=n_previous_replica,
                 logs_tail=logs_tail,
             )
@@ -734,14 +790,6 @@ class AppsManager:
             deployments = {}
 
         service_ids = await self._get_application_service_ids(application_id)
-
-        seen_nodes = set()
-        app_nodes: List[str] = []
-        for dep in deployments.values():
-            for node_id in dep.get("nodes") or []:
-                if node_id and node_id not in seen_nodes:
-                    seen_nodes.add(node_id)
-                    app_nodes.append(node_id)
 
         # Build static site URL with runtime config params so the frontend
         # knows which Hypha server and service to connect to.
@@ -764,7 +812,6 @@ class AppsManager:
             "recovered_app": application_info["recovered_app"],
             "status": status,
             "message": message,
-            "nodes": app_nodes,
             "deployments": deployments,
             "application_kwargs": application_info["application_kwargs"],
             "application_env_vars": self._filter_secret_env_vars(
@@ -2096,12 +2143,14 @@ class AppsManager:
         # Get Ray Serve status
         await self.ray_cluster.check_connection()
         serve_status = await self.ray_cluster.call_with_reconnect(serve.status)
+        instance_details = await self._get_serve_instance_details()
 
         # Iterate over applications to check
         status_tasks = [
             self._get_app_status(
                 application_id=application_id,
                 serve_status=serve_status,
+                instance_details=instance_details,
                 n_previous_replica=n_previous_replica,
                 logs_tail=logs_tail,
             )

--- a/bioengine/apps/manager.py
+++ b/bioengine/apps/manager.py
@@ -11,7 +11,6 @@ from hypha_rpc.rpc import RemoteService
 from hypha_rpc.utils.schema import schema_method
 from pydantic import Field
 from ray import serve
-from ray.serve.schema import ApplicationDetails, ServeStatus
 
 from bioengine import __version__
 from bioengine.apps.builder import AppBuilder
@@ -557,53 +556,14 @@ class AppsManager:
         self._deployed_applications.pop(application_id, None)
         self.logger.info(f"Undeployment of application '{application_id}' completed.")
 
-    async def _get_serve_instance_details(self) -> Dict[str, Any]:
-        """Fetch the Serve controller's full instance details (one RPC for all apps).
-
-        Returns the dict form of `ServeInstanceDetails` — same data as
-        `serve.status()` but with per-replica `ReplicaDetails` populated
-        (`node_id`, `node_ip`, `node_instance_id`, `state`, `pid`,
-        `start_time_s`, etc.). Returns an empty dict on failure so callers
-        can fall back to the simplified `serve.status()` view.
-        """
-        import ray
-
-        def _fetch() -> Dict[str, Any]:
-            client = serve.context._get_global_client()
-            details = ray.get(client._controller.get_serve_instance_details.remote())
-            if hasattr(details, "model_dump"):
-                return details.model_dump()
-            if isinstance(details, dict):
-                return details
-            return {}
-
-        try:
-            return await self.ray_cluster.call_with_reconnect(_fetch)
-        except Exception as e:
-            self.logger.error(f"Error fetching Serve instance details: {e}")
-            return {}
-
-    def _replicas_for_deployment(
-        self,
-        instance_details: Dict[str, Any],
-        application_id: str,
-        deployment_name: str,
+    def _project_replicas(
+        self, replicas: List[Dict[str, Any]]
     ) -> List[Dict[str, Any]]:
         """Pick the fields the dashboard needs from each ReplicaDetails entry.
 
         Keeps the payload small — `actor_id`, `worker_id`, `log_file_path`
         are intentionally dropped since the dashboard does not need them.
         """
-        try:
-            replicas = (
-                instance_details.get("applications", {})
-                .get(application_id, {})
-                .get("deployments", {})
-                .get(deployment_name, {})
-                .get("replicas", [])
-            )
-        except AttributeError:
-            return []
         out = []
         for r in replicas or []:
             out.append(
@@ -622,20 +582,26 @@ class AppsManager:
     async def _get_deployment_status(
         self,
         application_id: str,
-        application_status: ApplicationDetails,
-        instance_details: Dict[str, Any],
+        application_details: Dict[str, Any],
         n_previous_replica: int,
         logs_tail: int,
     ) -> Dict[str, Dict[str, Any]]:
         deployments_info = {}
-        for deployment_name, deployment_info in application_status.deployments.items():
+        for deployment_name, deployment_info in (
+            application_details.get("deployments") or {}
+        ).items():
+            replicas = self._project_replicas(deployment_info.get("replicas") or [])
+            replica_states: Dict[str, int] = {}
+            for r in replicas:
+                state = r.get("state")
+                if state:
+                    replica_states[state] = replica_states.get(state, 0) + 1
+
             deployments_info[deployment_name] = {
-                "status": deployment_info.status.value,
-                "message": deployment_info.message,
-                "replica_states": deployment_info.replica_states,
-                "replicas": self._replicas_for_deployment(
-                    instance_details, application_id, deployment_name
-                ),
+                "status": deployment_info.get("status"),
+                "message": deployment_info.get("message", ""),
+                "replica_states": replica_states,
+                "replicas": replicas,
                 "logs": None,
             }
 
@@ -741,7 +707,6 @@ class AppsManager:
     async def _get_app_status(
         self,
         application_id: str,
-        serve_status: ServeStatus,
         instance_details: Dict[str, Any],
         n_previous_replica: int,
         logs_tail: int,
@@ -763,16 +728,17 @@ class AppsManager:
 
         # Get application info from tracked applications
         application_info = self._deployed_applications[application_id]
-        application_status = serve_status.applications.get(application_id)
+        application_details = (instance_details.get("applications") or {}).get(
+            application_id
+        )
 
-        if application_status:
-            status = application_status.status.value
-            message = application_status.message
+        if application_details:
+            status = application_details.get("status")
+            message = application_details.get("message", "")
 
             deployments = await self._get_deployment_status(
                 application_id=application_id,
-                application_status=application_status,
-                instance_details=instance_details,
+                application_details=application_details,
                 n_previous_replica=n_previous_replica,
                 logs_tail=logs_tail,
             )
@@ -2142,14 +2108,14 @@ class AppsManager:
 
         # Get Ray Serve status
         await self.ray_cluster.check_connection()
-        serve_status = await self.ray_cluster.call_with_reconnect(serve.status)
-        instance_details = await self._get_serve_instance_details()
+        instance_details = (
+            await self.ray_cluster.proxy_actor_handle.get_serve_instance_details.remote()
+        )
 
         # Iterate over applications to check
         status_tasks = [
             self._get_app_status(
                 application_id=application_id,
-                serve_status=serve_status,
                 instance_details=instance_details,
                 n_previous_replica=n_previous_replica,
                 logs_tail=logs_tail,

--- a/bioengine/cluster/proxy_actor.py
+++ b/bioengine/cluster/proxy_actor.py
@@ -604,45 +604,6 @@ class BioEngineProxyActor:
         return replica_info
 
     @_touch_on_call
-    def get_deployment_nodes(
-        self, application_id: str, deployment_name: str
-    ) -> List[str]:
-        """
-        Get the distinct Ray node IDs hosting ALIVE replicas of a deployment.
-
-        Returns the same node_id strings used as keys in `get_cluster_state().nodes`,
-        suitable for joining application status against the cluster's node table.
-
-        Args:
-            application_id: Name of the Ray Serve application.
-            deployment_name: Name of the specific deployment within the app.
-
-        Returns:
-            List of distinct node_id strings for replicas currently in ALIVE state.
-            Empty list if no ALIVE replicas were found or `node_id` is unavailable.
-        """
-        class_name = f"ServeReplica:{application_id}:{deployment_name}"
-        deployment_actors = self.state_api_client.list(
-            resource=StateResource.ACTORS,
-            options=ListApiOptions(
-                limit=DEFAULT_LIMIT,
-                timeout=DEFAULT_RPC_TIMEOUT,
-                filters=[("class_name", "=", class_name), ("state", "=", "ALIVE")],
-                detail=False,
-                explain=False,
-            ),
-            raise_on_missing_output=True,
-        )
-        seen = set()
-        nodes = []
-        for actor in deployment_actors:
-            node_id = getattr(actor, "node_id", None)
-            if node_id and node_id not in seen:
-                seen.add(node_id)
-                nodes.append(node_id)
-        return nodes
-
-    @_touch_on_call
     def register_serve_replica(
         self,
         application_id: str,

--- a/bioengine/cluster/proxy_actor.py
+++ b/bioengine/cluster/proxy_actor.py
@@ -604,6 +604,35 @@ class BioEngineProxyActor:
         return replica_info
 
     @_touch_on_call
+    def get_serve_instance_details(self) -> Dict[str, Any]:
+        """Fetch the Serve controller's full instance details.
+
+        Returns the dict form of `ServeInstanceDetails`, including per-replica
+        `ReplicaDetails` (`node_id`, `node_ip`, `node_instance_id`, `state`,
+        `pid`, `start_time_s`, ...) for every deployment — the single source
+        of truth for application + deployment status and replica placement.
+        Returns an empty dict on failure so callers can render a degraded but
+        still-valid status payload.
+        """
+        try:
+            from ray import serve
+
+            client = serve.context._get_global_client()
+            details = ray.get(
+                client._controller.get_serve_instance_details.remote()
+            )
+            if hasattr(details, "model_dump"):
+                return details.model_dump()
+            if isinstance(details, dict):
+                return details
+            return {}
+        except Exception as e:
+            logger.error(
+                f"Failed to fetch Serve instance details: {e}", exc_info=True
+            )
+            return {}
+
+    @_touch_on_call
     def register_serve_replica(
         self,
         application_id: str,

--- a/bioengine/cluster/proxy_actor.py
+++ b/bioengine/cluster/proxy_actor.py
@@ -604,6 +604,45 @@ class BioEngineProxyActor:
         return replica_info
 
     @_touch_on_call
+    def get_deployment_nodes(
+        self, application_id: str, deployment_name: str
+    ) -> List[str]:
+        """
+        Get the distinct Ray node IDs hosting ALIVE replicas of a deployment.
+
+        Returns the same node_id strings used as keys in `get_cluster_state().nodes`,
+        suitable for joining application status against the cluster's node table.
+
+        Args:
+            application_id: Name of the Ray Serve application.
+            deployment_name: Name of the specific deployment within the app.
+
+        Returns:
+            List of distinct node_id strings for replicas currently in ALIVE state.
+            Empty list if no ALIVE replicas were found or `node_id` is unavailable.
+        """
+        class_name = f"ServeReplica:{application_id}:{deployment_name}"
+        deployment_actors = self.state_api_client.list(
+            resource=StateResource.ACTORS,
+            options=ListApiOptions(
+                limit=DEFAULT_LIMIT,
+                timeout=DEFAULT_RPC_TIMEOUT,
+                filters=[("class_name", "=", class_name), ("state", "=", "ALIVE")],
+                detail=False,
+                explain=False,
+            ),
+            raise_on_missing_output=True,
+        )
+        seen = set()
+        nodes = []
+        for actor in deployment_actors:
+            node_id = getattr(actor, "node_id", None)
+            if node_id and node_id not in seen:
+                seen.add(node_id)
+                nodes.append(node_id)
+        return nodes
+
+    @_touch_on_call
     def register_serve_replica(
         self,
         application_id: str,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.10.11"
+version = "0.10.12"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Problem

The worker dashboard renders cluster info from `worker.get_status()` (which already includes `ray_cluster_status.cluster_state.nodes` — keyed by 56-character Ray node IDs) and per-application info from `worker.get_app_status()` (which today only reports deployment status, replica counts, and logs). There is no join key between the two: an operator looking at a node card cannot answer *"which apps are running on this node"*, and an operator looking at an app cannot answer *"where is it placed"*.

Ray Serve's controller endpoint `get_serve_instance_details` answers exactly this question — every `ReplicaDetails` carries `node_id`, `node_ip`, `node_instance_id` (the Kubernetes worker pod name on KubeRay), `state`, `pid`, and `start_time_s`. The previous implementation of `get_app_status` threw all of that away.

## Solution

Surface the controller's per-replica detail under each deployment in `get_app_status`:

```jsonc
{
  ...,
  "deployments": {
    "CellposeFinetune": {
      "status": "HEALTHY",
      "message": "",
      "replica_states": {"RUNNING": 1},
      "replicas": [
        {
          "replica_id": "6cukdnhn",
          "node_id": "263ea6216e93778c660823c75c0b506cdd23d783a771bdda368b00c4",
          "node_ip": "10.42.0.189",
          "node_instance_id": "raycluster-kuberay-worker-workergroup-52j5d",
          "state": "RUNNING",
          "pid": 23608,
          "start_time_s": 1780671869.702535
        }
      ],
      "logs": {...}
    }
  }
}
```

The dashboard joins this against the existing `get_status.ray_cluster_status.cluster_state.nodes` (keyed by `node_id` — same 56-char hex string, exact equality). `get_status` is **not** modified.

Both directions the dashboard needs are served:
- **"Running on nodes X, Y" per app card** — reduce over `deployments[*].replicas[*].node_id`.
- **"Running here: <apps>" per node card** — client-side transposition of the same data already fetched for the app cards (no extra RPC).

## Implementation

The placement data flows through the proxy actor, which is co-located with the Serve controller inside the Ray cluster:

- **`BioEngineProxyActor.get_serve_instance_details`** (new method) — fetches `serve.context._get_global_client()._controller.get_serve_instance_details.remote()` from inside the cluster, returns the `model_dump()` dict, or `{}` on failure. Joins the existing pattern of cluster-state queries on the proxy actor (`get_deployment_replicas`, `get_deployment_logs`, `register_serve_replica`).
- **`AppsManager._project_replicas`** — projects each `ReplicaDetails` to the subset the dashboard uses; `actor_id`, `worker_id`, and `log_file_path` are dropped to keep the payload small.
- **`AppsManager._get_deployment_status`** — accepts the deployment dict from the controller's instance details, populates `replicas` and computes `replica_states` from `replicas[*].state` (a one-line `Counter`).
- **`AppsManager.get_app_status`** (the public RPC entry point) — fetches the controller's instance details **once** via the proxy actor for the whole batch of apps, then dispatches to `_get_app_status` for each requested app.

The previous `serve.status()` call in the `get_app_status` path is removed — `get_serve_instance_details` is a strict superset and is fetched anyway. The other four `serve.status()` callsites in `manager.py` (`deploy_app`, recovery flow, etc.) are out of this PR's scope and unchanged.

## Files

- `bioengine/cluster/proxy_actor.py` — new `get_serve_instance_details` method.
- `bioengine/apps/manager.py`:
  - Drops the `serve.status()` call in the `get_app_status` path; fetches `instance_details` from the proxy actor once.
  - `_get_app_status` and `_get_deployment_status` consume the controller dict directly (`ApplicationDetails` / `ServeStatus` schema types no longer needed in this path).
  - New `_project_replicas` helper.
  - `replica_states` is computed from `replicas[*].state` instead of being read from the simplified Serve view.

## Behavioural changes

- **Additive new field:** `deployments[<name>].replicas` is always present (empty list when there are no alive replicas) so the frontend does not need to guard against `undefined`.
- **`replica_states` shape is unchanged** (`{state_string: count}`), but is now derived from the per-replica list rather than the Serve simplified view. Returns `{}` when no replicas are alive.
- **No top-level `nodes` aggregate** on the app — the union is one line on the frontend.
- **One round-trip to Ray instead of two** per `get_app_status` call (the controller fetch replaces both the previous `serve.status()` and the intermediate state-API query I had at PR open).

## Test plan

- [x] Verified `get_serve_instance_details` returns the expected `ReplicaDetails` shape for all currently-deployed apps on the production KTH worker (cellpose-finetuning, model-runner, smart-microscopy-qc).
- [x] Confirmed `node_id` strings exactly equal the keys of `get_cluster_state.nodes` (string equality, length 56, no prefix). Examples:
  - cellpose-finetuning replicas → `263ea6216e93778c660823c75c0b506cdd23d783a771bdda368b00c4` (`workergroup-52j5d`).
  - model-runner `EntryDeployment` + `ProxyDeployment` → `95b045ede53487bb78db0ba25f40108a584116bd59cb752d65c1dc9e` (`kuberay-head-9f5md`).
  - model-runner `RuntimeDeployment` → `45e561d5a03203d867423ceafc6cfe8af551104e0e24ed56feeecf85` (`workergroup-nklqc`).
- [ ] After this version ships, verify the new field renders correctly on the worker dashboard (badge per app card + per node card) and that the `replica_states` field matches what `serve.status()` reported previously.

## Migration notes

None. `deployments[<name>].replicas` is additive; existing fields are unchanged. `replica_states` keeps the same shape (`{state_string: count}`). Frontends that ignore the new field continue to work.
