### PR TITLE
fix(apps): ship bioengine source as a second py_modules URI alongside user app zip

### DIFF
--- a/bioengine/_app/bootstrap.py
+++ b/bioengine/_app/bootstrap.py
@@ -309,6 +309,7 @@ def build_and_run_application(
     application_id: str,
     route_prefix: str,
     pkg_uri: str,
+    bioengine_uri: str,
     proxy_memory_in_gb: float,
 ) -> Dict[str, Any]:
     """Assemble the Ray Serve bind graph AND call ``serve.run`` in-process.
@@ -318,12 +319,15 @@ def build_and_run_application(
     unpickled deployment is re-accessed, so the graph must stay inside
     the process that built it.
 
-    ``pkg_uri`` is the Ray-internal ``gcs://`` URI of the user's app
-    package. Every deployment's ``runtime_env`` is augmented with this
-    URI so the replica venv can ``import`` the user's modules — without
-    this, cloudpickle on the replica fails with ``ModuleNotFoundError``
-    for deployments whose own ``pip=`` forced a fresh venv that didn't
-    inherit ``py_modules`` from the calling task.
+    ``pkg_uri`` is the ``file://`` URI of the user's app package.
+    ``bioengine_uri`` is the ``file://`` URI of the worker's own
+    bioengine source. Every deployment's ``runtime_env.py_modules`` is
+    augmented with both so the replica venv can ``import`` the user's
+    modules AND ``import bioengine``. Without ``bioengine_uri`` on the
+    replica side, deployments whose own ``pip=`` forced a fresh venv
+    crash at ``pickle.loads`` time with ``ModuleNotFoundError: No
+    module named 'bioengine'`` — bioengine itself is not on PyPI and
+    the venv only ships its deps.
 
     ``proxy_memory_in_gb`` overrides ``ProxyDeployment.ray_actor_options
     .memory`` so the scheduler is biased toward a node with at least
@@ -340,8 +344,9 @@ def build_and_run_application(
         opts = dict(cls.ray_actor_options or {})
         runtime_env = dict(opts.get("runtime_env") or {})
         py_modules = list(runtime_env.get("py_modules") or [])
-        if pkg_uri not in py_modules:
-            py_modules.append(pkg_uri)
+        for uri in (bioengine_uri, pkg_uri):
+            if uri not in py_modules:
+                py_modules.append(uri)
         runtime_env["py_modules"] = py_modules
         opts["runtime_env"] = runtime_env
         return cls.options(ray_actor_options=opts)

--- a/bioengine/apps/builder.py
+++ b/bioengine/apps/builder.py
@@ -275,6 +275,7 @@ class AppBuilder:
     def _build_introspect_runtime_env(
         self,
         pkg_uri: str,
+        bioengine_uri: str,
         env_vars: Dict[str, str],
     ) -> Dict[str, Any]:
         """Compose the runtime_env for the introspection + build Ray tasks.
@@ -288,9 +289,12 @@ class AppBuilder:
         imported lazily inside method bodies or from sibling modules
         that aren't imported during introspection.
 
-        ``pkg_uri`` is the ``file://...bioengine_pkg_<hash>.zip`` URI
-        returned by :meth:`_write_pkg_to_runtime_env_dir`. The caller is
-        responsible for running the zip walk off the asyncio loop.
+        ``py_modules`` ships two URIs: the worker's own ``bioengine``
+        source (the actor's venv only carries bioengine's *deps* — see
+        :meth:`_write_bioengine_source_to_runtime_env_dir`) and the
+        user app package. Both URIs are ``file://...zip`` returned by
+        :meth:`_write_pkg_to_runtime_env_dir`. The caller is responsible
+        for running the zip walks off the asyncio loop.
         """
         base_pip = update_requirements(
             [],
@@ -303,7 +307,7 @@ class AppBuilder:
         introspect_env.pop("BIOENGINE_DATA_SERVER_URL", None)
 
         return {
-            "py_modules": [pkg_uri],
+            "py_modules": [bioengine_uri, pkg_uri],
             "pip": base_pip,
             "env_vars": introspect_env,
         }
@@ -324,6 +328,9 @@ class AppBuilder:
         "*.gif",
         "*.svg",
         "*.pdf",
+        "*.pyc",
+        "*.pyo",
+        "*.so",
         "frontend/**",
         "__pycache__/**",
         ".git/**",
@@ -367,7 +374,10 @@ class AppBuilder:
         if not pkg_dir.is_dir():
             return
         count = 0
-        for orphan in pkg_dir.glob("bioengine_pkg_*.zip.tmp.*"):
+        orphans = list(pkg_dir.glob("bioengine_pkg_*.zip.tmp.*")) + list(
+            pkg_dir.glob("bioengine_runtime_*.zip.tmp.*")
+        )
+        for orphan in orphans:
             try:
                 orphan.unlink()
                 count += 1
@@ -381,7 +391,13 @@ class AppBuilder:
                 f"from {pkg_dir} — signal of a prior unclean shutdown"
             )
 
-    def _write_pkg_to_runtime_env_dir(self, pkg_root_dir: Path) -> str:
+    def _write_pkg_to_runtime_env_dir(
+        self,
+        pkg_root_dir: Path,
+        *,
+        filename_prefix: str = "bioengine_pkg",
+        arc_prefix: str = "",
+    ) -> str:
         """Build a content-hashed zip of ``pkg_root_dir`` and return a
         ``file://`` URI Ray accepts in task-level ``py_modules``.
 
@@ -424,6 +440,8 @@ class AppBuilder:
             )
 
         h = hashlib.sha256()
+        h.update(arc_prefix.encode("utf-8"))
+        h.update(b"\x00")
         total_src_bytes = 0
         for rel, abs_path in included:
             h.update(rel.encode("utf-8"))
@@ -443,7 +461,7 @@ class AppBuilder:
 
         pkg_dir = self.apps_workdir / self._RUNTIME_ENV_PKG_SUBDIR
         pkg_dir.mkdir(parents=True, exist_ok=True)
-        out_path = pkg_dir / f"bioengine_pkg_{digest}.zip"
+        out_path = pkg_dir / f"{filename_prefix}_{digest}.zip"
         if out_path.is_file():
             return out_path.as_uri()
 
@@ -451,7 +469,8 @@ class AppBuilder:
         try:
             with zipfile.ZipFile(tmp_path, "w", zipfile.ZIP_DEFLATED) as zf:
                 for rel, abs_path in included:
-                    zf.write(abs_path, arcname=rel)
+                    arc = f"{arc_prefix}/{rel}" if arc_prefix else rel
+                    zf.write(abs_path, arcname=arc)
             _os.replace(tmp_path, out_path)
         except BaseException:
             try:
@@ -466,6 +485,44 @@ class AppBuilder:
             f"{out_path.stat().st_size} zipped bytes)"
         )
         return out_path.as_uri()
+
+    def _build_py_modules_uris(self, pkg_root_dir: Path) -> tuple[str, str]:
+        """Write both runtime_env zips and return ``(pkg_uri, bioengine_uri)``.
+
+        Wrapped in a single ``asyncio.to_thread`` call by ``build()`` so
+        both blocking zip walks happen off the asyncio loop together.
+        """
+        pkg_uri = self._write_pkg_to_runtime_env_dir(pkg_root_dir)
+        bioengine_uri = self._write_bioengine_source_to_runtime_env_dir()
+        return pkg_uri, bioengine_uri
+
+    def _write_bioengine_source_to_runtime_env_dir(self) -> str:
+        """Bundle the worker's installed ``bioengine`` source as a
+        ``file://`` zip and return its URI for ``runtime_env.py_modules``.
+
+        Why this exists: in external-cluster mode the Ray actor that
+        runs ``introspect_app`` (and every user deployment replica)
+        spins up in a fresh process. ``runtime_env.pip`` installs
+        bioengine's *dependencies* into a venv, but bioengine itself is
+        not on PyPI, so the venv does not contain it. Without bioengine
+        on the actor's ``sys.path``, ``pickle.loads`` of any function
+        defined under ``bioengine._app`` fails immediately with
+        ``ModuleNotFoundError: No module named 'bioengine'``.
+
+        The fix is to ship the worker's own bioengine source as a
+        second ``py_modules`` URI on every runtime_env we hand to Ray.
+        Same content-addressed zip pattern as the user app — written
+        once per worker process, cached by content hash, served over
+        the shared NFS mount that backs ``apps_workdir``.
+        """
+        import bioengine
+
+        bioengine_dir = Path(bioengine.__file__).parent
+        return self._write_pkg_to_runtime_env_dir(
+            bioengine_dir,
+            filename_prefix="bioengine_runtime",
+            arc_prefix="bioengine",
+        )
 
     # ───────────────────────── kwargs translation ────────────────────────
 
@@ -657,20 +714,25 @@ class AppBuilder:
         # Off-loop: the zip walk hashes and compresses every file in
         # the artifact root and could block the asyncio loop for large
         # apps. 120s keeps us under the 150s liveness window so a slow
-        # disk fails cleanly instead of triggering a pod SIGKILL.
+        # disk fails cleanly instead of triggering a pod SIGKILL. We
+        # also bundle the worker's own bioengine source here — the
+        # actor's runtime_env.pip installs bioengine's *deps* into a
+        # venv but bioengine itself is not on PyPI, so without this the
+        # Ray actor crashes at ``pickle.loads(introspect_app)`` with
+        # ``ModuleNotFoundError: No module named 'bioengine'``.
         try:
-            pkg_uri: str = await asyncio.wait_for(
-                asyncio.to_thread(
-                    self._write_pkg_to_runtime_env_dir, pkg_root_dir
-                ),
+            pkg_uri, bioengine_uri = await asyncio.wait_for(
+                asyncio.to_thread(self._build_py_modules_uris, pkg_root_dir),
                 timeout=120,
             )
         except asyncio.TimeoutError as exc:
             raise RuntimeError(
-                "Timed out (120s) writing the application package zip "
-                "into the runtime_env packages directory."
+                "Timed out (120s) writing runtime_env package zips into "
+                "the runtime_env packages directory."
             ) from exc
-        runtime_env = self._build_introspect_runtime_env(pkg_uri, env_vars)
+        runtime_env = self._build_introspect_runtime_env(
+            pkg_uri, bioengine_uri, env_vars
+        )
 
         # 3. Introspect the user package via a Ray task in the app's env.
         try:
@@ -794,6 +856,7 @@ class AppBuilder:
             proxy_args=proxy_args,
             runtime_env=runtime_env,
             pkg_uri=pkg_uri,
+            bioengine_uri=bioengine_uri,
             proxy_memory_in_gb=proxy_memory_in_gb,
         )
 
@@ -818,6 +881,7 @@ class AppBuilder:
                     application_id,
                     f"/{application_id}",
                     built_app.pkg_uri,
+                    built_app.bioengine_uri,
                     built_app.proxy_memory_in_gb,
                 ),
             )
@@ -848,6 +912,7 @@ class BuiltApp:
         "proxy_args",
         "runtime_env",
         "pkg_uri",
+        "bioengine_uri",
         "proxy_memory_in_gb",
     )
 
@@ -859,6 +924,7 @@ class BuiltApp:
         proxy_args: Dict[str, Any],
         runtime_env: Dict[str, Any],
         pkg_uri: str,
+        bioengine_uri: str,
         proxy_memory_in_gb: float,
     ) -> None:
         self.metadata = metadata
@@ -867,4 +933,5 @@ class BuiltApp:
         self.proxy_args = proxy_args
         self.runtime_env = runtime_env
         self.pkg_uri = pkg_uri
+        self.bioengine_uri = bioengine_uri
         self.proxy_memory_in_gb = proxy_memory_in_gb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.11.5"
+version = "0.11.6"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [

--- a/tests/apps/test_builder_runtime_env_pkg.py
+++ b/tests/apps/test_builder_runtime_env_pkg.py
@@ -218,3 +218,95 @@ def test_sweep_removes_orphan_tmp_files(workdir: Path) -> None:
 
 def test_sweep_silent_when_dir_absent(workdir: Path) -> None:
     AppBuilder(apps_workdir=workdir)
+
+
+# ─────────────────────── bioengine source bundling ──────────────────────
+
+
+def test_bioengine_source_zip_has_distinct_filename_prefix(
+    builder: AppBuilder,
+) -> None:
+    uri = builder._write_bioengine_source_to_runtime_env_dir()
+    name = Path(uri[len("file://"):]).name
+    assert name.startswith("bioengine_runtime_")
+    assert name.endswith(".zip")
+
+
+def test_bioengine_source_zip_entries_are_prefixed_with_package_name(
+    builder: AppBuilder,
+) -> None:
+    uri = builder._write_bioengine_source_to_runtime_env_dir()
+    entries = _zipped_entries(Path(uri[len("file://"):]))
+
+    assert "bioengine/__init__.py" in entries
+    assert any(e.startswith("bioengine/_app/") for e in entries)
+    assert any(e.startswith("bioengine/apps/") for e in entries)
+
+    for entry in entries:
+        assert entry.startswith("bioengine/"), entry
+
+
+def test_bioengine_source_zip_excludes_pycache(
+    builder: AppBuilder,
+) -> None:
+    uri = builder._write_bioengine_source_to_runtime_env_dir()
+    entries = _zipped_entries(Path(uri[len("file://"):]))
+
+    for entry in entries:
+        assert "__pycache__" not in entry
+        assert not entry.endswith(".pyc")
+        assert not entry.endswith(".pyo")
+        assert not entry.endswith(".so")
+
+
+def test_arc_prefix_changes_hash(builder: AppBuilder, pkg: Path) -> None:
+    """Same source content under different arc_prefix must produce
+    different content hashes — the zip contents differ even though the
+    source files don't."""
+    uri_no_prefix = builder._write_pkg_to_runtime_env_dir(
+        pkg, filename_prefix="case_a"
+    )
+    uri_with_prefix = builder._write_pkg_to_runtime_env_dir(
+        pkg, filename_prefix="case_b", arc_prefix="wrap"
+    )
+    assert Path(uri_no_prefix).name != Path(uri_with_prefix).name
+
+
+def test_arc_prefix_wraps_entries(builder: AppBuilder, pkg: Path) -> None:
+    uri = builder._write_pkg_to_runtime_env_dir(
+        pkg, filename_prefix="wrapped_pkg", arc_prefix="wrap"
+    )
+    entries = _zipped_entries(Path(uri[len("file://"):]))
+    for entry in entries:
+        assert entry.startswith("wrap/"), entry
+
+
+def test_build_py_modules_uris_returns_distinct_pair(
+    builder: AppBuilder, pkg: Path
+) -> None:
+    pkg_uri, bioengine_uri = builder._build_py_modules_uris(pkg)
+
+    assert pkg_uri != bioengine_uri
+    pkg_path = Path(pkg_uri[len("file://"):])
+    bio_path = Path(bioengine_uri[len("file://"):])
+    assert pkg_path.name.startswith("bioengine_pkg_")
+    assert bio_path.name.startswith("bioengine_runtime_")
+    assert pkg_path.parent == bio_path.parent
+    assert pkg_path.is_file()
+    assert bio_path.is_file()
+
+
+def test_sweep_removes_both_filename_prefixes(workdir: Path) -> None:
+    pkg_dir = workdir / "_runtime_env_packages"
+    pkg_dir.mkdir(parents=True)
+    orphan_pkg = pkg_dir / "bioengine_pkg_aaaaaaaaaaaaaaaa.zip.tmp.111"
+    orphan_pkg.write_bytes(b"partial")
+    orphan_runtime = (
+        pkg_dir / "bioengine_runtime_bbbbbbbbbbbbbbbb.zip.tmp.222"
+    )
+    orphan_runtime.write_bytes(b"partial")
+
+    AppBuilder(apps_workdir=workdir)
+
+    assert not orphan_pkg.exists()
+    assert not orphan_runtime.exists()


### PR DESCRIPTION
## Problem

After PR #107 (0.11.5) made the head pod's client server able to unpickle `bioengine._app`, the `deploy_app('demo-app')` fire on the deNBI staging worker reached the next gate and failed with:

```
ray::introspect_app() (pid=…, ip=…)
RuntimeError: The remote function failed to import on the worker. …
  File ".../ray/_private/function_manager.py", line 308, in fetch_and_register_remote_function
    function = pickle.loads(serialized_function)
ModuleNotFoundError: No module named 'bioengine'
```

`sys.path` on the Ray actor at the moment of failure confirmed both runtime_env pathways had landed cleanly:

* the `file://` py_modules zip from Fix #2 was extracted to `runtime_resources/py_modules_files/file__…_bioengine_pkg_<hash>/`;
* a fresh pip venv from `runtime_env.pip` was provisioned at `runtime_resources/pip/<hash>/virtualenv/lib/python3.11/site-packages`.

Neither carried `bioengine` itself, though. The py_modules zip held the user app source (`deployment.py` for demo-app). The pip venv held bioengine's *dependencies* (`hypha-rpc`, `pydantic`, `httpx`, …) because `update_requirements(select=['httpx','hypha-rpc','pydantic'], extras=['worker'])` filters by dep name and bioengine isn't on PyPI to begin with.

Local single-machine mode masks this because the worker process **is** the Ray actor process — bioengine sits on the local `sys.path` from the worker's own install. External-cluster mode has no such shortcut: the actor is a separate Python process on a different pod, with only what `runtime_env` provides.

## Solution

Ship the worker's own installed `bioengine` source as a second `py_modules` URI on every runtime_env we hand to Ray. Same content-addressed `file://` zip pattern Fix #2 introduced — written to

```
<apps_workdir>/_runtime_env_packages/bioengine_runtime_<sha256[:16]>.zip
```

and served over whatever filesystem backs `apps_workdir`. On deNBI staging that's the same Manila NFS export every Ray cluster pod mounts; on single-machine mode that's the worker's own disk; both work without any conditional code.

### How it lays out

The bioengine source comes from `Path(bioengine.__file__).parent` (the worker's local install). The walk is content-hashed identically to user app zips, except every entry is prefixed with `bioengine/` so the extracted directory has

```
extracted_dir/
  bioengine/
    __init__.py
    _app/__init__.py
    apps/builder.py
    …
```

Ray's runtime_env machinery puts `extracted_dir` directly on `sys.path`, so `import bioengine` then resolves to the file lookup the actor needs to unpickle `introspect_app` and run any subsequent task body.

### Why not pip-install

Sanity-checked alternatives before committing to the file:// pattern:

* `pip install bioengine[worker]` — bioengine isn't on PyPI (TestPyPI only).
* `pip install git+https://github.com/aicell-lab/bioengine@<sha>` — ties cold-start to GitHub reachability *and* a maintained tag/SHA per release.
* `runtime_env.pip = ["./local-path"]` — re-resolves and re-installs per actor cold start; py_modules zip cache is faster and more deterministic.
* Bake bioengine into the ray-ml head/worker docker image — breaks the "bioengine version comes from the worker image, not the cluster image" boundary we've been holding.

The file:// pattern fits the existing infrastructure and is already proven in deNBI staging.

### Invariants

* **Content-addressed:** same bioengine source bytes → same SHA-256 → same `bioengine_runtime_<hash>.zip`; written exactly once per worker process per bioengine version.
* **Filename prefix is distinct** from user app zips (`bioengine_runtime_*` vs `bioengine_pkg_*`) so the two kinds are trivially distinguishable in NFS dir listings during debugging.
* **`_PY_MODULES_EXCLUDES` now drops `*.pyc`, `*.pyo`, `*.so`** so the bioengine content hash doesn't drift every time CPython regenerates bytecode for the worker's local install.
* **Atomic publish + orphan sweep** apply to both filename prefixes.
* **Replica side too:** `bioengine._app.bootstrap.build_and_run_application` injects both URIs into every deployment's `runtime_env.py_modules`. Without this, deployments whose `pip=` forced a fresh venv would crash with the same `ModuleNotFoundError` at replica boot.

## Test plan

- [x] `pytest tests/_app/ tests/apps/test_builder_runtime_env_pkg.py` — 69 / 69 passing.
  - 25 prior file:// packaging tests still green after the `arc_prefix` + `filename_prefix` refactor.
  - 7 new tests cover the bioengine source bundling:
    - distinct filename prefix
    - entries all live under `bioengine/`
    - excludes drop `__pycache__`, `*.pyc`, `*.pyo`, `*.so`
    - `arc_prefix` is included in the content hash
    - `arc_prefix` wraps every entry
    - `_build_py_modules_uris` returns two distinct paths
    - orphan sweep cleans both filename prefixes
- [ ] Re-deploy `apps/demo-app` on the deNBI 0.11.6 staging worker. Expected: introspection task completes and replicas boot.
- [ ] Re-deploy `apps/composition-demo` (multi-deployment composition).

## File-level summary

| File | Change |
|---|---|
| `bioengine/apps/builder.py` | New `_write_bioengine_source_to_runtime_env_dir()` and `_build_py_modules_uris()` helpers. `_write_pkg_to_runtime_env_dir` takes `filename_prefix` + `arc_prefix` kwargs (both included in the content hash). `_PY_MODULES_EXCLUDES` adds `*.pyc`, `*.pyo`, `*.so`. `_sweep_runtime_env_tmp_files` collects both prefixes. `_build_introspect_runtime_env` + `BuiltApp` carry both URIs. `build()` issues a single `asyncio.to_thread` for both zip writes under the existing 120 s `wait_for`. |
| `bioengine/_app/bootstrap.py` | `build_and_run_application` accepts `bioengine_uri` and injects both URIs into every deployment's `runtime_env.py_modules`. |
| `tests/apps/test_builder_runtime_env_pkg.py` | Added 7 tests for the bioengine source bundling + `arc_prefix` semantics + orphan sweep coverage for both filename prefixes. |
| `pyproject.toml` | Bumped to `0.11.6`. |
