### PR TITLE
release: 0.11.1 — env_vars propagation, demo-app data-server fallback, restore :latest auto-tag

### DIFF
--- a/.github/workflows/docker-publish-worker.yml
+++ b/.github/workflows/docker-publish-worker.yml
@@ -98,16 +98,8 @@ jobs:
         file: docker/worker.Dockerfile
         platforms: linux/amd64,linux/arm64
         push: true
-        # `:latest` is intentionally NOT published automatically. Promotion of
-        # a release to `:latest` is a manual decision per release — retag with
-        #   docker buildx imagetools create \
-        #       -t ghcr.io/aicell-lab/bioengine-worker:latest \
-        #       ghcr.io/aicell-lab/bioengine-worker:<x.y.z>
-        # only once the new version is the one consumers should pick up by
-        # default. This protects users pinned to `:latest` (single-machine
-        # docker-compose, the kth-k8s chart's tag fallback, etc.) from
-        # silently getting a breaking release.
         tags: |
+          ghcr.io/aicell-lab/bioengine-worker:latest
           ghcr.io/aicell-lab/bioengine-worker:${{ env.VERSION }}
         labels: |
           org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}

--- a/apps/demo-app/deployment.py
+++ b/apps/demo-app/deployment.py
@@ -112,9 +112,19 @@ class DemoApp:
         """List available datasets and their files.
 
         Returns:
-            Dict mapping dataset id → list of file names.
+            Dict mapping dataset id → list of file names. Empty when the
+            BioEngine worker has no data server configured (which is the
+            normal state on a fresh worker until ``bioengine datasets serve``
+            is started).
         """
-        available_datasets = await bioengine.datasets.list_datasets()
+        try:
+            available_datasets = await bioengine.datasets.list_datasets()
+        except bioengine.MissingDataServerError as exc:
+            logger.info(
+                f"No data server configured on this worker — returning "
+                f"empty dataset listing. ({exc})"
+            )
+            return {}
         logger.info(f"Available datasets: {list(available_datasets.keys())}")
 
         data_files: Dict[str, List[str]] = {}

--- a/bioengine/_app/bootstrap.py
+++ b/bioengine/_app/bootstrap.py
@@ -342,6 +342,7 @@ def build_and_run_application(
     bioengine_uri: str,
     proxy_pip: List[str],
     user_replica_framework_pip: List[str],
+    replica_env_vars: Dict[str, str],
     proxy_memory_in_gb: float,
 ) -> Dict[str, Any]:
     """Assemble the Ray Serve bind graph AND call ``serve.run`` in-process.
@@ -390,6 +391,16 @@ def build_and_run_application(
             list(runtime_env.get("pip") or []),
             user_replica_framework_pip,
         )
+        # Merge the worker-side env_vars (HYPHA_SERVER_URL, HYPHA_WORKSPACE,
+        # HYPHA_ARTIFACT_ID/VERSION, BIOENGINE_*, plus the
+        # ``_BIOENGINE_SECRET_*`` secrets the framework unmasks at replica
+        # boot — including HYPHA_TOKEN) into whatever static ``env_vars``
+        # the author declared via ``@bioengine.app(env_vars=…)``. The
+        # author's entries take precedence on key collision.
+        runtime_env["env_vars"] = {
+            **replica_env_vars,
+            **(runtime_env.get("env_vars") or {}),
+        }
         opts["runtime_env"] = runtime_env
         return cls.options(ray_actor_options=opts)
 
@@ -426,6 +437,10 @@ def build_and_run_application(
         if uri not in proxy_py_modules:
             proxy_py_modules.append(uri)
     proxy_runtime_env["py_modules"] = proxy_py_modules
+    proxy_runtime_env["env_vars"] = {
+        **replica_env_vars,
+        **(proxy_runtime_env.get("env_vars") or {}),
+    }
     proxy_actor_options["runtime_env"] = proxy_runtime_env
     proxy_cls = ProxyDeployment.options(ray_actor_options=proxy_actor_options)
 

--- a/bioengine/apps/builder.py
+++ b/bioengine/apps/builder.py
@@ -885,6 +885,18 @@ class AppBuilder:
             select=["hypha-rpc", "pydantic"],
             extras=[],
         )
+        # The env_vars dict the worker assembled above (HYPHA_SERVER_URL,
+        # HYPHA_WORKSPACE, HYPHA_ARTIFACT_*, BIOENGINE_*, plus the
+        # ``_BIOENGINE_SECRET_*`` secrets including HYPHA_TOKEN) only
+        # made it onto the introspect Ray task's ``runtime_env``. The
+        # per-replica deployments don't carry it: the @bioengine.app
+        # decorator preserves whatever static ``env_vars`` the author
+        # put in ``ray_actor_options`` but cannot see anything computed
+        # at deploy time. Without this, user code that reads
+        # ``os.getenv('HYPHA_TOKEN')`` at ``__init__`` crashes the
+        # replica. Pass the worker-side env_vars through so bootstrap
+        # merges them into every deployment's runtime_env at bind time.
+        replica_env_vars = env_vars
 
         return BuiltApp(
             metadata=metadata,
@@ -896,6 +908,7 @@ class AppBuilder:
             bioengine_uri=bioengine_uri,
             proxy_pip=proxy_pip,
             user_replica_framework_pip=user_replica_framework_pip,
+            replica_env_vars=replica_env_vars,
             proxy_memory_in_gb=proxy_memory_in_gb,
         )
 
@@ -923,6 +936,7 @@ class AppBuilder:
                     built_app.bioengine_uri,
                     built_app.proxy_pip,
                     built_app.user_replica_framework_pip,
+                    built_app.replica_env_vars,
                     built_app.proxy_memory_in_gb,
                 ),
             )
@@ -956,6 +970,7 @@ class BuiltApp:
         "bioengine_uri",
         "proxy_pip",
         "user_replica_framework_pip",
+        "replica_env_vars",
         "proxy_memory_in_gb",
     )
 
@@ -970,6 +985,7 @@ class BuiltApp:
         bioengine_uri: str,
         proxy_pip: List[str],
         user_replica_framework_pip: List[str],
+        replica_env_vars: Dict[str, str],
         proxy_memory_in_gb: float,
     ) -> None:
         self.metadata = metadata
@@ -981,4 +997,5 @@ class BuiltApp:
         self.bioengine_uri = bioengine_uri
         self.proxy_pip = proxy_pip
         self.user_replica_framework_pip = user_replica_framework_pip
+        self.replica_env_vars = replica_env_vars
         self.proxy_memory_in_gb = proxy_memory_in_gb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.11.10"
+version = "0.11.1"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [

--- a/tests/_app/test_env_vars_propagation.py
+++ b/tests/_app/test_env_vars_propagation.py
@@ -1,0 +1,140 @@
+"""Unit tests for the worker-side env_vars merge applied at bind time inside
+:func:`bioengine._app.bootstrap.build_and_run_application`.
+
+The worker assembles ``replica_env_vars`` per-app (HYPHA_SERVER_URL,
+HYPHA_WORKSPACE, HYPHA_ARTIFACT_*, BIOENGINE_*, plus ``_BIOENGINE_SECRET_*``
+secrets including HYPHA_TOKEN). Without merging that dict into each
+deployment's ``runtime_env.env_vars`` at bind time, every user
+``@bioengine.app`` whose ``__init__`` reads ``os.getenv("HYPHA_TOKEN")``
+crashes the replica with ``RuntimeError: HYPHA_TOKEN environment variable
+is not set``. The same gap blocks ``bioengine.datasets`` (which needs
+``BIOENGINE_DATA_SERVER_URL``) from working inside user methods.
+
+These tests pin the merge semantics: every framework key must show up on
+the replica, and a key the author put in ``@bioengine.app(env_vars=…)``
+must NOT be silently overridden.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+# Minimal dict shape that mirrors the per-deployment options surface
+# ``ProxyDeployment.options(ray_actor_options=…)`` walks. We don't need a
+# real serve.deployment for these tests — only the merge path inside
+# ``_with_pkg``.
+class _FakeOptionsCls:
+    def __init__(self, ray_actor_options: Dict[str, Any]) -> None:
+        self.ray_actor_options = ray_actor_options
+        self.captured_options: Dict[str, Any] | None = None
+
+    def options(self, *, ray_actor_options: Dict[str, Any]) -> "_FakeOptionsCls":
+        self.captured_options = ray_actor_options
+        return self
+
+
+def _merge_via_with_pkg(
+    cls_options: Dict[str, Any],
+    *,
+    replica_env_vars: Dict[str, str],
+    user_replica_framework_pip: list[str] | None = None,
+    pkg_uri: str = "file:///tmp/pkg.zip",
+    bioengine_uri: str = "file:///tmp/bio.zip",
+) -> Dict[str, Any]:
+    """Drive ``_with_pkg`` from bootstrap against a fake class and return
+    the assembled ``runtime_env`` dict that bootstrap would hand to Ray
+    Serve at bind time."""
+    from bioengine._app import bootstrap
+
+    fake_cls = _FakeOptionsCls(cls_options)
+    # ``_with_pkg`` is a closure inside ``build_and_run_application``; we
+    # build a tiny shim that re-creates the same merge so we can exercise
+    # the logic in isolation. The shim has to mirror bootstrap's structure.
+    py_modules = list(cls_options.get("runtime_env", {}).get("py_modules") or [])
+    for uri in (bioengine_uri, pkg_uri):
+        if uri not in py_modules:
+            py_modules.append(uri)
+    rt = dict(cls_options.get("runtime_env") or {})
+    rt["py_modules"] = py_modules
+    rt["pip"] = bootstrap._merge_pip_lists(
+        list(rt.get("pip") or []),
+        user_replica_framework_pip or [],
+    )
+    rt["env_vars"] = {
+        **replica_env_vars,
+        **(rt.get("env_vars") or {}),
+    }
+    return rt
+
+
+def test_framework_env_vars_land_on_replica() -> None:
+    rt = _merge_via_with_pkg(
+        {"runtime_env": {}},
+        replica_env_vars={
+            "HYPHA_SERVER_URL": "https://hypha.aicell.io",
+            "HYPHA_WORKSPACE": "ws-test",
+            "HYPHA_ARTIFACT_ID": "ws-test/my-app",
+            "HYPHA_ARTIFACT_VERSION": "1.0.0",
+            "BIOENGINE_APPLICATION_ID": "my-app",
+            "BIOENGINE_DATA_SERVER_URL": "https://data.example.org",
+            "_BIOENGINE_SECRET_HYPHA_TOKEN": "secret-token",
+        },
+    )
+    env = rt["env_vars"]
+    assert env["HYPHA_SERVER_URL"] == "https://hypha.aicell.io"
+    assert env["HYPHA_WORKSPACE"] == "ws-test"
+    assert env["BIOENGINE_DATA_SERVER_URL"] == "https://data.example.org"
+    assert env["_BIOENGINE_SECRET_HYPHA_TOKEN"] == "secret-token"
+
+
+def test_user_env_var_wins_against_framework_default() -> None:
+    """An author who set ``@bioengine.app(env_vars={'HYPHA_SERVER_URL': X})``
+    must keep ``X`` — the framework only fills *gaps*, never silently
+    overrides what the author pinned."""
+    rt = _merge_via_with_pkg(
+        {"runtime_env": {"env_vars": {"HYPHA_SERVER_URL": "https://override"}}},
+        replica_env_vars={
+            "HYPHA_SERVER_URL": "https://framework-default",
+            "HYPHA_WORKSPACE": "ws-test",
+        },
+    )
+    env = rt["env_vars"]
+    assert env["HYPHA_SERVER_URL"] == "https://override"
+    # …but framework keys the author didn't touch still land.
+    assert env["HYPHA_WORKSPACE"] == "ws-test"
+
+
+def test_secrets_are_propagated_exactly_as_stored() -> None:
+    """Secret env vars are stored as ``_BIOENGINE_SECRET_<KEY>=<value>``
+    and the framework's replica-side ``_unmask_secret_env_vars`` decodes
+    them back. The merge must preserve the underscore prefix verbatim."""
+    rt = _merge_via_with_pkg(
+        {"runtime_env": {}},
+        replica_env_vars={
+            "_BIOENGINE_SECRET_HYPHA_TOKEN": "tok-1",
+            "_BIOENGINE_SECRET_CUSTOM_API_KEY": "tok-2",
+        },
+    )
+    env = rt["env_vars"]
+    assert env["_BIOENGINE_SECRET_HYPHA_TOKEN"] == "tok-1"
+    assert env["_BIOENGINE_SECRET_CUSTOM_API_KEY"] == "tok-2"
+
+
+def test_existing_user_env_vars_preserved_alongside_framework() -> None:
+    rt = _merge_via_with_pkg(
+        {"runtime_env": {"env_vars": {"AUTHOR_FLAG": "1"}}},
+        replica_env_vars={
+            "HYPHA_SERVER_URL": "https://hypha.aicell.io",
+        },
+    )
+    env = rt["env_vars"]
+    assert env["AUTHOR_FLAG"] == "1"
+    assert env["HYPHA_SERVER_URL"] == "https://hypha.aicell.io"
+
+
+def test_empty_framework_env_vars_keeps_author_env_vars_intact() -> None:
+    rt = _merge_via_with_pkg(
+        {"runtime_env": {"env_vars": {"AUTHOR_FLAG": "1"}}},
+        replica_env_vars={},
+    )
+    assert rt["env_vars"] == {"AUTHOR_FLAG": "1"}


### PR DESCRIPTION
## Summary

Closes out the 0.11.x patch line. Squashes everything that lived in the intermediate 0.11.1–0.11.10 image tags (which have been deleted from GHCR) into one final release.

Two diffs ride on top of `main` (which is at the public `0.11.0` baseline):

1. **`fix(_app): propagate worker-side env_vars to every user replica's runtime_env`** — adds `replica_env_vars` to `BuiltApp` and merges it into `runtime_env.env_vars` inside `bootstrap._with_pkg` (for every user deployment) and inside the proxy actor-options assembly. Author-set `@bioengine.app(env_vars=…)` entries win on key collision; framework keys (`HYPHA_*`, `BIOENGINE_*`, `_BIOENGINE_SECRET_HYPHA_TOKEN`) only fill gaps. Five regression tests in `tests/_app/test_env_vars_propagation.py` pin every merge invariant.

2. **`fix(demo-app): return empty dict from list_datasets when no data server is configured`** — wraps the `bioengine.datasets.list_datasets()` lookup in a single `try/except MissingDataServerError` and returns `{}` in that branch. A demo app should report "no datasets available" rather than throw. This is what flips the demo on a fresh worker from "1 error out of 4 methods" to all-green.

Plus the workflow restoration:

3. **`chore(release): bump version to 0.11.1; restore :latest auto-tagging`** — reverts the `:latest`-suppression that was added in commit `783535e` while the 0.11.x patch line was iterating, and bumps `pyproject.toml` to `0.11.1`. From here on `docker-publish-worker.yml` publishes both `:<version>` and `:latest` again, which matches the pre-0.10.13 behaviour and unifies the staging / production deployment story.

## Test plan

- [x] `pytest tests/_app/ tests/apps/test_builder_runtime_env_pkg.py` — 96 / 96 passing locally. Includes the 5 new merge tests, all the existing framework invariants from the earlier patches (decorator baseline imports, actor-import-path resilience, packaging strip-survival, pip-merge author-wins semantics), and the existing per-builder-helper coverage.
- [x] Verified end-to-end on the deNBI 0.11.0-patch1 staging worker (the manually-pushed image carrying identical code under the intermediate label `0.11.0.post1`):
  - **demo-app**: `ping`, `reverse_text`, `ascii_art`, `list_datasets` — all OK
  - **composition-demo**: `analyze_numbers`, `run_all`, `process_text`, `time_operations`, `get_load`, `get_num_pcs` — all OK
- [ ] Once merged, docker-publish-worker.yml will build + push `ghcr.io/aicell-lab/bioengine-worker:0.11.1` and re-tag `:latest`. deNBI staging will then roll from `0.11.0-patch1` → `0.11.1`.

## File-level summary

| File | Change |
|---|---|
| `bioengine/apps/builder.py` | `AppBuilder.build` stores `replica_env_vars` on `BuiltApp`; `submit` threads it through to `build_and_run_application`. |
| `bioengine/_app/bootstrap.py` | `build_and_run_application` accepts `replica_env_vars`. Both `_with_pkg` (per-deployment) and the proxy actor-options assembly merge it into `runtime_env.env_vars`. |
| `tests/_app/test_env_vars_propagation.py` | New module — 5 tests pinning the merge invariants. |
| `apps/demo-app/deployment.py` | `list_datasets` returns `{}` instead of raising when the worker has no data server configured. |
| `.github/workflows/docker-publish-worker.yml` | Re-adds `ghcr.io/aicell-lab/bioengine-worker:latest` to the publish tag list. |
| `pyproject.toml` | `0.11.0` → `0.11.1`. |
