### PR TITLE
fix(apps): align worker with Ray 2.53+ packaging signatures; lift Ray floor

### DIFF
--- a/bioengine/apps/builder.py
+++ b/bioengine/apps/builder.py
@@ -338,7 +338,19 @@ class AppBuilder:
         task-level ``py_modules``. Idempotent: if the same content was
         uploaded before the function returns the cached URI without
         re-uploading.
+
+        Ray reshapes the signatures of the two helpers between versions
+        — e.g. Ray 2.55 added a required ``include_gitignore`` parameter
+        to ``get_uri_for_directory`` and made ``include_parent_dir``
+        keyword-only on ``upload_package_if_needed``. We probe the
+        installed function signatures and only pass kwargs Ray actually
+        accepts so the same builder works against Ray 2.33 (the floor
+        in ``pyproject.toml``) and Ray 2.55+ (the shipping worker image).
+        ``include_gitignore=False`` matches the pre-2.55 behaviour
+        (apply only explicit ``excludes``).
         """
+        import inspect
+
         from ray._private.runtime_env.packaging import (
             get_uri_for_directory,
             upload_package_if_needed,
@@ -348,16 +360,33 @@ class AppBuilder:
         # artifact-root contents directly. Ray's py_modules extraction
         # then puts that path on ``sys.path`` so a plain
         # ``import deployment`` succeeds inside the task.
+        def _filter_kwargs(func, candidates):
+            sig = inspect.signature(func)
+            return {k: v for k, v in candidates.items() if k in sig.parameters}
+
         pkg_uri = get_uri_for_directory(
-            str(pkg_root_dir), excludes=self._PY_MODULES_EXCLUDES
+            str(pkg_root_dir),
+            **_filter_kwargs(
+                get_uri_for_directory,
+                {
+                    "excludes": self._PY_MODULES_EXCLUDES,
+                    "include_gitignore": False,
+                },
+            ),
         )
         upload_package_if_needed(
             pkg_uri,
             base_directory=str(pkg_root_dir.parent),
             directory=str(pkg_root_dir),
-            include_parent_dir=False,
-            excludes=self._PY_MODULES_EXCLUDES,
-            logger=self.logger,
+            **_filter_kwargs(
+                upload_package_if_needed,
+                {
+                    "include_parent_dir": False,
+                    "excludes": self._PY_MODULES_EXCLUDES,
+                    "include_gitignore": False,
+                    "logger": self.logger,
+                },
+            ),
         )
         return pkg_uri
 

--- a/bioengine/apps/builder.py
+++ b/bioengine/apps/builder.py
@@ -339,54 +339,29 @@ class AppBuilder:
         uploaded before the function returns the cached URI without
         re-uploading.
 
-        Ray reshapes the signatures of the two helpers between versions
-        — e.g. Ray 2.55 added a required ``include_gitignore`` parameter
-        to ``get_uri_for_directory`` and made ``include_parent_dir``
-        keyword-only on ``upload_package_if_needed``. We probe the
-        installed function signatures and only pass kwargs Ray actually
-        accepts so the same builder works against Ray 2.33 (the floor
-        in ``pyproject.toml``) and Ray 2.55+ (the shipping worker image).
-        ``include_gitignore=False`` matches the pre-2.55 behaviour
-        (apply only explicit ``excludes``).
+        ``include_gitignore=False`` means Ray applies only our explicit
+        ``excludes``; ``include_parent_dir=False`` keeps the artifact root
+        at the top of the zip so a plain ``import deployment`` succeeds
+        inside the task.
         """
-        import inspect
-
         from ray._private.runtime_env.packaging import (
             get_uri_for_directory,
             upload_package_if_needed,
         )
 
-        # ``include_parent_dir=False`` so the zip's top level holds the
-        # artifact-root contents directly. Ray's py_modules extraction
-        # then puts that path on ``sys.path`` so a plain
-        # ``import deployment`` succeeds inside the task.
-        def _filter_kwargs(func, candidates):
-            sig = inspect.signature(func)
-            return {k: v for k, v in candidates.items() if k in sig.parameters}
-
         pkg_uri = get_uri_for_directory(
             str(pkg_root_dir),
-            **_filter_kwargs(
-                get_uri_for_directory,
-                {
-                    "excludes": self._PY_MODULES_EXCLUDES,
-                    "include_gitignore": False,
-                },
-            ),
+            include_gitignore=False,
+            excludes=self._PY_MODULES_EXCLUDES,
         )
         upload_package_if_needed(
             pkg_uri,
             base_directory=str(pkg_root_dir.parent),
-            directory=str(pkg_root_dir),
-            **_filter_kwargs(
-                upload_package_if_needed,
-                {
-                    "include_parent_dir": False,
-                    "excludes": self._PY_MODULES_EXCLUDES,
-                    "include_gitignore": False,
-                    "logger": self.logger,
-                },
-            ),
+            module_path=str(pkg_root_dir),
+            include_gitignore=False,
+            include_parent_dir=False,
+            excludes=self._PY_MODULES_EXCLUDES,
+            logger=self.logger,
         )
         return pkg_uri
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.11.1"
+version = "0.11.2"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ worker = [
     "cloudpickle>=3.1.1",
     "haikunator>=2.1.0",
     "pydantic~=2.12.0",
-    "ray[client,serve]>=2.33.0,<3.0.0",
+    "ray[client,serve]>=2.53.0,<3.0.0",
     "uv>=0.5.0",
 ]
 dev = [


### PR DESCRIPTION
## Problem

`AppBuilder._upload_pkg_to_gcs` calls two internal helpers from `ray._private.runtime_env.packaging`:

```python
pkg_uri = get_uri_for_directory(str(pkg_root_dir), excludes=…)
upload_package_if_needed(pkg_uri, base_directory=…, directory=…, include_parent_dir=False, …)
```

Ray reshaped both helpers in the 2.5x series:

- `get_uri_for_directory` now requires `include_gitignore`.
- `upload_package_if_needed` renamed `directory=` to `module_path=` and tightened keyword handling.

The 0.11.1 worker image ships Ray 2.55.1, so every `deploy_app` on it raises:

```
TypeError: get_uri_for_directory() missing 1 required positional argument: 'include_gitignore'
```

Caught when the deNBI 0.11.1 staging worker came online and the test-deploy of `apps/demo-app` failed immediately.

## Solution

Lift the supported Ray range to `>=2.53.0,<3.0.0` and call the packaging helpers with their 2.53+ signature directly:

```python
pkg_uri = get_uri_for_directory(
    str(pkg_root_dir),
    include_gitignore=False,
    excludes=self._PY_MODULES_EXCLUDES,
)
upload_package_if_needed(
    pkg_uri,
    base_directory=str(pkg_root_dir.parent),
    module_path=str(pkg_root_dir),
    include_gitignore=False,
    include_parent_dir=False,
    excludes=self._PY_MODULES_EXCLUDES,
    logger=self.logger,
)
```

`include_gitignore=False` keeps the pre-2.55 behaviour — Ray applies only the explicit `excludes`, ignoring any `.gitignore` in the artifact root.

### Why 2.53 as the floor

- KubeRay's test matrix tracks the three most recent Ray minor releases — at the time of writing 2.53 / 2.54 / 2.55.
- Every production worker is at or above 2.54: the canonical worker image ships 2.55.1; the TÜBİTAK overlay ships 2.54.1 to match its remote head; deNBI staging runs 2.55.1.
- The packaging signature in question stabilised at 2.53 and is identical through 2.55, so a single direct call covers every supported version.

## Test plan

- [x] `pytest tests/_app/` — 32/32 unit tests pass.
- [x] End-to-end verification against Ray 2.54.1 inside the TÜBİTAK worker overlay image (`bioengine-worker-local:0.10.12-ray2.54.1`): a local Ray instance accepts `get_uri_for_directory(..., include_gitignore=False, excludes=…)` and the first call to `upload_package_if_needed(...)` returns `True`; the second call returns `False`, confirming the idempotent hash-based skip path still works.
- [ ] After 0.11.2 publishes, deploy `demo-app` + `composition-demo` on the deNBI 0.11.1+ staging worker (Ray 2.55.1) to confirm the live path.

## File-level summary

| File | Change |
|---|---|
| `bioengine/apps/builder.py` | `_upload_pkg_to_gcs` calls `get_uri_for_directory` and `upload_package_if_needed` with the Ray 2.53+ signature directly. Inspect-based kwargs shim removed. |
| `pyproject.toml` | `ray[client,serve]>=2.53.0,<3.0.0` (was `>=2.33.0`). Package version `0.11.2`. |
