### PR TITLE
fix(apps): wrap bioengine source in a throwaway dir so Ray's strip preserves the package

### DIFF
--- a/bioengine/apps/builder.py
+++ b/bioengine/apps/builder.py
@@ -509,11 +509,20 @@ class AppBuilder:
         defined under ``bioengine._app`` fails immediately with
         ``ModuleNotFoundError: No module named 'bioengine'``.
 
-        The fix is to ship the worker's own bioengine source as a
-        second ``py_modules`` URI on every runtime_env we hand to Ray.
-        Same content-addressed zip pattern as the user app — written
-        once per worker process, cached by content hash, served over
-        the shared NFS mount that backs ``apps_workdir``.
+        Why the ``_bioengine_wrap/`` prefix: Ray 2.55.1 calls
+        ``unzip_package(remove_top_level_directory=True)`` when the URI
+        protocol is ``file://`` (and every other "remote" scheme); a zip
+        whose entries all live under a single top-level directory has
+        that directory stripped on extraction. If we zipped entries as
+        ``bioengine/__init__.py`` directly, Ray would strip ``bioengine/``
+        and place ``__init__.py`` at the extract dir's root — and
+        ``import bioengine`` would fail. By zipping under
+        ``_bioengine_wrap/bioengine/`` we give Ray a throwaway top-level
+        directory to strip, leaving ``bioengine/__init__.py`` at the
+        extract dir's root, which is what gets added to ``sys.path``.
+        ``gcs://`` URIs do the opposite (no strip) but we cannot use
+        ``gcs://`` here — see PR #106 for the Ray-client wedge that
+        forced the move to ``file://``.
         """
         import bioengine
 
@@ -521,7 +530,7 @@ class AppBuilder:
         return self._write_pkg_to_runtime_env_dir(
             bioengine_dir,
             filename_prefix="bioengine_runtime",
-            arc_prefix="bioengine",
+            arc_prefix="_bioengine_wrap/bioengine",
         )
 
     # ───────────────────────── kwargs translation ────────────────────────

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.11.6"
+version = "0.11.7"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [

--- a/tests/apps/test_builder_runtime_env_pkg.py
+++ b/tests/apps/test_builder_runtime_env_pkg.py
@@ -232,18 +232,93 @@ def test_bioengine_source_zip_has_distinct_filename_prefix(
     assert name.endswith(".zip")
 
 
-def test_bioengine_source_zip_entries_are_prefixed_with_package_name(
+def test_bioengine_source_zip_has_throwaway_wrapper_dir(
     builder: AppBuilder,
 ) -> None:
+    """Ray strips the top-level directory from file:// py_modules zips when
+    every entry shares one. We give it a throwaway ``_bioengine_wrap/`` to
+    strip so the actual ``bioengine/`` package directory survives extraction.
+
+    All entries must therefore live under ``_bioengine_wrap/bioengine/``."""
     uri = builder._write_bioengine_source_to_runtime_env_dir()
     entries = _zipped_entries(Path(uri[len("file://"):]))
 
-    assert "bioengine/__init__.py" in entries
-    assert any(e.startswith("bioengine/_app/") for e in entries)
-    assert any(e.startswith("bioengine/apps/") for e in entries)
-
+    assert entries, "expected at least one entry"
     for entry in entries:
-        assert entry.startswith("bioengine/"), entry
+        assert entry.startswith("_bioengine_wrap/bioengine/"), entry
+
+    assert "_bioengine_wrap/bioengine/__init__.py" in entries
+    assert any(
+        e.startswith("_bioengine_wrap/bioengine/_app/") for e in entries
+    )
+    assert any(
+        e.startswith("_bioengine_wrap/bioengine/apps/") for e in entries
+    )
+
+
+def test_bioengine_source_zip_imports_after_simulated_ray_strip(
+    builder: AppBuilder, tmp_path: Path
+) -> None:
+    """End-to-end simulation of Ray's extraction path for the bioengine zip.
+
+    Reproduces ``download_and_unpack_package`` for a ``file://`` URI:
+    Ray's ``unzip_package(remove_top_level_directory=True)`` strips a
+    single top-level directory if one exists. After that step, adding
+    the extract dir to ``sys.path`` must let ``import bioengine`` resolve
+    to a file inside the extracted layout. This is the invariant Fix #4
+    +#5 exists to maintain.
+    """
+    import subprocess
+    import sys
+    import zipfile
+
+    uri = builder._write_bioengine_source_to_runtime_env_dir()
+    zip_path = Path(uri[len("file://"):])
+
+    extract_dir = tmp_path / "ray_extract"
+    extract_dir.mkdir()
+
+    with zipfile.ZipFile(zip_path) as zf:
+        names = zf.namelist()
+        top_components = {n.split("/", 1)[0] for n in names if n}
+        assert len(top_components) == 1, (
+            f"expected a single top-level dir for Ray to strip, got "
+            f"{top_components}"
+        )
+        top = next(iter(top_components))
+        for name in names:
+            if name.endswith("/"):
+                continue
+            stripped = name[len(top) + 1:]
+            target = extract_dir / stripped
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(zf.read(name))
+
+    assert (extract_dir / "bioengine" / "__init__.py").is_file()
+    assert (extract_dir / "bioengine" / "_app" / "__init__.py").is_file()
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys; "
+                f"sys.path.insert(0, {str(extract_dir)!r}); "
+                "import bioengine; "
+                "print(bioengine.__file__)"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin"},
+    )
+    assert proc.returncode == 0, (
+        f"import bioengine after simulated Ray strip failed:\n"
+        f"stdout: {proc.stdout}\nstderr: {proc.stderr}"
+    )
+    assert str(extract_dir / "bioengine") in proc.stdout, (
+        f"resolved bioengine elsewhere: stdout={proc.stdout!r}"
+    )
 
 
 def test_bioengine_source_zip_excludes_pycache(


### PR DESCRIPTION
## Problem

The 0.11.6 staging fire still failed with `ModuleNotFoundError: No module named 'bioengine'` inside the `introspect_app` Ray task, even though PR #108's `bioengine_runtime_<hash>.zip` was visible on the actor's `sys.path` and matched the file the worker had written.

Ray 2.55.1's `download_and_unpack_package` dispatches differently by URI protocol:

```python
# .../runtime_env/packaging.py
if is_zip_uri(pkg_uri):                          # gcs://
    unzip_package(..., remove_top_level_directory=False, ...)
elif protocol in Protocol.remote_protocols():    # file://, https://, s3://, ...
    if pkg_file.suffix in [".zip", ".jar"]:
        unzip_package(..., remove_top_level_directory=True, ...)
```

`unzip_package`'s docstring: *"If `remove_top_level_directory` is `True` and the top level consists of a single directory (...), the function will automatically remove the top-level directory and store the contents directly in `target_dir`."*

PR #108 zipped every bioengine entry under one single top-level directory (`bioengine/`). On a `file://` URI Ray treated that as the strippable wrapper and unpacked the contents directly into the extract dir, leaving `__init__.py`, `_app/`, `apps/`, … at the extract root and no `bioengine/` subdirectory at all. Adding the extract dir to `sys.path` then did nothing useful — `import bioengine` failed.

Verified on the deNBI staging worker:

```
$ kubectl exec ... -- ls /tmp/ray/session_latest/runtime_resources/py_modules_files/file__…_bioengine_runtime_dc5a8db5ce7e7e81/
__init__.py        ← was bioengine/__init__.py — Ray stripped 'bioengine/'
_app/
apps/
cli/
…
```

User app zips don't trip this. demo-app has a single bare `deployment.py` at root (no single top-level directory, strip is a no-op). composition-demo has `entry.py`, `utils.py`, `runtimes/` all at root (multiple top-level entries, strip is a no-op). Only the bioengine source bundle was affected because its contents *must* extract under a named subdirectory that the consumer imports by name.

## Solution

One throwaway wrapper. The bioengine source zip now writes entries under `_bioengine_wrap/bioengine/…` instead of `bioengine/…`. Ray treats `_bioengine_wrap/` as the strippable top-level directory and unpacks the contents one level shallower — leaving the real `bioengine/` package at the extract root, where `sys.path` resolves it as a package.

The change is a single string in `_write_bioengine_source_to_runtime_env_dir`:

```python
return self._write_pkg_to_runtime_env_dir(
    bioengine_dir,
    filename_prefix="bioengine_runtime",
    arc_prefix="_bioengine_wrap/bioengine",   # was "bioengine"
)
```

Documented inline so the next reader knows why the extra prefix exists — it is invisible at the consumer side after Ray strips it, but absolutely required to keep the package directory intact through that strip.

## Why this stayed hidden until 0.11.6 on a real external-cluster

* PR #108 introduced `arc_prefix` and the bioengine zip, but the Ray-strip simulation wasn't in scope yet.
* My earlier Ray smoke test (during the PR #106 planning) used a single bare `smoke_mod.py` zip entry — no top-level directory to strip, so the same code path that broke `bioengine/` didn't surface. The smoke test ran `ray.init` locally, not through the ray-client bridge, but even with a client bridge the bare-file zip would have passed.
* The `gcs://` path Ray uses for its *own* internal package uploads explicitly skips the strip (`remove_top_level_directory=False`), which is why every example of `runtime_env.py_modules=["gcs://_ray_pkg_*.zip"]` in Ray documentation "just works" — those zips can ship `bioengine/` at root and Ray won't strip it. We can't use that scheme here for the reason PR #106 documents (the cluster-side `PinRuntimeEnvURI` handler hangs in external-cluster mode).

## Test plan

- [x] `pytest tests/_app/ tests/apps/test_builder_runtime_env_pkg.py` — 70 / 70 passing locally. New tests:
  - `test_bioengine_source_zip_has_throwaway_wrapper_dir` — every entry must live under `_bioengine_wrap/bioengine/…`.
  - `test_bioengine_source_zip_imports_after_simulated_ray_strip` — end-to-end: build the zip, replicate Ray's `unzip_package(remove_top_level_directory=True)` against the actual produced bytes, then spawn a clean subprocess that adds the extract dir to `sys.path` and runs `import bioengine; print(bioengine.__file__)`. The subprocess must resolve `bioengine` from the simulated extract layout. This pins the invariant: any future regression where bioengine doesn't extract to `bioengine/` at the root of the extract dir fails CI, not the next external-cluster deploy.
- [ ] Re-deploy `apps/demo-app` on the deNBI 0.11.7 staging worker. Expected: `introspect_app` succeeds, replicas boot, application registers as a Hypha service.
- [ ] Re-deploy `apps/composition-demo` (multi-deployment composition) on the same worker.

## File-level summary

| File | Change |
|---|---|
| `bioengine/apps/builder.py` | `_write_bioengine_source_to_runtime_env_dir()` now passes `arc_prefix="_bioengine_wrap/bioengine"` (was `"bioengine"`), with the inline rationale documented. |
| `tests/apps/test_builder_runtime_env_pkg.py` | Replaced the old "entries are prefixed with `bioengine/`" test with `test_bioengine_source_zip_has_throwaway_wrapper_dir`. Added `test_bioengine_source_zip_imports_after_simulated_ray_strip` — replicates Ray's strip and confirms `import bioengine` works in a clean subprocess. |
| `pyproject.toml` | Bumped to `0.11.7`. |
