### PR TITLE
fix(apps): assemble ProxyDeployment runtime_env on the worker, not at actor import time

### DIFF
--- a/bioengine/_app/bootstrap.py
+++ b/bioengine/_app/bootstrap.py
@@ -310,6 +310,7 @@ def build_and_run_application(
     route_prefix: str,
     pkg_uri: str,
     bioengine_uri: str,
+    proxy_pip: List[str],
     proxy_memory_in_gb: float,
 ) -> Dict[str, Any]:
     """Assemble the Ray Serve bind graph AND call ``serve.run`` in-process.
@@ -369,9 +370,22 @@ def build_and_run_application(
     # The default 0 reservation lets Ray place the proxy on any node,
     # including resource-tight ones (e.g. the head). A real reservation
     # biases scheduling toward nodes with headroom for the
-    # WebSocket/WebRTC payloads the proxy terminates.
+    # WebSocket/WebRTC payloads the proxy terminates. ``proxy_pip`` is
+    # computed on the worker (where bioengine has dist-info); the proxy
+    # class deliberately ships with no static ``runtime_env`` because
+    # resolving the pip list at import time crashed the actor pod —
+    # see :mod:`bioengine.apps.proxy_deployment` for the rationale.
     proxy_actor_options = dict(ProxyDeployment.ray_actor_options or {})
+    proxy_actor_options["num_cpus"] = proxy_actor_options.get("num_cpus", 0)
     proxy_actor_options["memory"] = int(proxy_memory_in_gb * (1024**3))
+    proxy_runtime_env = dict(proxy_actor_options.get("runtime_env") or {})
+    proxy_runtime_env["pip"] = proxy_pip
+    proxy_py_modules = list(proxy_runtime_env.get("py_modules") or [])
+    for uri in (bioengine_uri, pkg_uri):
+        if uri not in proxy_py_modules:
+            proxy_py_modules.append(uri)
+    proxy_runtime_env["py_modules"] = proxy_py_modules
+    proxy_actor_options["runtime_env"] = proxy_runtime_env
     proxy_cls = ProxyDeployment.options(ray_actor_options=proxy_actor_options)
 
     app = proxy_cls.bind(

--- a/bioengine/apps/builder.py
+++ b/bioengine/apps/builder.py
@@ -47,6 +47,7 @@ from bioengine._app.errors import BioEngineUserError
 from bioengine.apps.proxy_deployment import ProxyDeployment
 from bioengine.utils import (
     create_logger,
+    get_pip_requirements,
     update_requirements,
     validate_manifest,
 )
@@ -858,6 +859,19 @@ class AppBuilder:
             f"Introspected '{application_id}' "
             f"(methods: {available_methods})"
         )
+        # Compute the proxy's runtime_env.pip list here on the worker —
+        # ``get_pip_requirements`` uses ``importlib.metadata`` which only
+        # finds bioengine on a host where it was pip-installed. The Ray
+        # actor that runs ``ProxyDeployment`` only has bioengine as raw
+        # source (shipped via py_modules), so resolving the list there
+        # raises ``PackageNotFoundError``. We compute it on the worker
+        # and bootstrap.build_and_run_application applies it at bind
+        # time via ``ProxyDeployment.options(ray_actor_options=…)``.
+        proxy_pip = get_pip_requirements(
+            select=["aiortc", "httpx", "hypha-rpc", "pydantic"],
+            extras=["worker"],
+        )
+
         return BuiltApp(
             metadata=metadata,
             spec=spec,
@@ -866,6 +880,7 @@ class AppBuilder:
             runtime_env=runtime_env,
             pkg_uri=pkg_uri,
             bioengine_uri=bioengine_uri,
+            proxy_pip=proxy_pip,
             proxy_memory_in_gb=proxy_memory_in_gb,
         )
 
@@ -891,6 +906,7 @@ class AppBuilder:
                     f"/{application_id}",
                     built_app.pkg_uri,
                     built_app.bioengine_uri,
+                    built_app.proxy_pip,
                     built_app.proxy_memory_in_gb,
                 ),
             )
@@ -922,6 +938,7 @@ class BuiltApp:
         "runtime_env",
         "pkg_uri",
         "bioengine_uri",
+        "proxy_pip",
         "proxy_memory_in_gb",
     )
 
@@ -934,6 +951,7 @@ class BuiltApp:
         runtime_env: Dict[str, Any],
         pkg_uri: str,
         bioengine_uri: str,
+        proxy_pip: List[str],
         proxy_memory_in_gb: float,
     ) -> None:
         self.metadata = metadata
@@ -943,4 +961,5 @@ class BuiltApp:
         self.runtime_env = runtime_env
         self.pkg_uri = pkg_uri
         self.bioengine_uri = bioengine_uri
+        self.proxy_pip = proxy_pip
         self.proxy_memory_in_gb = proxy_memory_in_gb

--- a/bioengine/apps/proxy_deployment.py
+++ b/bioengine/apps/proxy_deployment.py
@@ -15,21 +15,22 @@ from ray.exceptions import RayTaskError
 from ray.serve import deployment, get_replica_context
 from ray.serve.handle import DeploymentHandle
 
-from bioengine.utils import get_pip_requirements
-
 logger = logging.getLogger("ray.serve")
 
 
+# ``ray_actor_options`` is intentionally minimal here. The proxy needs a
+# ``runtime_env.pip`` list (aiortc, httpx, hypha-rpc, pydantic + their pins
+# from ``[worker]``), but computing it requires ``importlib.metadata`` to
+# find bioengine's dist-info — which exists on the worker pod but NOT on
+# the Ray actor pod, where bioengine ships as raw source via
+# ``runtime_env.py_modules``. Evaluating that call at module import time
+# crashed the actor with ``PackageNotFoundError: No package metadata was
+# found for bioengine``. The full options dict (CPUs, memory reservation,
+# runtime_env.pip, runtime_env.py_modules) is assembled on the worker in
+# :func:`bioengine._app.bootstrap.build_and_run_application` and applied
+# via ``ProxyDeployment.options(ray_actor_options=…)`` at bind time, so
+# this module stays importable in any environment.
 @deployment(
-    ray_actor_options={
-        "num_cpus": 0,
-        "runtime_env": {
-            "pip": get_pip_requirements(
-                select=["aiortc", "httpx", "hypha-rpc", "pydantic"],
-                extras=["worker"],
-            ),
-        },
-    },
     # Fixed at one replica. ProxyDeployment is a 0-CPU Hypha bridge — actual
     # compute scaling lives in the inner deployments. Concurrency is bounded
     # by the in-actor semaphore sized by the per-app max_ongoing_requests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.11.8"
+version = "0.11.9"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [

--- a/tests/_app/test_actor_import_path.py
+++ b/tests/_app/test_actor_import_path.py
@@ -91,3 +91,34 @@ def test_proxy_deployment_importable_without_haikunator() -> None:
     finally:
         _drop_relevant_modules()
         sys.modules.update(saved)
+
+
+def test_proxy_deployment_importable_without_bioengine_dist_info() -> None:
+    """On the Ray actor, bioengine ships as raw source via
+    ``runtime_env.py_modules`` — no ``.dist-info`` directory exists, so
+    ``importlib.metadata.metadata('bioengine')`` raises
+    ``PackageNotFoundError``. The proxy_deployment module must NOT
+    invoke that call at import time; the proxy's ``runtime_env.pip`` is
+    assembled by the worker side and applied at bind time by
+    ``bioengine._app.bootstrap.build_and_run_application``.
+    """
+    import importlib.metadata as md
+
+    real_metadata = md.metadata
+
+    def fake_metadata(name: str):
+        if name == "bioengine":
+            raise md.PackageNotFoundError(name)
+        return real_metadata(name)
+
+    saved = _snapshot_relevant_modules()
+    try:
+        _drop_relevant_modules()
+        md.metadata = fake_metadata  # type: ignore[assignment]
+        try:
+            importlib.import_module("bioengine.apps.proxy_deployment")
+        finally:
+            md.metadata = real_metadata  # type: ignore[assignment]
+    finally:
+        _drop_relevant_modules()
+        sys.modules.update(saved)


### PR DESCRIPTION
## Problem

After Fix #6 (PR #110) cleared the `haikunator` cascade, the 0.11.8 staging fire surfaced one more layer underneath. `introspect_app` succeeded but `build_and_run_application` raised on the Ray actor at module-import time:

```
19:42:18  AppBuilder   Introspected 'demo-app' (methods: [...])
19:42:18  AppsManager  ERROR  Failed to deploy application 'demo-app' with error:
                              No package metadata was found for bioengine
19:42:18  AppsManager  WARNING  Application 'demo-app' is marked as deployed
                                but not found in Ray Serve status.
```

`bioengine/apps/proxy_deployment.py` used to declare:

```python
@deployment(
    ray_actor_options={
        "num_cpus": 0,
        "runtime_env": {
            "pip": get_pip_requirements(
                select=["aiortc", "httpx", "hypha-rpc", "pydantic"],
                extras=["worker"],
            ),
        },
    },
    ...
)
class ProxyDeployment: ...
```

`get_pip_requirements` reads bioengine's dependency block out of its dist-info via `importlib.metadata.metadata("bioengine")`. On the BioEngineWorker pod that resolves cleanly because bioengine is pip-installed there. On the Ray actor pod it does not — bioengine arrives as raw source via `runtime_env.py_modules` (Fixes #4 / #5) and there is no `bioengine-*.dist-info` directory on the actor's `sys.path`. The decorator runs the moment `build_and_run_application`'s function body does `from bioengine.apps.proxy_deployment import ProxyDeployment`, and the metadata call raises `PackageNotFoundError` before the deployment graph is even built.

## Solution

Move the pip resolution to the worker, where bioengine is pip-installed. `proxy_deployment.py` now ships with a minimal `@deployment(num_replicas=1, max_ongoing_requests=10, …)` and no static `ray_actor_options` — importable in any environment that has `ray.serve`, including the Ray actor's pre-runtime_env env.

The full `ray_actor_options` (CPUs, memory reservation, `runtime_env.pip`, `runtime_env.py_modules` for bioengine source + user app source) is assembled where it can be: on the worker, where `AppBuilder.build` calls `get_pip_requirements` itself, stores the list on the `BuiltApp`, and `bioengine._app.bootstrap.build_and_run_application` applies it via `ProxyDeployment.options(ray_actor_options=…)` at bind time. The bind-time options dict subsumes both the per-replica memory reservation (already done since 0.11.1) and the now-explicit proxy pip + py_modules list.

This generalises the pattern Fix #6 used for `AppsManager`: keep the modules the actor imports free of *any* call that depends on resources only the worker has.

## Test plan

- [x] `pytest tests/_app/ tests/apps/test_builder_runtime_env_pkg.py` — 73 / 73 passing locally, including a new test that monkey-patches `importlib.metadata.metadata("bioengine")` to raise `PackageNotFoundError` and asserts `import bioengine.apps.proxy_deployment` still succeeds.
- [ ] Re-deploy `apps/demo-app` on the deNBI 0.11.9 staging worker — expected: `serve.run` succeeds, the application registers as a Hypha service, status reaches RUNNING.
- [ ] Re-deploy `apps/composition-demo` (multi-deployment composition) on the same worker — exercises the same import + bind path through three composed deployments.

## File-level summary

| File | Change |
|---|---|
| `bioengine/apps/proxy_deployment.py` | Removed the static `ray_actor_options` from the `@deployment` decorator. Top-of-class comment documents why the options dict is now assembled on the worker. Dropped the (now unused) import of `get_pip_requirements`. |
| `bioengine/apps/builder.py` | `AppBuilder.build` calls `get_pip_requirements(select=["aiortc", "httpx", "hypha-rpc", "pydantic"], extras=["worker"])` itself and stores the list on the returned `BuiltApp` as `proxy_pip`. `submit` passes it to `build_and_run_application`. |
| `bioengine/_app/bootstrap.py` | `build_and_run_application` now takes `proxy_pip`. At bind time it assembles `proxy_actor_options` with `num_cpus`, the existing `memory` reservation, the new `runtime_env.pip = proxy_pip`, and `runtime_env.py_modules = [bioengine_uri, pkg_uri]` (so the proxy actor's venv sees bioengine source). |
| `tests/_app/test_actor_import_path.py` | Added `test_proxy_deployment_importable_without_bioengine_dist_info` — patches `importlib.metadata.metadata` to raise for bioengine and asserts the module still imports cleanly. |
| `pyproject.toml` | Bumped to `0.11.9`. |
