### PR TITLE
fix(apps): wire proxy_memory_in_gb through build_and_run_application

### DIFF
--- a/bioengine/_app/bootstrap.py
+++ b/bioengine/_app/bootstrap.py
@@ -309,6 +309,7 @@ def build_and_run_application(
     application_id: str,
     route_prefix: str,
     pkg_uri: str,
+    proxy_memory_in_gb: float,
 ) -> Dict[str, Any]:
     """Assemble the Ray Serve bind graph AND call ``serve.run`` in-process.
 
@@ -323,6 +324,11 @@ def build_and_run_application(
     this, cloudpickle on the replica fails with ``ModuleNotFoundError``
     for deployments whose own ``pip=`` forced a fresh venv that didn't
     inherit ``py_modules`` from the calling task.
+
+    ``proxy_memory_in_gb`` overrides ``ProxyDeployment.ray_actor_options
+    .memory`` so the scheduler is biased toward a node with at least
+    that much free memory for the WebSocket/WebRTC bridge. Ray treats
+    ``memory`` as a placement hint, not a runtime cap.
     """
     from ray import serve
 
@@ -353,7 +359,17 @@ def build_and_run_application(
         return handles[cid]
 
     entry_handle = bind(spec["entry_id"])
-    app = ProxyDeployment.bind(
+
+    # Override the proxy's ray_actor_options.memory at deployment time.
+    # The default 0 reservation lets Ray place the proxy on any node,
+    # including resource-tight ones (e.g. the head). A real reservation
+    # biases scheduling toward nodes with headroom for the
+    # WebSocket/WebRTC payloads the proxy terminates.
+    proxy_actor_options = dict(ProxyDeployment.ray_actor_options or {})
+    proxy_actor_options["memory"] = int(proxy_memory_in_gb * (1024**3))
+    proxy_cls = ProxyDeployment.options(ray_actor_options=proxy_actor_options)
+
+    app = proxy_cls.bind(
         entry_deployment_handle=entry_handle,
         method_schemas=spec["classes"][spec["entry_id"]]["method_schemas"],
         **proxy_args,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.11.0"
+version = "0.11.1"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Problem

`AppBuilder.submit` (introduced in #84) calls `build_and_run_application.remote(...)` with seven positional arguments — the seventh being `built_app.proxy_memory_in_gb`. The bootstrap function on `main` still has six. Every `deploy_app(...)` therefore raises `TypeError: build_and_run_application() takes 6 positional arguments but 7 were given` the moment the submit Ray task fires, which means `:0.11.0` cannot deploy *any* app, with or without an explicit `proxy_memory_in_gb` argument.

## Solution

Add `proxy_memory_in_gb: float` to `build_and_run_application` and apply it via `ProxyDeployment.options(ray_actor_options={..., memory: int(GiB * 2**30)})` before binding, matching the parameter documented in `AppsManager.deploy_app`. The override biases the Ray scheduler toward a node with at least that much free memory for the WebSocket/WebRTC bridge.

## Test plan

- Live-deployed `apps/demo-app` on a single-machine 0.11.x worker with `deploy_app(application_id="demo-app", proxy_memory_in_gb=2.0)`. RUNNING in 4 s; `get_app_status` reports `application_resources.memory == 2.5 GiB` = 2.0 (proxy override) + 0.5 (DemoApp class memory). Without this patch the same call raises the `TypeError` above before the deploy starts.
- `pytest tests/_app/` — 32/32 unit tests pass.

## File-level summary

| File | Change |
|---|---|
| `bioengine/_app/bootstrap.py` | `build_and_run_application` accepts `proxy_memory_in_gb` and applies it to `ProxyDeployment.ray_actor_options.memory` before bind. |
| `pyproject.toml` | `version = "0.11.1"` (next strictly-greater version above the published `:0.11.0` GHCR tag). |