### PR TITLE
fix(_app): lazy hypha_rpc + ray.serve imports so head pod can unpickle bioengine._app

### DIFF
--- a/bioengine/_app/decorators.py
+++ b/bioengine/_app/decorators.py
@@ -23,11 +23,16 @@ from __future__ import annotations
 import inspect
 from typing import Any, Callable, Dict, List, Optional
 
-from hypha_rpc.utils.schema import schema_method
-from ray import serve
-
 from bioengine._app.errors import ReservedMethodNameError
 from bioengine._app.mixin import _make_check_health, wrap_init
+
+# Top-level imports of hypha_rpc and ray.serve were moved inside the
+# decorator function bodies. The introspection task in
+# bioengine._app.bootstrap is pickled-by-reference; unpickling it on the
+# Ray client server (head-pod side, upstream of any runtime_env) re-runs
+# this module's import block in whatever base environment that pod has.
+# That pod is not guaranteed to ship hypha_rpc or ray[serve] — anything
+# the decorators need at *application* time stays a lazy import.
 
 # Method names the framework owns. User code cannot define them as plain
 # methods — the new contract is to mark a method with @bioengine.<hook>
@@ -48,6 +53,8 @@ def method(fn: Callable[..., Any]) -> Callable[..., Any]:
     ``@bioengine.app`` decorator reads at class-creation time to assemble
     ``_bioengine_method_schemas``.
     """
+    from hypha_rpc.utils.schema import schema_method
+
     wrapped = schema_method(fn)
     setattr(wrapped, _KIND_ATTR, "method")
     return wrapped
@@ -135,6 +142,8 @@ def app(
     """
 
     def decorator(cls: type) -> Any:
+        from ray import serve
+
         if not inspect.isclass(cls):
             raise TypeError(
                 "@bioengine.app must be applied to a class, not "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.11.4"
+version = "0.11.5"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [

--- a/tests/_app/test_decorators_baseline_imports.py
+++ b/tests/_app/test_decorators_baseline_imports.py
@@ -1,0 +1,143 @@
+"""Lock in the baseline-import invariant for ``bioengine._app``.
+
+Importing ``bioengine._app`` (and any of its submodules that the cloudpickle
+unpickler may walk through on the Ray client server) must NOT require
+``hypha_rpc`` or ``ray.serve`` to be installed. Those land via the user's
+runtime_env on the actor where the decorator is *applied*; they are not
+expected to be present on whatever pod the Ray client server runs on
+upstream of the actor boundary.
+
+This was the root cause of the 0.11.4 deploy_app regression — a top-level
+``from hypha_rpc.utils.schema import schema_method`` in
+``bioengine/_app/decorators.py`` crashed the head pod's unpickler with
+``ModuleNotFoundError: No module named 'hypha_rpc'`` before the actor's
+runtime_env was ever materialised. These tests pin the fix so the
+regression doesn't sneak back in.
+"""
+from __future__ import annotations
+
+import builtins
+import importlib
+import sys
+
+
+_BIOENGINE_APP_MODULES = (
+    "bioengine._app",
+    "bioengine._app.decorators",
+    "bioengine._app.mixin",
+    "bioengine._app.runtime_handle",
+    "bioengine._app.errors",
+    "bioengine._app.accessors",
+    "bioengine._app.bootstrap",
+)
+
+
+def _snapshot_relevant_modules() -> dict:
+    return {
+        k: v
+        for k, v in sys.modules.items()
+        if k.startswith("bioengine._app")
+        or k.startswith("hypha_rpc")
+        or k.startswith("ray.serve")
+        or k.startswith("ray._private.deploy")
+    }
+
+
+def _drop_relevant_modules() -> None:
+    for k in list(sys.modules):
+        if (
+            k.startswith("bioengine._app")
+            or k.startswith("hypha_rpc")
+            or k.startswith("ray.serve")
+        ):
+            sys.modules.pop(k, None)
+
+
+def _patched_import(banned: tuple[str, ...]):
+    """Return a replacement ``builtins.__import__`` that raises
+    ImportError for any module whose name starts with one of ``banned``."""
+    real = builtins.__import__
+
+    def fake(name, globals=None, locals=None, fromlist=(), level=0):
+        if any(name == b or name.startswith(b + ".") for b in banned):
+            raise ImportError(f"simulated missing module: {name}")
+        return real(name, globals, locals, fromlist, level)
+
+    return fake
+
+
+def test_app_subpackage_imports_without_hypha_rpc() -> None:
+    """Replicates the head-pod environment: hypha_rpc absent."""
+    saved = _snapshot_relevant_modules()
+    try:
+        _drop_relevant_modules()
+        original_import = builtins.__import__
+        builtins.__import__ = _patched_import(("hypha_rpc",))
+        try:
+            importlib.import_module("bioengine._app")
+        finally:
+            builtins.__import__ = original_import
+    finally:
+        _drop_relevant_modules()
+        sys.modules.update(saved)
+
+
+def test_app_subpackage_imports_without_ray_serve() -> None:
+    """Same shape: ray-core only, no ray[serve]."""
+    saved = _snapshot_relevant_modules()
+    try:
+        _drop_relevant_modules()
+        original_import = builtins.__import__
+        builtins.__import__ = _patched_import(("ray.serve",))
+        try:
+            importlib.import_module("bioengine._app")
+        finally:
+            builtins.__import__ = original_import
+    finally:
+        _drop_relevant_modules()
+        sys.modules.update(saved)
+
+
+def test_bootstrap_imports_without_hypha_rpc_or_ray_serve() -> None:
+    """The introspection module the Ray client server unpickles must not
+    pull in hypha_rpc or ray.serve transitively either."""
+    saved = _snapshot_relevant_modules()
+    try:
+        _drop_relevant_modules()
+        original_import = builtins.__import__
+        builtins.__import__ = _patched_import(("hypha_rpc", "ray.serve"))
+        try:
+            importlib.import_module("bioengine._app.bootstrap")
+        finally:
+            builtins.__import__ = original_import
+    finally:
+        _drop_relevant_modules()
+        sys.modules.update(saved)
+
+
+def test_method_decorator_still_works_when_invoked() -> None:
+    """The lazy import inside ``method()`` must succeed at decoration time."""
+    from bioengine._app.decorators import method
+
+    @method
+    async def ping(self) -> dict:
+        return {"ok": True}
+
+    assert hasattr(ping, "__schema__")
+    assert getattr(ping, "_bioengine_kind", None) == "method"
+
+
+def test_app_decorator_still_works_when_invoked() -> None:
+    """The lazy ``from ray import serve`` inside ``app()``'s inner
+    ``decorator(cls)`` must succeed at decoration time."""
+    from ray.serve import Deployment
+
+    from bioengine._app.decorators import app, method
+
+    @app(num_cpus=0)
+    class Demo:
+        @method
+        async def ping(self) -> dict:
+            return {"ok": True}
+
+    assert isinstance(Demo, Deployment)


### PR DESCRIPTION
## Problem

After PR #106 (0.11.4) replaced the Ray-client `gcs://` upload with a content-hashed `file://` zip, the deNBI staging worker accepted the runtime_env payload cleanly — the zip landed on shared NFS, Ray's URI parser was happy — but the very next step still failed. `deploy_app('demo-app')` raised at `ray.remote(...)(introspect_app).remote(...)` (the introspection task submission) within 3 s, with the truncated client-side traceback bottoming out in `ray._private.auto_init_hook`.

The deNBI session captured the full server-side error from the Ray head pod's `ray_client_server_*.err`:

```
2026-06-11 19:14:39,819 - ray.util.client.server.server - ERROR - Put failed:
Traceback (most recent call last):
  File ".../ray/util/client/server/server.py", line 536, in _put_object
    obj = loads_from_client(data, self)
  File ".../ray/util/client/server/server_pickler.py", line 124, in loads_from_client
    ).load()
  File ".../runtime_resources/py_modules_files/_ray_pkg_28b08d64df1532f7/bioengine/_app/__init__.py", line 16, in <module>
    from bioengine._app.decorators import (
  File ".../bioengine/_app/decorators.py", line 26, in <module>
    from hypha_rpc.utils.schema import schema_method
ModuleNotFoundError: No module named 'hypha_rpc'
```

When the Ray client server unpickles a remote-call payload, it walks the function's module hierarchy in whatever base env that pod ships with. That is **upstream of the runtime_env boundary** — the actor's `hypha_rpc`-bearing venv has not yet been materialised. The head pod has `ray-core` but no `hypha_rpc`, so the top-level `from hypha_rpc.utils.schema import schema_method` in `decorators.py` crashed the unpickle, and `deploy_app` raised before the introspection task ever reached the actor.

A note that this is the *asymmetry the local smoke test couldn't catch*: a single-machine Ray cluster runs the worker and the actor in one Python process where every dependency is present. External-cluster mode has a client/server hop whose deserializer runs in a process that has neither `bioengine` nor `hypha_rpc` in its base env — only ray-core.

## Solution

Move both third-party imports in `bioengine/_app/decorators.py` inside the decorator function bodies that actually use them:

* `from hypha_rpc.utils.schema import schema_method` → now inside `method(fn)`.
* `from ray import serve` → now inside the inner `decorator(cls)` returned by `app(...)`.

Importing `bioengine._app` now requires only the standard library and `bioengine` internals (`errors`, `mixin`). Those are guaranteed to be present wherever the worker has shipped a `py_modules` bundle, including the leftover dirs the head pod's client server is resolving `bioengine._app` from. The decorators themselves are only ever applied inside user app code that already ships its own runtime_env, where `hypha_rpc` and `ray.serve` are guaranteed installed.

The fix is paired with regression tests that simulate the head-pod environment by routing both module names through a `builtins.__import__` that raises `ImportError`, and confirm:

* `bioengine._app` imports successfully without `hypha_rpc`.
* `bioengine._app` imports successfully without `ray.serve`.
* `bioengine._app.bootstrap` (the module the client server actually unpickles into) imports successfully without either.
* `@bioengine.method` and `@bioengine.app` still work when invoked in an environment where the deps are present.

The latter two pin the invariant — if someone later re-adds a top-level third-party import to `bioengine/_app/` and ships it, these tests will fail at CI time rather than at the next external-cluster deploy.

## Test plan

- [x] `pytest tests/_app/ tests/apps/test_builder_runtime_env_pkg.py` — 62 / 62 passing locally (21 existing decorator tests + 4 new baseline-import tests + 25 file:// packaging tests + 12 bootstrap tests).
- [ ] Re-deploy `apps/demo-app` on the deNBI 0.11.5 staging worker — expected: successful RUNNING state.
- [ ] Re-deploy `apps/composition-demo` on the same worker — exercises the multi-deployment composition path through the same unpickling chain.

## File-level summary

| File | Change |
|---|---|
| `bioengine/_app/decorators.py` | `from hypha_rpc.utils.schema import schema_method` and `from ray import serve` moved out of the module-level import block and into the bodies of `method()` and the inner `decorator(cls)` returned by `app()`. Top-of-module note documents why. |
| `tests/_app/test_decorators_baseline_imports.py` | New regression suite that monkey-patches `builtins.__import__` to simulate the head-pod environment (no `hypha_rpc`, no `ray.serve`), and verifies `bioengine._app` and its submodules import cleanly anyway. |
| `pyproject.toml` | Bumped to `0.11.5`. |
