### PR TITLE
feat(apps): expose ProxyDeployment memory reservation as deploy_app parameter

### DIFF
--- a/bioengine/apps/builder.py
+++ b/bioengine/apps/builder.py
@@ -1300,6 +1300,7 @@ class AppBuilder:
         hypha_token: Optional[str],
         disable_gpu: bool,
         max_ongoing_requests: int,
+        proxy_memory_in_gb: float,
         debug: bool,
         started_at: Optional[float] = None,
         last_updated_at: Optional[float] = None,
@@ -1441,8 +1442,19 @@ class AppBuilder:
                     "runtime_env"
                 ]["env_vars"]
 
-            # Calculate the total number of required resources
-            proxy_deployment = ProxyDeployment
+            # Override the proxy's ray_actor_options.memory at deployment time —
+            # the default 0 reservation on the decorator lets Ray place the proxy
+            # anywhere, including resource-tight nodes (e.g. the head). A real
+            # reservation biases scheduling toward nodes with headroom for the
+            # WebSocket/WebRTC payloads the proxy terminates. Ray treats `memory`
+            # as a scheduling hint, not a runtime cap.
+            proxy_ray_actor_options = dict(ProxyDeployment.ray_actor_options)
+            proxy_ray_actor_options["memory"] = int(
+                proxy_memory_in_gb * (1024**3)
+            )
+            proxy_deployment = ProxyDeployment.options(
+                ray_actor_options=proxy_ray_actor_options
+            )
             required_resources = self._calculate_required_resources(
                 deployments + [proxy_deployment]
             )
@@ -1576,6 +1588,7 @@ class AppBuilder:
                 "application_env_vars": sanitized_env_vars,
                 "disable_gpu": disable_gpu,
                 "max_ongoing_requests": max_ongoing_requests,
+                "proxy_memory_in_gb": proxy_memory_in_gb,
                 "application_resources": required_resources,
                 "authorized_users": effective_authorized_users,
                 "available_methods": [

--- a/bioengine/apps/manager.py
+++ b/bioengine/apps/manager.py
@@ -939,6 +939,7 @@ class AppsManager:
                     "hypha_token": None,
                     "disable_gpu": app_data["disable_gpu"],
                     "max_ongoing_requests": app_data["max_ongoing_requests"],
+                    "proxy_memory_in_gb": app_data.get("proxy_memory_in_gb", 0.5),
                     "application_resources": app_data["application_resources"],
                     "authorized_users": updated_authorized_users,
                     "available_methods": app_data["available_methods"],
@@ -1548,6 +1549,10 @@ class AppsManager:
             None,
             description="Maximum number of concurrent requests this application instance can handle simultaneously. Higher values allow more parallelism but use more memory. If not specified, uses 10 for a new application, or preserves the previous value if updating an existing application (only when application_id is specified).",
         ),
+        proxy_memory_in_gb: float = Field(
+            None,
+            description="Memory reservation (in GiB) for the application's ProxyDeployment — the actor that terminates the WebSocket/WebRTC connection and forwards client payloads to the compute deployments. Ray uses this as a scheduling hint (places the proxy on a node with at least this much free memory), not a hard runtime cap. Together with `max_ongoing_requests`, it bounds the worst-case memory pressure on whatever node receives the proxy, biasing placement away from resource-tight nodes (e.g. the head). If not specified, uses 0.5 for a new application, or preserves the previous value if updating an existing application (only when application_id is specified). Typical values: 0.5-4 GiB; raise for apps expecting large image/array uploads.",
+        ),
         auto_redeploy: bool = Field(
             None,
             description="If set to true, the application will be automatically redeployed if it becomes unhealthy. If not specified, uses False for a new application, or preserves the previous setting if updating an existing application (only when application_id is specified).",
@@ -1666,6 +1671,8 @@ class AppsManager:
                     disable_gpu = existing_app["disable_gpu"]
                 if max_ongoing_requests is None:
                     max_ongoing_requests = existing_app["max_ongoing_requests"]
+                if proxy_memory_in_gb is None:
+                    proxy_memory_in_gb = existing_app.get("proxy_memory_in_gb", 0.5)
                 if auto_redeploy is None:
                     auto_redeploy = existing_app["auto_redeploy"]
                 if debug is None:
@@ -1688,6 +1695,8 @@ class AppsManager:
                     disable_gpu = False
                 if max_ongoing_requests is None:
                     max_ongoing_requests = 10
+                if proxy_memory_in_gb is None:
+                    proxy_memory_in_gb = 0.5
                 if auto_redeploy is None:
                     auto_redeploy = False
                 if debug is None:
@@ -1782,6 +1791,7 @@ class AppsManager:
                 hypha_token=hypha_token,
                 disable_gpu=disable_gpu,
                 max_ongoing_requests=max_ongoing_requests,
+                proxy_memory_in_gb=proxy_memory_in_gb,
                 debug=debug,
                 started_at=started_at,
                 last_updated_at=last_updated_at,
@@ -1819,6 +1829,7 @@ class AppsManager:
                 "hypha_token": hypha_token,
                 "disable_gpu": disable_gpu,
                 "max_ongoing_requests": max_ongoing_requests,
+                "proxy_memory_in_gb": proxy_memory_in_gb,
                 "application_resources": app.metadata["resources"],
                 "authorized_users": app.metadata["authorized_users"],
                 "available_methods": app.metadata["available_methods"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.10.12"
+version = "0.10.13"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Problem

The ProxyDeployment terminates the WebSocket / WebRTC connection at the replica process and forwards client payloads to the compute deployments. Today its `ray_actor_options` carries `num_cpus: 0` and no `memory` reservation, so Ray's scheduler treats it as a 0-cost actor and is free to place it on any node, **including the head**. A multi-hundred-MB client upload landing on the head pod can OOM-kill that pod and take the cluster's entire control plane (GCS, dashboard, Serve controller) with it — every deployment unhealthy at once.

## Solution

Expose `proxy_memory_in_gb` as a new parameter on `AppsManager.deploy_app`, defaulting to 0.5 GiB. The value is plumbed through to `AppBuilder.build`, which copies `ProxyDeployment.ray_actor_options`, sets `memory = int(GiB * 2**30)`, and rebinds the deployment via `.options(...)` — preserving the runtime_env inherited from the decorator.

Ray treats `memory` as a **scheduling hint**, not a runtime cap:
- At scheduling time, Ray only places the proxy on a node with at least that much free memory.
- At runtime, the actor can still exceed the reservation; Ray won't kill it for that reason. Hard caps remain the job of the container cgroup or Ray's last-resort memory monitor.

Together with the existing `max_ongoing_requests`, the operator gets a clean two-knob control surface bounding worst-case proxy memory pressure: `max_concurrent_payloads × max_payload_size ≤ proxy_memory_in_gb`.

No placement automation, no NodeAffinity, no co-location — Ray's existing automatic placement is unchanged. The reservation just steers the scheduler away from resource-tight nodes.

## Behavioural changes

- New apps without an explicit `proxy_memory_in_gb` get **0.5 GiB** reserved by default. Naturally biases the proxy off resource-tight control-plane nodes for typical control-flow apps. Apps expecting large uploads should pass a larger value (1-4 GiB typical).
- Updates without an explicit value preserve the previously-configured one (same shape as `max_ongoing_requests`, `disable_gpu`, etc.).
- Recovered apps that were deployed before this change read through a 0.5 GiB fallback in `_deployed_applications[application_id]['proxy_memory_in_gb']` — no recovery break.

## Files

- `bioengine/apps/manager.py` —
  - New Pydantic `Field` on `deploy_app` with full description.
  - Inheritance branch (`is_update`) and new-application defaults both land at 0.5.
  - Plumbed into `app_builder.build` call.
  - Stored in `_deployed_applications[application_id]` for status + post-recovery reuse.
  - Recovery path reads with `.get(..., 0.5)` so apps from before this change recover cleanly.
- `bioengine/apps/builder.py` —
  - New parameter on `build`.
  - Copies `ProxyDeployment.ray_actor_options`, sets `memory`, rebinds via `.options(...)`.
  - Persists the value into `app_data` (the dict the proxy serves back via `get_app_data.remote()` for crash-recovery).

## Test plan

- [ ] Deploy demo-app without specifying `proxy_memory_in_gb`; confirm the ProxyDeployment replica's `ray_actor_options` reports ~0.5 GiB memory reserved.
- [ ] Deploy with `proxy_memory_in_gb=4.0`; confirm the reservation flows through and is reflected in `get_app_status`.
- [ ] Restart a worker that has apps deployed before this change; confirm recovery succeeds via the `0.5` fallback (no `KeyError`).
- [ ] Run the existing `tests/end_to_end/` suite.

## Migration notes

None. Additive parameter with a sane default. Existing apps continue to deploy unchanged unless they want to specify a non-default reservation. Existing recovered apps fall back to the 0.5 GiB default cleanly.