### PR TITLE
fix(_app): inject framework pip deps into every user-replica runtime_env at bind time

### DIFF
--- a/bioengine/_app/bootstrap.py
+++ b/bioengine/_app/bootstrap.py
@@ -302,6 +302,36 @@ def _safe_default(default: Any) -> Any:
 # ───────────────────────── application builder ───────────────────────────
 
 
+_REQ_NAME_SPLIT = ("==", ">=", "<=", "~=", ">", "<", "[")
+
+
+def _requirement_name(req: str) -> str:
+    """Extract the package name from a pip requirement string.
+
+    ``pandas==2.2.0`` → ``pandas``; ``hypha-rpc>=0.21`` → ``hypha-rpc``;
+    ``httpx[http2]==0.28.1`` → ``httpx``.
+    """
+    out = req.strip()
+    for sep in _REQ_NAME_SPLIT:
+        if sep in out:
+            out = out.split(sep, 1)[0]
+    return out.strip().lower()
+
+
+def _merge_pip_lists(base: List[str], to_add: List[str]) -> List[str]:
+    """Append entries from ``to_add`` to ``base`` unless an entry with the
+    same package name already exists. User-declared entries (in ``base``)
+    win on name collision so the framework never silently rewrites a
+    pinned version the user set."""
+    existing_names = {_requirement_name(r) for r in base}
+    merged = list(base)
+    for req in to_add:
+        if _requirement_name(req) not in existing_names:
+            merged.append(req)
+            existing_names.add(_requirement_name(req))
+    return merged
+
+
 def build_and_run_application(
     spec: Dict[str, Any],
     application_kwargs: Dict[str, Dict[str, Any]],
@@ -311,6 +341,7 @@ def build_and_run_application(
     pkg_uri: str,
     bioengine_uri: str,
     proxy_pip: List[str],
+    user_replica_framework_pip: List[str],
     proxy_memory_in_gb: float,
 ) -> Dict[str, Any]:
     """Assemble the Ray Serve bind graph AND call ``serve.run`` in-process.
@@ -349,6 +380,16 @@ def build_and_run_application(
             if uri not in py_modules:
                 py_modules.append(uri)
         runtime_env["py_modules"] = py_modules
+        # Merge the framework-required pip deps (hypha-rpc, pydantic)
+        # into whatever the user declared via ``@bioengine.app(pip=…)``.
+        # The replica needs them at cloudpickle.loads time to resolve
+        # references that the ``@bioengine.method`` wrapping created
+        # via ``hypha_rpc.utils.schema.schema_method``. User-declared
+        # entries take precedence on package name.
+        runtime_env["pip"] = _merge_pip_lists(
+            list(runtime_env.get("pip") or []),
+            user_replica_framework_pip,
+        )
         opts["runtime_env"] = runtime_env
         return cls.options(ray_actor_options=opts)
 

--- a/bioengine/apps/builder.py
+++ b/bioengine/apps/builder.py
@@ -859,17 +859,31 @@ class AppBuilder:
             f"Introspected '{application_id}' "
             f"(methods: {available_methods})"
         )
-        # Compute the proxy's runtime_env.pip list here on the worker —
+        # Compute the proxy + user-replica pip lists here on the worker.
         # ``get_pip_requirements`` uses ``importlib.metadata`` which only
-        # finds bioengine on a host where it was pip-installed. The Ray
-        # actor that runs ``ProxyDeployment`` only has bioengine as raw
-        # source (shipped via py_modules), so resolving the list there
-        # raises ``PackageNotFoundError``. We compute it on the worker
-        # and bootstrap.build_and_run_application applies it at bind
-        # time via ``ProxyDeployment.options(ray_actor_options=…)``.
+        # finds bioengine on a host where it was pip-installed; on the
+        # Ray actor bioengine arrives as raw source via ``py_modules``,
+        # so ``importlib.metadata`` raises. The lists are passed through
+        # ``BuiltApp`` to bootstrap, where they are applied at bind time.
         proxy_pip = get_pip_requirements(
             select=["aiortc", "httpx", "hypha-rpc", "pydantic"],
             extras=["worker"],
+        )
+        # User deployments' ``runtime_env.pip`` only contains what the
+        # author declared via ``@bioengine.app(pip=…)``. But ``@bioengine
+        # .method`` wraps each method with ``hypha_rpc.utils.schema
+        # .schema_method``, and that wrapping creates a cloudpickle
+        # reference into ``hypha_rpc``. When Ray Serve cold-starts a
+        # replica it ``cloudpickle.loads`` the deployment definition,
+        # which re-imports any module the references point at —
+        # so without ``hypha-rpc`` (and the ``pydantic`` it pulls in
+        # via ``schema_method``) on the replica's venv, the replica
+        # crashes at ``__init__`` with ``ModuleNotFoundError: No module
+        # named 'hypha_rpc'``. Same story as Fix #7, just one layer
+        # deeper. Inject both at bind time.
+        user_replica_framework_pip = get_pip_requirements(
+            select=["hypha-rpc", "pydantic"],
+            extras=[],
         )
 
         return BuiltApp(
@@ -881,6 +895,7 @@ class AppBuilder:
             pkg_uri=pkg_uri,
             bioengine_uri=bioengine_uri,
             proxy_pip=proxy_pip,
+            user_replica_framework_pip=user_replica_framework_pip,
             proxy_memory_in_gb=proxy_memory_in_gb,
         )
 
@@ -907,6 +922,7 @@ class AppBuilder:
                     built_app.pkg_uri,
                     built_app.bioengine_uri,
                     built_app.proxy_pip,
+                    built_app.user_replica_framework_pip,
                     built_app.proxy_memory_in_gb,
                 ),
             )
@@ -939,6 +955,7 @@ class BuiltApp:
         "pkg_uri",
         "bioengine_uri",
         "proxy_pip",
+        "user_replica_framework_pip",
         "proxy_memory_in_gb",
     )
 
@@ -952,6 +969,7 @@ class BuiltApp:
         pkg_uri: str,
         bioengine_uri: str,
         proxy_pip: List[str],
+        user_replica_framework_pip: List[str],
         proxy_memory_in_gb: float,
     ) -> None:
         self.metadata = metadata
@@ -962,4 +980,5 @@ class BuiltApp:
         self.pkg_uri = pkg_uri
         self.bioengine_uri = bioengine_uri
         self.proxy_pip = proxy_pip
+        self.user_replica_framework_pip = user_replica_framework_pip
         self.proxy_memory_in_gb = proxy_memory_in_gb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.11.9"
+version = "0.11.10"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [

--- a/tests/_app/test_pip_merge.py
+++ b/tests/_app/test_pip_merge.py
@@ -1,0 +1,108 @@
+"""Unit tests for the runtime_env pip-list merge in
+:func:`bioengine._app.bootstrap._merge_pip_lists`.
+
+The merge runs at bind time inside ``build_and_run_application`` and is
+how the framework's required deps (``hypha-rpc``, ``pydantic``) make it
+onto every user replica's venv alongside whatever the user declared via
+``@bioengine.app(pip=…)``. Two invariants matter:
+
+* A framework dep is added if it's not already present.
+* A user-declared entry on the same package name is preserved verbatim,
+  including any version pin or extra spec — the framework never
+  silently overrides what the user set.
+"""
+from __future__ import annotations
+
+import pytest
+
+from bioengine._app.bootstrap import _merge_pip_lists, _requirement_name
+
+
+@pytest.mark.parametrize(
+    "req,expected",
+    [
+        ("hypha-rpc", "hypha-rpc"),
+        ("hypha-rpc==0.21.40", "hypha-rpc"),
+        ("hypha-rpc>=0.21.40", "hypha-rpc"),
+        ("hypha-rpc<=1.0.0", "hypha-rpc"),
+        ("hypha-rpc~=0.21.0", "hypha-rpc"),
+        ("hypha-rpc>0.21", "hypha-rpc"),
+        ("hypha-rpc<2", "hypha-rpc"),
+        ("httpx[http2]==0.28.1", "httpx"),
+        ("Pandas==2.2.0", "pandas"),
+        ("  spaces==1.0  ", "spaces"),
+    ],
+)
+def test_requirement_name_extracts_package(req: str, expected: str) -> None:
+    assert _requirement_name(req) == expected
+
+
+def test_appends_missing_framework_deps() -> None:
+    merged = _merge_pip_lists(
+        ["pandas==2.2.0"],
+        ["hypha-rpc==0.21.40", "pydantic==2.12.0"],
+    )
+    assert merged == [
+        "pandas==2.2.0",
+        "hypha-rpc==0.21.40",
+        "pydantic==2.12.0",
+    ]
+
+
+def test_user_pin_wins_over_framework_pin() -> None:
+    merged = _merge_pip_lists(
+        ["hypha-rpc==0.20.0", "pandas==2.2.0"],
+        ["hypha-rpc==0.21.40", "pydantic==2.12.0"],
+    )
+    assert merged == [
+        "hypha-rpc==0.20.0",
+        "pandas==2.2.0",
+        "pydantic==2.12.0",
+    ]
+
+
+def test_user_unpinned_wins_over_framework_pin() -> None:
+    merged = _merge_pip_lists(
+        ["pydantic"],
+        ["pydantic==2.12.0"],
+    )
+    assert merged == ["pydantic"]
+
+
+def test_user_extras_preserved() -> None:
+    merged = _merge_pip_lists(
+        ["httpx[http2]==0.28.1"],
+        ["httpx==0.28.1"],
+    )
+    assert merged == ["httpx[http2]==0.28.1"]
+
+
+def test_empty_base_returns_framework_list() -> None:
+    merged = _merge_pip_lists(
+        [],
+        ["hypha-rpc==0.21.40", "pydantic==2.12.0"],
+    )
+    assert merged == ["hypha-rpc==0.21.40", "pydantic==2.12.0"]
+
+
+def test_empty_framework_returns_base() -> None:
+    merged = _merge_pip_lists(["pandas==2.2.0"], [])
+    assert merged == ["pandas==2.2.0"]
+
+
+def test_idempotent_when_framework_already_in_base() -> None:
+    merged = _merge_pip_lists(
+        ["hypha-rpc==0.21.40", "pydantic==2.12.0"],
+        ["hypha-rpc==0.21.40", "pydantic==2.12.0"],
+    )
+    assert merged == ["hypha-rpc==0.21.40", "pydantic==2.12.0"]
+
+
+def test_case_insensitive_name_match() -> None:
+    """PEP 503-style name normalization is conservative; we lowercase to
+    avoid duplicate-but-different-cased entries on the replica."""
+    merged = _merge_pip_lists(
+        ["Pydantic==2.12.0"],
+        ["pydantic==2.10.0"],
+    )
+    assert merged == ["Pydantic==2.12.0"]


### PR DESCRIPTION
## Problem

After Fix #7 (PR #111) cleared the proxy's import-time pip resolution, the 0.11.9 staging fire actually reached Ray Serve. ProxyDeployment went UPDATING. Then DemoApp crashed three times in a row:

```
Starting Replica(id='vckifonj', deployment='DemoApp', app='demo-app').
Exception when allocating Replica(...):
ray.exceptions.ActorDiedError: The actor died because of an error raised in its creation task,
  ray::SERVE_REPLICA::demo-app#DemoApp#vckifonj:ServeReplica.__init__()
  File "ray/serve/_private/replica.py", line 2671, in __init__
    deployment_def = cloudpickle.loads(serialized_deployment_def)
ModuleNotFoundError: No module named 'hypha_rpc'
```

Ray Serve marked DEPLOY_FAILED after three identical failures on two different worker nodes.

`@bioengine.method` wraps every exposed user method with `hypha_rpc.utils.schema.schema_method` (the lazy-import landed in Fix #3). The wrapped object carries a cloudpickle reference into `hypha_rpc`. When Ray Serve cold-starts a replica it has to `cloudpickle.loads(serialized_deployment_def)`, which re-imports every module the references point at. The user replica's venv only contains what the author declared via `@bioengine.app(pip=…)` — for demo-app that's just `pandas`. `hypha-rpc` isn't there, so the replica crashes at `__init__` before any user code runs.

This is the same class of bug as Fix #7, one layer deeper: the framework's own decorators created a dependency that the framework never told the actor pip layer about.

## Solution

The framework owns the dependency (it's created by `@bioengine.method`), so the framework should ship it onto every user replica. Same shape as Fix #7:

* `AppBuilder.build` (worker side, where bioengine has dist-info) resolves `user_replica_framework_pip = get_pip_requirements(select=["hypha-rpc", "pydantic"], extras=[])` and stores it on the `BuiltApp`.
* `bioengine._app.bootstrap.build_and_run_application` takes the list as a new arg and merges it into `runtime_env.pip` inside the existing `_with_pkg` helper that already injects `bioengine_uri` and `pkg_uri` into `py_modules`.
* Merge is package-name-keyed with case-folding + stripping of version specifiers / extras. User-declared entries always win on collision — bioengine never silently overrides a pinned version the user set.

## Why pydantic too

`hypha_rpc.utils.schema.schema_method` builds a pydantic model under the hood for parameter validation. The cloudpickle reference chain transitively reaches into `pydantic`. Including it alongside `hypha-rpc` keeps the replica boot path from re-doing this dance one more time as Fix #9.

## Test plan

- [x] `pytest tests/_app/ tests/apps/test_builder_runtime_env_pkg.py` — 91 / 91 passing locally.
  - 9 new tests for `_merge_pip_lists` and the `_requirement_name` helper:
    - 10 parametrised name-extraction cases covering all PEP 440 operators + extras + casing
    - framework deps are added when missing
    - user version pin survives the merge against a different framework pin
    - user bare name survives the merge against a framework pin
    - user extras (`httpx[http2]`) preserved
    - empty-base / empty-framework edge cases
    - idempotent on a re-merge
    - case-insensitive name match (so `Pydantic` and `pydantic` don't both end up in the list)
- [ ] Re-deploy `apps/demo-app` on the deNBI 0.11.10 staging worker — expected: `serve.run` materialises replicas successfully and the application reaches RUNNING.
- [ ] Re-deploy `apps/composition-demo` (multi-deployment composition) on the same worker — the merge runs once per deployment in the graph.

## File-level summary

| File | Change |
|---|---|
| `bioengine/apps/builder.py` | `AppBuilder.build` resolves `user_replica_framework_pip` via `get_pip_requirements(select=["hypha-rpc", "pydantic"])`. Stored on `BuiltApp`. `submit` passes it to `build_and_run_application`. |
| `bioengine/_app/bootstrap.py` | `build_and_run_application` accepts the new list. New module-level helpers `_requirement_name` (PEP 440-aware package-name extractor) and `_merge_pip_lists` (user-pin-wins merge). The existing `_with_pkg` calls the merge into `runtime_env.pip`. |
| `tests/_app/test_pip_merge.py` | New module. 9 tests covering all merge invariants. |
| `pyproject.toml` | Bumped to `0.11.10`. |
