### PR TITLE
fix(apps): off-load Ray package upload so deploy_app can't wedge the asyncio loop

### DIFF
--- a/bioengine/apps/builder.py
+++ b/bioengine/apps/builder.py
@@ -272,7 +272,7 @@ class AppBuilder:
 
     def _build_introspect_runtime_env(
         self,
-        pkg_root_dir: Path,
+        pkg_uri: str,
         env_vars: Dict[str, str],
     ) -> Dict[str, Any]:
         """Compose the runtime_env for the introspection + build Ray tasks.
@@ -286,10 +286,10 @@ class AppBuilder:
         imported lazily inside method bodies or from sibling modules
         that aren't imported during introspection.
 
-        Ray rejects local paths in ``runtime_env.py_modules`` at task or
-        actor level (only ``ray.init`` accepts them). To work around that
-        we pre-package the user's directory and upload it to Ray's GCS
-        storage, then reference the resulting ``gcs://...zip`` URI.
+        ``pkg_uri`` is the ``gcs://_ray_pkg_<hash>.zip`` URI returned by
+        :meth:`_upload_pkg_to_gcs`. The caller is responsible for
+        running that upload off the asyncio loop (it makes blocking Ray
+        client calls).
         """
         base_pip = update_requirements(
             [],
@@ -300,8 +300,6 @@ class AppBuilder:
             k: v for k, v in env_vars.items() if not k.startswith("_BIOENGINE_SECRET_")
         }
         introspect_env.pop("BIOENGINE_DATA_SERVER_URL", None)
-
-        pkg_uri = self._upload_pkg_to_gcs(pkg_root_dir)
 
         return {
             "py_modules": [pkg_uri],
@@ -552,14 +550,24 @@ class AppBuilder:
             application_id, artifact_id, version,
             non_secret_env_vars, secret_env_vars, hypha_token,
         )
-        runtime_env = self._build_introspect_runtime_env(
-            pkg_root_dir, env_vars
-        )
-        # The bootstrap tasks both receive the package URI directly so
-        # they can inject it into each deployment's ``runtime_env`` at
-        # bind time. Pulling it back out of ``runtime_env`` keeps a
-        # single source of truth.
-        pkg_uri = runtime_env["py_modules"][0]
+        # Off-loop: ``upload_package_if_needed`` is blocking Ray client
+        # gRPC; running it on the asyncio loop wedges get_status, the
+        # liveness probe, and every other coroutine. 120s keeps us
+        # under the 150s liveness window so a stuck upload returns a
+        # clean error instead of triggering a pod SIGKILL.
+        try:
+            pkg_uri: str = await asyncio.wait_for(
+                asyncio.to_thread(self._upload_pkg_to_gcs, pkg_root_dir),
+                timeout=120,
+            )
+        except asyncio.TimeoutError as exc:
+            raise RuntimeError(
+                "Timed out (120s) uploading the application package to "
+                "the Ray cluster. In external-cluster mode this usually "
+                "means the Ray client server's runtime-env handler is "
+                "unreachable or stuck."
+            ) from exc
+        runtime_env = self._build_introspect_runtime_env(pkg_uri, env_vars)
 
         # 3. Introspect the user package via a Ray task in the app's env.
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.11.2"
+version = "0.11.3"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Problem

deNBI's v0.11.2 staging worker was wedged for the full k8s liveness window on every `deploy_app` call against an external-cluster Ray backend, and got SIGKILL'd by the kubelet. A py-spy dump of the running worker process pinpointed the stuck frame on the MainThread (the asyncio loop thread):

```
_call_stub                     ray/util/client/worker.py:311
pin_runtime_env_uri            ray/util/client/worker.py:836
_pin_runtime_env_uri           ray/util/client/api.py:369
wrapper                        ray/_private/client_mode_hook.py:106
pin_runtime_env_uri            ray/_private/runtime_env/packaging.py:428
upload_package_if_needed       ray/_private/runtime_env/packaging.py:739
_upload_pkg_to_gcs             bioengine/apps/builder.py:357
_build_introspect_runtime_env  bioengine/apps/builder.py:304
build                          bioengine/apps/builder.py:555
deploy_app                     bioengine/apps/manager.py:1794
```

Two distinct problems chained together:

1. **Sync-in-async violation.** `_upload_pkg_to_gcs` invokes Ray's `upload_package_if_needed` → `pin_runtime_env_uri`, both blocking synchronous calls. They ran on the asyncio loop thread, so while they were pending the loop could not service any other coroutine — `get_status`, `list_apps`, the kubelet liveness HTTP probe, all of them timed out. This wedge was invisible in single-machine mode (the local Ray cluster replied in <1 s) but lethal in external-cluster mode, where the call sits on a gRPC RPC to a remote Ray client server.
2. **Cluster-side `PinRuntimeEnvURI` never replies.** Other gRPC streams on the same ray-client channel were healthy in the dump (log stream, data stream, channel_spin, request iterator), so the channel itself was up — only this specific request never got a server-side response. The most likely cause is that in external-cluster mode the Ray client bridge's runtime-env handler can't reach the cluster's HTTP package server, but disentangling that needs more work and a separate strategy (e.g. shipping `py_modules` via a different URI scheme that doesn't depend on the bridge).

This PR addresses (1) only. (2) needs a design decision about the `runtime_env.py_modules` upload path in external-cluster mode and will land as a follow-up.

## Solution

Hoist the blocking Ray call out of the asyncio loop. `_build_introspect_runtime_env` now takes the already-uploaded `pkg_uri` as input, and `build()` runs `_upload_pkg_to_gcs` on `asyncio.to_thread` under an `asyncio.wait_for(..., timeout=120)`:

```python
try:
    pkg_uri: str = await asyncio.wait_for(
        asyncio.to_thread(self._upload_pkg_to_gcs, pkg_root_dir),
        timeout=120,
    )
except asyncio.TimeoutError as exc:
    raise RuntimeError(
        "Timed out (120s) uploading the application package to the "
        "Ray cluster. In external-cluster mode this usually means the "
        "Ray client server's runtime-env handler is unreachable or stuck."
    ) from exc
```

* **The asyncio loop stays responsive** for the entire upload, regardless of how long it takes. `get_status`, `list_apps`, the liveness probe and every other RPC continue to serve.
* **120 s < 150 s liveness window**, so a stuck upload returns a clean `RuntimeError` to the `deploy_app` caller before the kubelet can SIGKILL the pod. The user sees an actionable error.
* The orphaned thread holding the gRPC call cannot be cancelled (Python threads have no kill API). `AppsManager._deployment_lock` serialises deploys, so at most one orphan accumulates per stalled attempt; subsequent calls don't pile up.

## Test plan

- [x] `pytest tests/_app/` — 32/32 unit tests pass.
- [ ] Re-deploy `apps/demo-app` from `ws-user-github|49943582/demo-app` against the deNBI 0.11 staging worker. Expected outcomes:
  - Liveness probe stays healthy throughout the call (no SIGKILL).
  - `get_status` and `list_apps` against the worker continue to respond in under a second while the deploy is in flight.
  - The `deploy_app` RPC either succeeds (if and when problem #2 is also resolved) or returns the `RuntimeError` above after ~120 s. The pod must remain running either way.

## File-level summary

| File | Change |
|---|---|
| `bioengine/apps/builder.py` | `_build_introspect_runtime_env` takes `pkg_uri` instead of `pkg_root_dir`. `build()` runs `_upload_pkg_to_gcs` via `asyncio.to_thread` under a 120 s `wait_for`, raising a clear `RuntimeError` on timeout. |
