### PR TITLE
chore(docker): unpin ray-overlay base default, drop stale version refs

### DIFF
--- a/.github/workflows/docker-publish-worker.yml
+++ b/.github/workflows/docker-publish-worker.yml
@@ -9,7 +9,6 @@ on:
       - '!bioengine/datasets/**'
       - 'requirements-worker.txt'
       - 'docker/worker.Dockerfile'
-      - 'docker/worker-ray-overlay.Dockerfile'
       - '.dockerignore'
   workflow_dispatch:
 

--- a/.github/workflows/docker-publish-worker.yml
+++ b/.github/workflows/docker-publish-worker.yml
@@ -62,8 +62,6 @@ jobs:
         TAGS=$(skopeo list-tags "$IMAGE" | jq -r '.Tags[]')
 
         # Canonical X.Y.Z tags only — this is what this workflow publishes.
-        # Excludes manually-pushed rc tags (0.9.1-rcN) and external-cluster
-        # overlays (0.9.1-rcN-rayX.Y.Z), neither of which CI ever produces.
         LATEST_VERSION=$(echo "$TAGS" \
           | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
           | sort -V \

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -48,8 +48,10 @@ jobs:
         CHANGED_FILES=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
         echo "Changed files:" && echo "$CHANGED_FILES" | sed 's/^/ - /'
 
-        # Match original path filters
-        if echo "$CHANGED_FILES" | grep -E '^(bioengine/|docker/|requirements[^/]*\.txt$|pyproject\.toml$|\.dockerignore$)' >/dev/null; then
+        # Match the file patterns that drive the published image builds.
+        # docker/worker-ray-overlay.Dockerfile is a user-facing recipe, not part
+        # of the canonical worker image build — changes to it do not need a bump.
+        if echo "$CHANGED_FILES" | grep -E '^(bioengine/|docker/worker\.Dockerfile$|docker/datasets\.Dockerfile$|requirements[^/]*\.txt$|pyproject\.toml$|\.dockerignore$)' >/dev/null; then
           echo "RELEVANT_CHANGE=true" >> $GITHUB_ENV
           echo "relevant=true" >> $GITHUB_OUTPUT
           echo "Relevant changes detected; version check will run."

--- a/README.md
+++ b/README.md
@@ -80,16 +80,16 @@ UID=$(id -u) GID=$(id -g) docker compose up
 
 #### Building against a specific Ray version
 
-The published `ghcr.io/aicell-lab/bioengine-worker:0.9.0` image ships **Ray 2.55.1**. When connecting to a managed Ray cluster (KubeRay, Anyscale, etc.) Ray Client enforces an **exact** version match between driver and cluster — so you may need an image built against the version your cluster runs. Two ways:
+The published `ghcr.io/aicell-lab/bioengine-worker` image ships **Ray 2.55.1**. When connecting to a managed Ray cluster (KubeRay, Anyscale, etc.) Ray Client enforces an **exact** version match between driver and cluster — so you may need an image built against the version your cluster runs. Two ways:
 
 **Overlay on the published image (fast — pulls the image, rebuilds only the Ray install + env layers, ~1-2 min):**
 
 ```bash
 docker build \
-    --build-arg BIOENGINE_IMAGE=ghcr.io/aicell-lab/bioengine-worker:0.9.0 \
+    --build-arg BIOENGINE_IMAGE=ghcr.io/aicell-lab/bioengine-worker:<bioengine-version> \
     --build-arg RAY_VERSION=2.54.1 \
     -f docker/worker-ray-overlay.Dockerfile \
-    -t bioengine-worker:0.9.0-ray2.54.1 .
+    -t bioengine-worker:<bioengine-version>-ray2.54.1 .
 ```
 
 **Full build from source (~5-10 min):**
@@ -98,7 +98,7 @@ docker build \
 docker build \
     --build-arg RAY_VERSION=2.54.1 \
     -f docker/worker.Dockerfile \
-    -t bioengine-worker:0.9.0-ray2.54.1 .
+    -t bioengine-worker:<bioengine-version>-ray2.54.1 .
 ```
 
 Both paths produce equivalent images. The active Ray version is exposed inside the image as `$BIOENGINE_RAY_VERSION` for diagnostics. The supported Ray range is `>=2.33.0, <3.0.0` (set in `pyproject.toml`).

--- a/docker/worker-ray-overlay.Dockerfile
+++ b/docker/worker-ray-overlay.Dockerfile
@@ -5,17 +5,17 @@
 #
 # Build:
 #   docker build \
-#       --build-arg BIOENGINE_IMAGE=ghcr.io/aicell-lab/bioengine-worker:0.9.0 \
-#       --build-arg RAY_VERSION=2.54.1 \
+#       --build-arg BIOENGINE_IMAGE=ghcr.io/aicell-lab/bioengine-worker:<bioengine-version> \
+#       --build-arg RAY_VERSION=<ray-version> \
 #       -f docker/worker-ray-overlay.Dockerfile \
-#       -t bioengine-worker:0.9.0-ray2.54.1 .
+#       -t bioengine-worker:<bioengine-version>-ray<ray-version> .
 #
-# BIOENGINE_IMAGE: the published image to use as the base. Update this
-#   when you want a newer BioEngine release as the floor.
+# BIOENGINE_IMAGE: the published image to use as the base. Pin to a specific
+#   tag for reproducible builds; `latest` is fine for ad-hoc work.
 # RAY_VERSION:     the exact Ray release to swap in. Must satisfy the
 #   range BioEngine supports (>=2.33.0, <3.0.0) — see pyproject.toml.
 
-ARG BIOENGINE_IMAGE=ghcr.io/aicell-lab/bioengine-worker:0.9.0
+ARG BIOENGINE_IMAGE=ghcr.io/aicell-lab/bioengine-worker:latest
 FROM ${BIOENGINE_IMAGE}
 
 ARG RAY_VERSION=2.55.1


### PR DESCRIPTION
## Problem

Two adjacent problems with the same root cause: treating `docker/worker-ray-overlay.Dockerfile` as image-affecting.

**1. Stale version references in the overlay Dockerfile + README.** The Dockerfile shipped a hardcoded default of `ghcr.io/aicell-lab/bioengine-worker:0.9.0` for the `BIOENGINE_IMAGE` build arg — a year-plus stale pin. The same `0.9.0` was duplicated three places (Dockerfile comment block, Dockerfile ARG default, four occurrences in the README overlay build examples). Nothing in CI forced it to be updated, and the pattern has demonstrably failed at staying in sync. The CI workflow `docker-publish-worker.yml` also carried a stale comment enumerating rc tag patterns (`0.9.1-rcN`, `0.9.1-rcN-rayX.Y.Z`) the workflow does *not* produce — explaining what a workflow doesn't do is rot bait.

**2. CI gates treated overlay Dockerfile changes as worker-image changes.** Any edit to `docker/worker-ray-overlay.Dockerfile` (a *user-facing* build recipe — not part of the canonical worker image build) required a `pyproject.toml` version bump via `version-check.yml` AND triggered a worker image rebuild via `docker-publish-worker.yml`. Both wrong: nothing inside `ghcr.io/aicell-lab/bioengine-worker:<version>` changes when the overlay Dockerfile changes. The result was a forced no-op release per overlay edit.

## Solution

**Documentation cleanup:**
- `docker/worker-ray-overlay.Dockerfile`: `ARG BIOENGINE_IMAGE` default changes from `:0.9.0` → `:latest`. Comment-block build example uses `<bioengine-version>` and `<ray-version>` placeholders so it stops going stale. Accompanying note says *"Pin to a specific tag for reproducible builds; `latest` is fine for ad-hoc work"*.
- `README.md`: overlay + full-build examples switch to the same placeholders. Leading sentence refers to the image generically (no version).
- `.github/workflows/docker-publish-worker.yml`: drops the two-line comment enumerating tag patterns the workflow rejects.

**CI tightening:**
- `.github/workflows/version-check.yml`: switch the in-job path filter from `docker/` (all docker files) to an explicit allow-list — `docker/worker.Dockerfile` and `docker/datasets.Dockerfile`. Other files under `docker/` no longer demand a `pyproject.toml` bump.
- `.github/workflows/docker-publish-worker.yml`: drop `docker/worker-ray-overlay.Dockerfile` from the push trigger paths. Overlay edits no longer trigger a worker image rebuild on merge to main.

Changes to `docker/worker.Dockerfile` (the actual worker image build) still require a bump and still trigger a rebuild. Datasets image gates are unchanged.

## Behavioural changes

- **Overlay Dockerfile default.** `latest` only matters when someone runs `docker build` *without* `--build-arg`, which was the exact case where they were getting a year-stale base image. Every documented build recipe (CI, the Tubitak overlay) passes `--build-arg BIOENGINE_IMAGE=...` explicitly, so the default never influences production builds.
- **CI gates.** Overlay Dockerfile edits no longer demand a version bump or trigger an image rebuild. The narrower allow-list is the explicit shape of what is image-affecting today; if a future Dockerfile is added that *does* affect the published image, the filter will need to be extended at the same time — which is the right moment to make that decision.

## Files

- `docker/worker-ray-overlay.Dockerfile` — ARG default + comment examples
- `README.md` — overlay/full-build examples
- `.github/workflows/version-check.yml` — narrow in-job path filter
- `.github/workflows/docker-publish-worker.yml` — drop overlay from trigger paths; drop rejected-tag-pattern comment

## Test plan

- [x] `check-version` runs against this PR and skips the bump requirement, because the narrowed filter excludes overlay-Dockerfile changes.
- [ ] After merge: verify that a future overlay-Dockerfile-only edit does not trigger `docker-publish-worker.yml`.
- [ ] Manual sanity-check: `docker build --build-arg BIOENGINE_IMAGE=ghcr.io/aicell-lab/bioengine-worker:0.10.12 --build-arg RAY_VERSION=2.54.1 -f docker/worker-ray-overlay.Dockerfile -t check:0.10.12-ray2.54.1 .` still produces a working overlay (nothing else in the Dockerfile depended on the old default).
