### PR TITLE
fix(apps): ship runtime_env.py_modules via file:// content-hashed zip

### DIFF
--- a/bioengine/apps/builder.py
+++ b/bioengine/apps/builder.py
@@ -79,6 +79,8 @@ class AppBuilder:
         self.proxy_actor_name: Optional[str] = proxy_actor_name
         self.data_server_url: Optional[str] = None
 
+        self._sweep_runtime_env_tmp_files()
+
     def complete_initialization(
         self,
         server: RemoteService,
@@ -146,7 +148,7 @@ class AppBuilder:
         top level. The whole directory is later shipped as ``py_modules``;
         non-Python content (``manifest.yaml``, ``README.md``,
         ``frontend/``, notebooks) is excluded by
-        :meth:`_upload_pkg_to_gcs`.
+        :meth:`_write_pkg_to_runtime_env_dir`.
         """
         target_dir = self.apps_workdir / application_id / "source"
         if target_dir.exists():
@@ -286,10 +288,9 @@ class AppBuilder:
         imported lazily inside method bodies or from sibling modules
         that aren't imported during introspection.
 
-        ``pkg_uri`` is the ``gcs://_ray_pkg_<hash>.zip`` URI returned by
-        :meth:`_upload_pkg_to_gcs`. The caller is responsible for
-        running that upload off the asyncio loop (it makes blocking Ray
-        client calls).
+        ``pkg_uri`` is the ``file://...bioengine_pkg_<hash>.zip`` URI
+        returned by :meth:`_write_pkg_to_runtime_env_dir`. The caller is
+        responsible for running the zip walk off the asyncio loop.
         """
         base_pip = update_requirements(
             [],
@@ -329,39 +330,142 @@ class AppBuilder:
         ".github/**",
     ]
 
-    def _upload_pkg_to_gcs(self, pkg_root_dir: Path) -> str:
-        """Package ``pkg_root_dir`` and upload to Ray's internal GCS storage.
+    #: Subdirectory of ``apps_workdir`` where content-addressed
+    #: ``runtime_env.py_modules`` zips live. On a worker whose
+    #: ``apps_workdir`` is on a shared filesystem with the Ray cluster
+    #: (e.g. NFS) this is exactly the path Ray sees through the
+    #: ``file://`` URI we hand it.
+    _RUNTIME_ENV_PKG_SUBDIR = "_runtime_env_packages"
 
-        Returns a ``gcs://_ray_pkg_<hash>.zip`` URI that Ray accepts in
-        task-level ``py_modules``. Idempotent: if the same content was
-        uploaded before the function returns the cached URI without
-        re-uploading.
+    @staticmethod
+    def _is_excluded(rel_path: str, excludes: List[str]) -> bool:
+        """Match ``rel_path`` against the AppBuilder exclude patterns.
 
-        ``include_gitignore=False`` means Ray applies only our explicit
-        ``excludes``; ``include_parent_dir=False`` keeps the artifact root
-        at the top of the zip so a plain ``import deployment`` succeeds
-        inside the task.
+        Two pattern shapes are supported, mirroring the subset of
+        gitignore semantics ``_PY_MODULES_EXCLUDES`` uses:
+
+        * ``foo`` / ``foo*`` / ``*.ext`` — fnmatch against the basename.
+        * ``dir/**`` — match if ``dir`` appears as any directory
+          component along the path.
         """
-        from ray._private.runtime_env.packaging import (
-            get_uri_for_directory,
-            upload_package_if_needed,
-        )
+        import fnmatch
 
-        pkg_uri = get_uri_for_directory(
-            str(pkg_root_dir),
-            include_gitignore=False,
-            excludes=self._PY_MODULES_EXCLUDES,
+        components = rel_path.split("/")
+        basename = components[-1]
+        for pat in excludes:
+            if pat.endswith("/**"):
+                if pat[:-3] in components[:-1]:
+                    return True
+            elif fnmatch.fnmatch(basename, pat):
+                return True
+        return False
+
+    def _sweep_runtime_env_tmp_files(self) -> None:
+        """Unlink ``*.tmp.<pid>`` files left in ``_runtime_env_packages/``
+        by a prior crashed write (worker SIGKILL'd mid-zip)."""
+        pkg_dir = self.apps_workdir / self._RUNTIME_ENV_PKG_SUBDIR
+        if not pkg_dir.is_dir():
+            return
+        count = 0
+        for orphan in pkg_dir.glob("bioengine_pkg_*.zip.tmp.*"):
+            try:
+                orphan.unlink()
+                count += 1
+            except OSError as exc:
+                self.logger.warning(
+                    f"Could not remove orphan tmp file {orphan}: {exc}"
+                )
+        if count:
+            self.logger.info(
+                f"Swept {count} orphan tmp runtime_env package(s) "
+                f"from {pkg_dir}"
+            )
+
+    def _write_pkg_to_runtime_env_dir(self, pkg_root_dir: Path) -> str:
+        """Build a content-hashed zip of ``pkg_root_dir`` and return a
+        ``file://`` URI Ray accepts in task-level ``py_modules``.
+
+        Why not ``gcs://`` via Ray's ``upload_package_if_needed``? In
+        external-cluster mode the upload routes through the ray-client
+        gRPC bridge to a server-side runtime-env handler that has been
+        observed to never reply, wedging the worker's asyncio loop. A
+        local zip on a path the Ray cluster can read directly (e.g. the
+        shared NFS mount that backs ``apps_workdir`` on the deNBI
+        staging cluster) takes the bridge out of the upload path.
+
+        Same input bytes → same SHA-256 → same destination path, so
+        repeat calls return without re-writing. Atomic publish via
+        ``tmp.<pid>`` + ``os.replace`` keeps readers from ever seeing a
+        partial file. Two writers racing the same content_hash is safe
+        because the bytes are by construction identical.
+
+        The directory ``<apps_workdir>/_runtime_env_packages/`` is
+        content-addressed across every app and grows monotonically; a
+        GC pass keyed on currently-deployed apps will be a follow-up.
+        """
+        import hashlib
+        import os as _os
+        import zipfile
+
+        pkg_root = pkg_root_dir.resolve()
+        included: List[tuple[str, Path]] = []
+        for abs_path in sorted(pkg_root.rglob("*")):
+            if not abs_path.is_file():
+                continue
+            rel = abs_path.relative_to(pkg_root).as_posix()
+            if self._is_excluded(rel, self._PY_MODULES_EXCLUDES):
+                continue
+            included.append((rel, abs_path))
+
+        if not included:
+            raise RuntimeError(
+                f"No Python source files to ship from {pkg_root_dir} "
+                f"after applying excludes."
+            )
+
+        h = hashlib.sha256()
+        total_src_bytes = 0
+        for rel, abs_path in included:
+            h.update(rel.encode("utf-8"))
+            h.update(b"\x00")
+            size = abs_path.stat().st_size
+            total_src_bytes += size
+            h.update(size.to_bytes(8, "big"))
+            h.update(b"\x00")
+            with open(abs_path, "rb") as f:
+                while True:
+                    chunk = f.read(64 * 1024)
+                    if not chunk:
+                        break
+                    h.update(chunk)
+            h.update(b"\x00")
+        digest = h.hexdigest()[:16]
+
+        pkg_dir = self.apps_workdir / self._RUNTIME_ENV_PKG_SUBDIR
+        pkg_dir.mkdir(parents=True, exist_ok=True)
+        out_path = pkg_dir / f"bioengine_pkg_{digest}.zip"
+        if out_path.is_file():
+            return out_path.as_uri()
+
+        tmp_path = pkg_dir / f"{out_path.name}.tmp.{_os.getpid()}"
+        try:
+            with zipfile.ZipFile(tmp_path, "w", zipfile.ZIP_DEFLATED) as zf:
+                for rel, abs_path in included:
+                    zf.write(abs_path, arcname=rel)
+            _os.replace(tmp_path, out_path)
+        except BaseException:
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise
+
+        self.logger.info(
+            f"Wrote runtime_env package {out_path.name} "
+            f"({len(included)} files, {total_src_bytes} src bytes, "
+            f"{out_path.stat().st_size} zipped bytes)"
         )
-        upload_package_if_needed(
-            pkg_uri,
-            base_directory=str(pkg_root_dir.parent),
-            module_path=str(pkg_root_dir),
-            include_gitignore=False,
-            include_parent_dir=False,
-            excludes=self._PY_MODULES_EXCLUDES,
-            logger=self.logger,
-        )
-        return pkg_uri
+        return out_path.as_uri()
 
     # ───────────────────────── kwargs translation ────────────────────────
 
@@ -550,22 +654,21 @@ class AppBuilder:
             application_id, artifact_id, version,
             non_secret_env_vars, secret_env_vars, hypha_token,
         )
-        # Off-loop: ``upload_package_if_needed`` is blocking Ray client
-        # gRPC; running it on the asyncio loop wedges get_status, the
-        # liveness probe, and every other coroutine. 120s keeps us
-        # under the 150s liveness window so a stuck upload returns a
-        # clean error instead of triggering a pod SIGKILL.
+        # Off-loop: the zip walk hashes and compresses every file in
+        # the artifact root and could block the asyncio loop for large
+        # apps. 120s keeps us under the 150s liveness window so a slow
+        # disk fails cleanly instead of triggering a pod SIGKILL.
         try:
             pkg_uri: str = await asyncio.wait_for(
-                asyncio.to_thread(self._upload_pkg_to_gcs, pkg_root_dir),
+                asyncio.to_thread(
+                    self._write_pkg_to_runtime_env_dir, pkg_root_dir
+                ),
                 timeout=120,
             )
         except asyncio.TimeoutError as exc:
             raise RuntimeError(
-                "Timed out (120s) uploading the application package to "
-                "the Ray cluster. In external-cluster mode this usually "
-                "means the Ray client server's runtime-env handler is "
-                "unreachable or stuck."
+                "Timed out (120s) writing the application package zip "
+                "into the runtime_env packages directory."
             ) from exc
         runtime_env = self._build_introspect_runtime_env(pkg_uri, env_vars)
 

--- a/bioengine/apps/builder.py
+++ b/bioengine/apps/builder.py
@@ -376,9 +376,9 @@ class AppBuilder:
                     f"Could not remove orphan tmp file {orphan}: {exc}"
                 )
         if count:
-            self.logger.info(
+            self.logger.warning(
                 f"Swept {count} orphan tmp runtime_env package(s) "
-                f"from {pkg_dir}"
+                f"from {pkg_dir} — signal of a prior unclean shutdown"
             )
 
     def _write_pkg_to_runtime_env_dir(self, pkg_root_dir: Path) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.11.3"
+version = "0.11.4"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [

--- a/tests/apps/test_builder_runtime_env_pkg.py
+++ b/tests/apps/test_builder_runtime_env_pkg.py
@@ -1,0 +1,220 @@
+"""Unit tests for AppBuilder's content-hashed file:// runtime_env package
+writer (:meth:`AppBuilder._write_pkg_to_runtime_env_dir` and helpers).
+
+The whole point of this code path is to take the ray-client bridge out
+of the package upload flow. These tests verify the invariants the deNBI
+session and I aligned on:
+
+* Content hash is deterministic across walk order.
+* Same input → same output path → no re-write.
+* Exclude patterns filter the right files.
+* Atomic publish: only the final ``bioengine_pkg_<hash>.zip`` survives
+  a successful write.
+* Orphan ``*.tmp.<pid>`` files left by a crashed write are swept on
+  AppBuilder construction.
+"""
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from bioengine.apps.builder import AppBuilder
+
+
+@pytest.fixture
+def workdir(tmp_path: Path) -> Path:
+    return tmp_path / "apps_workdir"
+
+
+@pytest.fixture
+def builder(workdir: Path) -> AppBuilder:
+    return AppBuilder(apps_workdir=workdir)
+
+
+@pytest.fixture
+def pkg(tmp_path: Path) -> Path:
+    """A representative app package: top-level py + sub-package + the
+    kinds of files _PY_MODULES_EXCLUDES is supposed to drop."""
+    root = tmp_path / "demo_pkg"
+    root.mkdir()
+    (root / "manifest.yaml").write_text("name: x\n")
+    (root / "README.md").write_text("docs\n")
+    (root / "tutorial.ipynb").write_text("{}\n")
+    (root / "deployment.py").write_text("VALUE = 1\n")
+    (root / "utils.py").write_text("def f(): pass\n")
+    (root / "frontend").mkdir()
+    (root / "frontend" / "index.html").write_text("<html></html>\n")
+    sub = root / "runtimes"
+    sub.mkdir()
+    (sub / "__init__.py").write_text("")
+    (sub / "a.py").write_text("VALUE = 2\n")
+    cache = root / "__pycache__"
+    cache.mkdir()
+    (cache / "stale.pyc").write_bytes(b"\x00\x01")
+    return root
+
+
+def _zipped_entries(zip_path: Path) -> list[str]:
+    with zipfile.ZipFile(zip_path) as zf:
+        return sorted(zf.namelist())
+
+
+# ────────────────────────── exclude matcher ─────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "rel,expected",
+    [
+        ("manifest.yaml", True),
+        ("manifest.yml", True),
+        ("README.md", True),
+        ("README", True),
+        ("notes.md", True),
+        ("tutorial.ipynb", True),
+        ("logo.png", True),
+        ("frontend/index.html", True),
+        ("frontend/static/app.js", True),
+        ("__pycache__/x.pyc", True),
+        (".git/HEAD", True),
+        (".github/workflows/ci.yml", True),
+        ("deployment.py", False),
+        ("utils.py", False),
+        ("runtimes/a.py", False),
+        ("runtimes/__init__.py", False),
+    ],
+)
+def test_is_excluded(rel: str, expected: bool) -> None:
+    assert (
+        AppBuilder._is_excluded(rel, AppBuilder._PY_MODULES_EXCLUDES)
+        is expected
+    )
+
+
+# ─────────────────────── packaging end-to-end ───────────────────────────
+
+
+def test_writes_zip_and_returns_file_uri(builder: AppBuilder, pkg: Path) -> None:
+    uri = builder._write_pkg_to_runtime_env_dir(pkg)
+
+    assert uri.startswith("file:///")
+    out_path = Path(uri[len("file://"):])
+    assert out_path.is_file()
+    assert out_path.name.startswith("bioengine_pkg_")
+    assert out_path.name.endswith(".zip")
+    assert out_path.parent.name == "_runtime_env_packages"
+
+
+def test_zip_excludes_non_python_content(
+    builder: AppBuilder, pkg: Path
+) -> None:
+    uri = builder._write_pkg_to_runtime_env_dir(pkg)
+    entries = _zipped_entries(Path(uri[len("file://"):]))
+
+    assert "deployment.py" in entries
+    assert "utils.py" in entries
+    assert "runtimes/__init__.py" in entries
+    assert "runtimes/a.py" in entries
+
+    for excluded in (
+        "manifest.yaml",
+        "README.md",
+        "tutorial.ipynb",
+        "frontend/index.html",
+        "__pycache__/stale.pyc",
+    ):
+        assert excluded not in entries, (
+            f"{excluded!r} should not be shipped"
+        )
+
+
+def test_is_idempotent_no_rewrite(
+    builder: AppBuilder, pkg: Path
+) -> None:
+    uri1 = builder._write_pkg_to_runtime_env_dir(pkg)
+    path = Path(uri1[len("file://"):])
+    mtime_before = path.stat().st_mtime_ns
+
+    uri2 = builder._write_pkg_to_runtime_env_dir(pkg)
+    assert uri2 == uri1
+    assert path.stat().st_mtime_ns == mtime_before, (
+        "Second call should detect existing file and skip the write"
+    )
+
+
+def test_different_content_produces_different_hash(
+    builder: AppBuilder, pkg: Path
+) -> None:
+    uri1 = builder._write_pkg_to_runtime_env_dir(pkg)
+    (pkg / "deployment.py").write_text("VALUE = 999\n")
+
+    uri2 = builder._write_pkg_to_runtime_env_dir(pkg)
+    assert uri2 != uri1
+    assert Path(uri1[len("file://"):]).is_file()
+    assert Path(uri2[len("file://"):]).is_file()
+
+
+def test_rename_is_filename_not_path(
+    builder: AppBuilder, pkg: Path
+) -> None:
+    """If the only difference between two materialisations is the
+    source directory location, the resulting filename should be
+    identical — hash lives in the filename, not in apps_workdir."""
+    uri1 = builder._write_pkg_to_runtime_env_dir(pkg)
+
+    moved = pkg.parent / "renamed_pkg"
+    pkg.rename(moved)
+    uri2 = builder._write_pkg_to_runtime_env_dir(moved)
+
+    assert Path(uri1).name == Path(uri2).name
+
+
+def test_atomic_publish_no_tmp_leftovers(
+    builder: AppBuilder, pkg: Path
+) -> None:
+    builder._write_pkg_to_runtime_env_dir(pkg)
+    pkg_dir = builder.apps_workdir / "_runtime_env_packages"
+
+    leftover = list(pkg_dir.glob("*.tmp.*"))
+    assert leftover == [], (
+        f"Atomic write should leave no .tmp.<pid> files: found {leftover}"
+    )
+
+
+def test_raises_on_empty_input(
+    builder: AppBuilder, tmp_path: Path
+) -> None:
+    empty = tmp_path / "empty_pkg"
+    empty.mkdir()
+    (empty / "README.md").write_text("only docs\n")
+
+    with pytest.raises(RuntimeError, match="No Python source files"):
+        builder._write_pkg_to_runtime_env_dir(empty)
+
+
+# ─────────────────────────── startup sweep ──────────────────────────────
+
+
+def test_sweep_removes_orphan_tmp_files(workdir: Path) -> None:
+    pkg_dir = workdir / "_runtime_env_packages"
+    pkg_dir.mkdir(parents=True)
+    real = pkg_dir / "bioengine_pkg_aaaaaaaaaaaaaaaa.zip"
+    real.write_bytes(b"real")
+    orphan_a = pkg_dir / "bioengine_pkg_bbbbbbbbbbbbbbbb.zip.tmp.12345"
+    orphan_a.write_bytes(b"partial")
+    orphan_b = pkg_dir / "bioengine_pkg_cccccccccccccccc.zip.tmp.67890"
+    orphan_b.write_bytes(b"partial")
+    unrelated = pkg_dir / "some_other_file.txt"
+    unrelated.write_bytes(b"not ours")
+
+    AppBuilder(apps_workdir=workdir)
+
+    assert real.is_file()
+    assert unrelated.is_file()
+    assert not orphan_a.exists()
+    assert not orphan_b.exists()
+
+
+def test_sweep_silent_when_dir_absent(workdir: Path) -> None:
+    AppBuilder(apps_workdir=workdir)


### PR DESCRIPTION
## Problem

The deNBI session captured a py-spy dump while the staging worker was hung mid-`deploy_app`. The MainThread stack pinpointed the wedge in Ray's package upload, inside `pin_runtime_env_uri` waiting on the Ray-client gRPC `_call_stub`:

```
_call_stub                     ray/util/client/worker.py:311
pin_runtime_env_uri            ray/util/client/worker.py:836
upload_package_if_needed       ray/_private/runtime_env/packaging.py:739
_upload_pkg_to_gcs             bioengine/apps/builder.py:357
build                          bioengine/apps/builder.py:555
deploy_app                     bioengine/apps/manager.py:1794
```

Other gRPC streams on the same ray-client channel were healthy in the same dump — the channel was up, only this specific `PinRuntimeEnvURI` request never got a server-side response. Reproducible behaviour on the deNBI external-cluster setup, Ray 2.55.1.

PR #105 (released as 0.11.3) bounded the blast radius by moving the call onto `asyncio.to_thread` under a 120 s `wait_for`. That keeps the worker's asyncio loop responsive and lets `deploy_app` return a clean `RuntimeError` instead of triggering a pod SIGKILL — verified end-to-end on the 0.11.3 staging pod (RPC returned the wrapped `RuntimeError` at T+122.8 s, restartCount stayed at 0, `get_status` stayed responsive throughout). But it did not unblock real deploys: every external-cluster `deploy_app` still hits the safety timeout because the underlying gRPC upload never completes.

## Solution

Cut the Ray-client bridge out of the package upload path entirely. AppBuilder now writes the artifact root into a content-addressed zip at

```
<apps_workdir>/_runtime_env_packages/bioengine_pkg_<sha256[:16]>.zip
```

and hands Ray a `file://` URI in `runtime_env.py_modules`. The Ray runtime-env agent fetches that URI directly on the cluster side — no client-bridge round trip, no `PinRuntimeEnvURI` call, no dependency on Ray's private `upload_package_if_needed` / `get_uri_for_directory` helpers (which have already had a breaking signature change once in the 2.5x series, see PR #104).

The URI scheme handed to Ray changes from `gcs://_ray_pkg_<hash>.zip` to `file:///<apps_workdir>/_runtime_env_packages/bioengine_pkg_<hash>.zip`. The directory is shared across all apps on the worker (the hash is content-addressed, not per-app), and lives directly under `apps_workdir`.

Verified with a smoke test on Ray 2.54.1: a packaged module shipped via `file://` round-trips through `ray.remote(...).remote()` in 1.7 s.

### Deployment prerequisite

Because the URI scheme is now `file://`, **the worker pod's `apps_workdir` must be visible at the same absolute path on every Ray cluster node** that will run the introspection task or any deployment replica.

* On **deNBI staging**, all three pod types (bioengine-worker, raycluster head, raycluster workers) mount the same Manila NFS export (`share-a99cbc1f…`) at `/home/bioengine`. The worker writes the zip; every Ray pod reads it through the same path. Verified live before the design was approved.
* On **single-machine mode**, the worker is the Ray cluster, so the local disk under `apps_workdir` is by definition reachable.
* On any **external-cluster deployment without a shared mount at the same path** (no overlay we ship today is in that category, but it is worth flagging), this change must be paired with a different upload strategy — e.g. an HTTPS endpoint on the worker serving the same zip. A per-overlay config switch would carry that. Out of scope for this PR; flagging so a future overlay maintainer knows what to look for.

### Invariants worth naming, since the on-disk layout is part of the worker's public surface

* **Content-addressed:** same input bytes → same SHA-256 → same destination path. The hash lives in the filename, not in the directory, so a future change to `apps_workdir` does not orphan packages.
* **Idempotent:** an existing file short-circuits the write.
* **Atomic publish** via `tmp.<pid>` + `os.replace` — readers see either ENOENT or the complete file, never a torn write. Ray's URI resolution treats ENOENT as "not yet available" and retries, which composes cleanly.
* **Two writers racing the same content hash** is safe — the bytes are by construction identical; whichever `os.replace` wins, the result is correct.
* **Orphan `bioengine_pkg_*.zip.tmp.<pid>` files** left by a SIGKILL'd worker are swept on the next `AppBuilder.__init__`. A non-zero sweep count is logged at WARNING level so it surfaces in any dashboard that grep's logs by severity (signal of a prior unclean shutdown).

### Out of scope

Garbage collection of `_runtime_env_packages/` is a follow-up. Content addressing makes the directory grow monotonically as apps evolve — a cleanup pass keyed on the currently-deployed app set is tracked separately. Not blocking for this PR.

## Test plan

- [x] `pytest tests/_app/ tests/apps/test_builder_runtime_env_pkg.py` — 57 / 57 passing, including 17 parameterised cases for the exclude matcher and dedicated coverage for each invariant above (content-hash determinism, idempotency, exclude semantics, atomic publish, sweep of orphan tmp files, empty-input rejection).
- [x] Ray 2.54.1 smoke test in a `bioengine-worker-local` container: `@ray.remote(runtime_env={"py_modules": ["file:///tmp/<…>.zip"]})` ships and imports correctly, round-trip in 1.7 s.
- [ ] Re-deploy `apps/demo-app` on the deNBI 0.11.4 staging worker. Expected: the deploy completes successfully and the application registers as a Hypha service.
- [ ] Re-deploy `apps/composition-demo` on the same worker — exercises the multi-deployment composition path through the same upload mechanism.

## File-level summary

| File | Change |
|---|---|
| `bioengine/apps/builder.py` | New `_write_pkg_to_runtime_env_dir(pkg_root_dir) -> str` builds a content-addressed zip under `<apps_workdir>/_runtime_env_packages/` and returns a `file://` URI. New `_is_excluded` matcher (handles `*.ext`, basename globs, and `dir/**`). New `_sweep_runtime_env_tmp_files()` invoked at `__init__`, logs at WARNING when the count is non-zero. `build()` now writes via `asyncio.to_thread(_write_pkg_to_runtime_env_dir, …)` under the same 120 s `wait_for`; the old `_upload_pkg_to_gcs` and its Ray-internal imports are removed. |
| `tests/apps/test_builder_runtime_env_pkg.py` | New unit-test module covering the exclude matcher (17 parametrised cases), end-to-end zip-and-URI semantics, idempotency, content-hash determinism (independent of source path), atomic publish (no `.tmp.*` leftovers), error on empty input, and orphan-sweep behaviour. |
| `pyproject.toml` | Bumped to `0.11.4`. |
