### PR TITLE
fix(apps): stop re-exporting AppsManager from bioengine.apps so the actor doesn't pull haikunator

### DIFF
--- a/bioengine/apps/__init__.py
+++ b/bioengine/apps/__init__.py
@@ -1,1 +1,15 @@
-from .manager import AppsManager
+"""BioEngine application lifecycle: ``AppsManager`` (worker-side orchestrator),
+``AppBuilder`` (build a Ray Serve application from a Hypha artifact), and
+``ProxyDeployment`` (the actor that terminates the WebSocket/WebRTC client
+bridge and forwards calls to user deployments).
+
+This package's ``__init__`` deliberately re-exports nothing. The Ray actor that
+runs ``bioengine._app.bootstrap.build_and_run_application`` imports a single
+submodule (``proxy_deployment``) and must not transitively pull in
+``manager.py`` — that module imports ``haikunator`` and other worker-only
+dependencies that are not present in the actor's runtime_env, and a top-level
+re-export here would crash unpickling on every external-cluster deploy.
+
+Worker-side code that wants the manager should ``from bioengine.apps.manager
+import AppsManager`` directly.
+"""

--- a/bioengine/worker/worker.py
+++ b/bioengine/worker/worker.py
@@ -14,7 +14,7 @@ from hypha_rpc.utils.schema import schema_method
 from pydantic import Field
 
 from bioengine import __version__
-from bioengine.apps import AppsManager
+from bioengine.apps.manager import AppsManager
 from bioengine.datasets import BioEngineDatasets
 from bioengine.cluster.ray_cluster import RayCluster
 from bioengine.utils import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.11.7"
+version = "0.11.8"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [

--- a/tests/_app/test_actor_import_path.py
+++ b/tests/_app/test_actor_import_path.py
@@ -1,0 +1,93 @@
+"""Pin the invariant that ``bioengine._app.bootstrap.build_and_run_application``
+imports only modules importable in the Ray actor's environment.
+
+The actor lives in a runtime_env whose pip layer ships bioengine's *deps*
+(``hypha-rpc``, ``pydantic``, ``httpx``, …), and whose py_modules layer
+ships bioengine's source. Worker-only dependencies (``haikunator``, ``uv``,
+``aiortc``) are deliberately NOT installed there — they're worker-side
+plumbing for the BioEngineWorker that lives only on the bioengine-worker
+pod, not on the Ray actor pod.
+
+If any module the actor walks at unpickle / call time happens to do a
+top-level import of one of those worker-only deps, ``serve.run`` raises
+``ModuleNotFoundError`` and the deploy_app finishes with no deployments
+registered, which is how this regression was caught in 0.11.7.
+
+These tests use the same pattern as test_decorators_baseline_imports.py:
+intercept ``builtins.__import__`` to simulate a missing module, then drive
+the import chain the actor actually walks and assert it survives.
+"""
+from __future__ import annotations
+
+import builtins
+import importlib
+import sys
+
+
+_WORKER_ONLY_MODULES = ("haikunator",)
+
+
+def _snapshot_relevant_modules() -> dict:
+    return {
+        k: v
+        for k, v in sys.modules.items()
+        if k.startswith("bioengine")
+        or any(k == m or k.startswith(m + ".") for m in _WORKER_ONLY_MODULES)
+    }
+
+
+def _drop_relevant_modules() -> None:
+    for k in list(sys.modules):
+        if k.startswith("bioengine") or any(
+            k == m or k.startswith(m + ".") for m in _WORKER_ONLY_MODULES
+        ):
+            sys.modules.pop(k, None)
+
+
+def _patched_import(banned: tuple[str, ...]):
+    real = builtins.__import__
+
+    def fake(name, globals=None, locals=None, fromlist=(), level=0):
+        if any(name == b or name.startswith(b + ".") for b in banned):
+            raise ImportError(f"simulated missing module: {name}")
+        return real(name, globals, locals, fromlist, level)
+
+    return fake
+
+
+def test_apps_package_init_does_not_pull_haikunator() -> None:
+    """Importing ``bioengine.apps`` is the first thing Python does when a
+    submodule under it is referenced. The package ``__init__`` must not
+    transitively load ``haikunator`` (it's a worker-only dep)."""
+    saved = _snapshot_relevant_modules()
+    try:
+        _drop_relevant_modules()
+        original_import = builtins.__import__
+        builtins.__import__ = _patched_import(_WORKER_ONLY_MODULES)
+        try:
+            importlib.import_module("bioengine.apps")
+        finally:
+            builtins.__import__ = original_import
+    finally:
+        _drop_relevant_modules()
+        sys.modules.update(saved)
+
+
+def test_proxy_deployment_importable_without_haikunator() -> None:
+    """``build_and_run_application`` imports
+    ``bioengine.apps.proxy_deployment`` inside its function body, which
+    cascades through ``bioengine.apps.__init__``. Both must work in an
+    environment that has bioengine's actor-side deps but no worker-only
+    deps like haikunator."""
+    saved = _snapshot_relevant_modules()
+    try:
+        _drop_relevant_modules()
+        original_import = builtins.__import__
+        builtins.__import__ = _patched_import(_WORKER_ONLY_MODULES)
+        try:
+            importlib.import_module("bioengine.apps.proxy_deployment")
+        finally:
+            builtins.__import__ = original_import
+    finally:
+        _drop_relevant_modules()
+        sys.modules.update(saved)


### PR DESCRIPTION
## Problem

After Fixes #4 and #5 made the `introspect_app` Ray task succeed cleanly, the 0.11.7 staging fire reached the next gate. `deploy_app('demo-app')` returned the application_id in 4.1 s, but `get_app_status` immediately reported:

```
status: UNHEALTHY
message: "Application 'demo-app' is marked as deployed but not found in Ray Serve status."
deployments: {}
```

Worker stdout pinpointed it:

```
19:24:04  AppBuilder   Introspected 'demo-app' (methods: ['ascii_art', 'list_datasets', 'ping', 'reverse_text', 'set_fail_health_check'])
19:24:04  AppsManager  DEBUG  Checking resources for application 'demo-app': {'num_cpus': 1, 'num_gpus': 0, 'memory': 1073741824}
19:24:04  AppsManager  ERROR  Failed to deploy application 'demo-app' with error: No module named 'haikunator'
```

`haikunator` is a worker-side dep (used by `AppsManager.deploy_app` to mint random `application_id`s when the caller doesn't supply one). It lives in the `[worker]` pip extras of `pyproject.toml` and is installed on the BioEngineWorker pod, but is deliberately NOT in the actor's `runtime_env.pip` — `update_requirements(select=['httpx','hypha-rpc','pydantic'], extras=['worker'])` filters down to the deps the actor actually needs to run the user code.

What bridged the gap was the package `__init__`:

```python
# bioengine/apps/__init__.py
from .manager import AppsManager
```

`bioengine._app.bootstrap.build_and_run_application` calls

```python
from bioengine.apps.proxy_deployment import ProxyDeployment
```

inside its function body — the call that drives `serve.run`. Python's import machinery runs `bioengine/apps/__init__.py` before it touches `proxy_deployment.py`. The re-export of `AppsManager` from `manager.py` cascaded the whole worker-side import tree into the actor's process — including `haikunator`.

## Solution

Drop the re-export. `bioengine/apps/__init__.py` is now just a docstring. `ProxyDeployment`, `AppBuilder`, and `AppsManager` are addressed by their submodule paths:

* The Ray actor still does `from bioengine.apps.proxy_deployment import ProxyDeployment` — that import now stays scoped to the one file it names, and never visits `manager.py` or its top-level `haikunator` import.
* The only consumer of the old top-level re-export was `bioengine/worker/worker.py`, which now uses `from bioengine.apps.manager import AppsManager` directly. That code only runs on the BioEngineWorker pod, where `haikunator` is present.

## Why this is the right shape (vs. just adding haikunator to the actor's pip)

I considered adding `haikunator` to `update_requirements(select=…)`, but the underlying problem is broader: any module the actor's import path visits must be importable in the actor's env. That set is exactly `bioengine._app.*` plus the small set the actor's function bodies reach into (currently `bioengine.apps.proxy_deployment` and a couple of `bioengine.utils.*` symbols). The fix that holds across future additions is to keep `bioengine.apps.__init__` empty so unrelated submodules don't get dragged in, and let actor-side reachability stay defined by what the actor's call paths actually import. That also matches the same shape as PR #107 (Fix #3), which is what we did to `bioengine._app.decorators`.

## Test plan

- [x] `pytest tests/_app/ tests/apps/test_builder_runtime_env_pkg.py` — 72 / 72 passing locally, including two new tests:
  - `test_apps_package_init_does_not_pull_haikunator` — patches `builtins.__import__` to raise `ImportError` for `haikunator`, then asserts `import bioengine.apps` succeeds.
  - `test_proxy_deployment_importable_without_haikunator` — same harness, asserts the import chain `build_and_run_application` actually walks (`bioengine.apps.proxy_deployment`) stays clean.
- [ ] Re-deploy `apps/demo-app` on the deNBI 0.11.8 staging worker — expected: `serve.run` registers the deployments and the application reaches RUNNING.
- [ ] Re-deploy `apps/composition-demo` — exercises the same import chain through three composed deployments.

## File-level summary

| File | Change |
|---|---|
| `bioengine/apps/__init__.py` | Reduced to a docstring. Documents that the package deliberately re-exports nothing because the Ray actor's import path must not pull in `manager.py`'s worker-only deps. |
| `bioengine/worker/worker.py` | `from bioengine.apps import AppsManager` → `from bioengine.apps.manager import AppsManager`. |
| `tests/_app/test_actor_import_path.py` | New regression suite pinning the invariant that `bioengine.apps` and `bioengine.apps.proxy_deployment` import cleanly when `haikunator` is unavailable. |
| `pyproject.toml` | Bumped to `0.11.8`. |
