### PR TITLE
feat(cellpose-finetuning): migrate to v0.6.0 manifest + decorator API

### DIFF
--- a/apps/cellpose-finetuning/main.py
+++ b/apps/cellpose-finetuning/main.py
@@ -4,6 +4,13 @@ This service downloads training data from a Hypha Artifact, fine-tunes a
 Cellpose model, and exposes training control and inference functions.
 """
 
+# PEP 563 — defer annotation evaluation. Helper signatures elsewhere in this
+# module reference TYPE_CHECKING-only types like AsyncHyphaArtifact and
+# CellposeModel; without this the module fails to import on the introspection
+# task. @bioengine.method-decorated entry points use only builtin annotations,
+# so pydantic still resolves their schemas correctly.
+from __future__ import annotations
+
 import os
 
 # torch._dynamo (>=2.5) calls getpass.getuser() at import; fails when USER is

--- a/apps/cellpose-finetuning/main.py
+++ b/apps/cellpose-finetuning/main.py
@@ -596,9 +596,25 @@ def to_local_path(root: Path, rel: Path) -> Path:
     return root / strip_leading_slash(rel)
 
 
+def _data_root() -> Path:
+    """Return the writable base directory for cellpose-finetuning training state.
+
+    Honours ``CELLPOSE_DATA_DIR`` so cluster operators can point sessions and
+    artifact caches at a shared NFS mount; falls back to
+    ``/tmp/bioengine/cellpose-finetuning``. We deliberately don't use
+    ``Path.home()`` — the framework sets HOME to ``apps_workdir/<app_id>/``,
+    which on shared-NFS workers may live on a mount the replica's UID cannot
+    create subdirectories on.
+    """
+    return Path(
+        os.environ.get("CELLPOSE_DATA_DIR")
+        or "/tmp/bioengine/cellpose-finetuning"
+    ).expanduser().resolve()
+
+
 def get_sessions_path() -> Path:
     """Return the path to the directory where training sessions are stored."""
-    return Path.home() / "sessions"
+    return _data_root() / "sessions"
 
 
 def get_model_path(session_id: str) -> Path:
@@ -695,7 +711,7 @@ async def ensure_published_model_local_session(model_reference: str) -> str:
 def artifact_cache_dir(artifact_id: str) -> Path:
     """Return local cache dir for an artifact id, ensuring it exists."""
     safe = artifact_id.replace("/", "__")
-    d = Path.home() / "data_cache" / safe
+    d = _data_root() / "data_cache" / safe
     d.mkdir(parents=True, exist_ok=True)
     return d
 
@@ -3753,6 +3769,12 @@ def _predict_and_encode(
         "matplotlib",
         "hypha-artifact==0.1.2",
     ],
+    env_vars={
+        # Shared writable NFS path so training sessions + data caches survive
+        # replica restarts. Override per-cluster via the manifest if a
+        # different shared path is provisioned.
+        "CELLPOSE_DATA_DIR": "/home/bioengine/staging/model-cache/cellpose-finetuning",
+    },
     max_ongoing_requests=1,
     max_queued_requests=10,
     autoscaling_config={

--- a/apps/cellpose-finetuning/main.py
+++ b/apps/cellpose-finetuning/main.py
@@ -4,8 +4,6 @@ This service downloads training data from a Hypha Artifact, fine-tunes a
 Cellpose model, and exposes training control and inference functions.
 """
 
-from __future__ import annotations
-
 import os
 
 # torch._dynamo (>=2.5) calls getpass.getuser() at import; fails when USER is
@@ -30,9 +28,22 @@ from urllib.parse import urlparse
 
 import numpy as np
 import numpy.typing as npt
+import bioengine
 from hypha_rpc.utils.schema import schema_method
 from pydantic import Field
 from ray import serve
+
+
+def _bioengine_method_arbitrary(fn):
+    """@bioengine.method variant that allows arbitrary types in the pydantic schema.
+
+    Equivalent to @schema_method(arbitrary_types_allowed=True) plus the
+    `_bioengine_kind = "method"` marker that @bioengine.app reads at class
+    creation time.
+    """
+    wrapped = schema_method(arbitrary_types_allowed=True)(fn)
+    wrapped._bioengine_kind = "method"
+    return wrapped
 
 if TYPE_CHECKING:
     import torch
@@ -3723,22 +3734,18 @@ def _predict_and_encode(
 # ---------------------------------------------------------------------------
 # Ray Serve deployment
 # ---------------------------------------------------------------------------
-@serve.deployment(  # type: ignore
-    ray_actor_options={
-        "num_gpus": 1,
-        "num_cpus": 4,
-        "memory": 12 * GB,
-        "runtime_env": {
-            "pip": [
-                "cellpose==4.0.7",
-                "numpy==1.26.4",
-                "tifffile",
-                "Pillow",
-                "matplotlib",
-                "hypha-artifact==0.1.2",
-            ],
-        },
-    },
+@bioengine.app(
+    num_cpus=4,
+    num_gpus=1,
+    memory_mb=12 * 1024,
+    pip=[
+        "cellpose==4.0.7",
+        "numpy==1.26.4",
+        "tifffile",
+        "Pillow",
+        "matplotlib",
+        "hypha-artifact==0.1.2",
+    ],
     max_ongoing_requests=1,
     max_queued_requests=10,
     autoscaling_config={
@@ -3805,7 +3812,7 @@ class CellposeFinetune:
         )
         raise ValueError(msg)
 
-    @schema_method(arbitrary_types_allowed=True)  # type: ignore
+    @_bioengine_method_arbitrary
     async def start_training(
         self,
         artifact: str = Field(
@@ -4099,7 +4106,7 @@ class CellposeFinetune:
         status = get_status(session_id)
         return SessionStatusWithId(**status, session_id=session_id)
 
-    @schema_method(arbitrary_types_allowed=True)  # type: ignore
+    @_bioengine_method_arbitrary
     async def stop_training(
         self,
         session_id: str = Field(
@@ -4140,7 +4147,7 @@ class CellposeFinetune:
 
         return get_status(session_id)
 
-    @schema_method(arbitrary_types_allowed=True)  # type: ignore
+    @_bioengine_method_arbitrary
     async def debug_task_info(
         self,
         session_id: str = Field(
@@ -4170,7 +4177,7 @@ class CellposeFinetune:
 
         return info
 
-    @schema_method(arbitrary_types_allowed=True)  # type: ignore
+    @_bioengine_method_arbitrary
     async def get_training_status(
         self,
         session_id: str = Field(
@@ -4240,7 +4247,7 @@ class CellposeFinetune:
             )
         return session_data
 
-    @schema_method(arbitrary_types_allowed=True)  # type: ignore
+    @_bioengine_method_arbitrary
     async def restart_training(
         self,
         session_id: str = Field(description="Session ID to restart from"),
@@ -4434,7 +4441,7 @@ class CellposeFinetune:
 
         return sessions
 
-    @schema_method(arbitrary_types_allowed=True)  # type: ignore
+    @_bioengine_method_arbitrary
     async def list_training_sessions(
         self,
         status_types: list[str] | None = Field(
@@ -4473,7 +4480,7 @@ class CellposeFinetune:
             limit = wrapped.get("limit", limit)
         return await asyncio.to_thread(self._list_sessions_sync, status_types, limit, dataset_artifact_ids, labels)
 
-    @schema_method(arbitrary_types_allowed=True)  # type: ignore
+    @_bioengine_method_arbitrary
     async def delete_training_session(
         self,
         session_id: str = Field(description="Session ID to delete"),
@@ -4535,7 +4542,7 @@ class CellposeFinetune:
         logger.info(f"Deleted training session {session_id} (caller: {caller_id})")
         return {"deleted": session_id}
 
-    @schema_method(arbitrary_types_allowed=True)  # type: ignore
+    @_bioengine_method_arbitrary
     async def export_model(
         self,
         session_id: str = Field(description="Training session ID to export"),
@@ -4999,7 +5006,7 @@ BSD-3-Clause (Cellpose license)
             except Exception as e:
                 logger.warning(f"Failed to clean up export directory: {e}")
 
-    @schema_method  # type: ignore
+    @bioengine.method
     async def list_models_by_dataset(
         self,
         dataset_id: str = Field(
@@ -5102,7 +5109,7 @@ BSD-3-Clause (Cellpose license)
             logger.error(f"Error listing models by dataset: {e}")
             raise RuntimeError(f"Failed to list models by dataset: {e}") from e
 
-    @schema_method(arbitrary_types_allowed=True)  # type: ignore
+    @_bioengine_method_arbitrary
     async def infer(
         self,
         artifact: str | None = Field(

--- a/apps/cellpose-finetuning/main.py
+++ b/apps/cellpose-finetuning/main.py
@@ -36,21 +36,9 @@ from urllib.parse import urlparse
 import numpy as np
 import numpy.typing as npt
 import bioengine
-from hypha_rpc.utils.schema import schema_method
 from pydantic import Field
 from ray import serve
 
-
-def _bioengine_method_arbitrary(fn):
-    """@bioengine.method variant that allows arbitrary types in the pydantic schema.
-
-    Equivalent to @schema_method(arbitrary_types_allowed=True) plus the
-    `_bioengine_kind = "method"` marker that @bioengine.app reads at class
-    creation time.
-    """
-    wrapped = schema_method(arbitrary_types_allowed=True)(fn)
-    wrapped._bioengine_kind = "method"
-    return wrapped
 
 if TYPE_CHECKING:
     import torch
@@ -596,25 +584,9 @@ def to_local_path(root: Path, rel: Path) -> Path:
     return root / strip_leading_slash(rel)
 
 
-def _data_root() -> Path:
-    """Return the writable base directory for cellpose-finetuning training state.
-
-    Honours ``CELLPOSE_DATA_DIR`` so cluster operators can point sessions and
-    artifact caches at a shared NFS mount; falls back to
-    ``/tmp/bioengine/cellpose-finetuning``. We deliberately don't use
-    ``Path.home()`` — the framework sets HOME to ``apps_workdir/<app_id>/``,
-    which on shared-NFS workers may live on a mount the replica's UID cannot
-    create subdirectories on.
-    """
-    return Path(
-        os.environ.get("CELLPOSE_DATA_DIR")
-        or "/tmp/bioengine/cellpose-finetuning"
-    ).expanduser().resolve()
-
-
 def get_sessions_path() -> Path:
     """Return the path to the directory where training sessions are stored."""
-    return _data_root() / "sessions"
+    return Path.home() / "sessions"
 
 
 def get_model_path(session_id: str) -> Path:
@@ -711,7 +683,7 @@ async def ensure_published_model_local_session(model_reference: str) -> str:
 def artifact_cache_dir(artifact_id: str) -> Path:
     """Return local cache dir for an artifact id, ensuring it exists."""
     safe = artifact_id.replace("/", "__")
-    d = _data_root() / "data_cache" / safe
+    d = Path.home() / "data_cache" / safe
     d.mkdir(parents=True, exist_ok=True)
     return d
 
@@ -3769,12 +3741,6 @@ def _predict_and_encode(
         "matplotlib",
         "hypha-artifact==0.1.2",
     ],
-    env_vars={
-        # Shared writable NFS path so training sessions + data caches survive
-        # replica restarts. Override per-cluster via the manifest if a
-        # different shared path is provisioned.
-        "CELLPOSE_DATA_DIR": "/home/bioengine/staging/model-cache/cellpose-finetuning",
-    },
     max_ongoing_requests=1,
     max_queued_requests=10,
     autoscaling_config={
@@ -3841,7 +3807,7 @@ class CellposeFinetune:
         )
         raise ValueError(msg)
 
-    @_bioengine_method_arbitrary
+    @bioengine.method
     async def start_training(
         self,
         artifact: str = Field(
@@ -4135,7 +4101,7 @@ class CellposeFinetune:
         status = get_status(session_id)
         return SessionStatusWithId(**status, session_id=session_id)
 
-    @_bioengine_method_arbitrary
+    @bioengine.method
     async def stop_training(
         self,
         session_id: str = Field(
@@ -4176,7 +4142,7 @@ class CellposeFinetune:
 
         return get_status(session_id)
 
-    @_bioengine_method_arbitrary
+    @bioengine.method
     async def debug_task_info(
         self,
         session_id: str = Field(
@@ -4206,7 +4172,7 @@ class CellposeFinetune:
 
         return info
 
-    @_bioengine_method_arbitrary
+    @bioengine.method
     async def get_training_status(
         self,
         session_id: str = Field(
@@ -4276,7 +4242,7 @@ class CellposeFinetune:
             )
         return session_data
 
-    @_bioengine_method_arbitrary
+    @bioengine.method
     async def restart_training(
         self,
         session_id: str = Field(description="Session ID to restart from"),
@@ -4470,7 +4436,7 @@ class CellposeFinetune:
 
         return sessions
 
-    @_bioengine_method_arbitrary
+    @bioengine.method
     async def list_training_sessions(
         self,
         status_types: list[str] | None = Field(
@@ -4509,7 +4475,7 @@ class CellposeFinetune:
             limit = wrapped.get("limit", limit)
         return await asyncio.to_thread(self._list_sessions_sync, status_types, limit, dataset_artifact_ids, labels)
 
-    @_bioengine_method_arbitrary
+    @bioengine.method
     async def delete_training_session(
         self,
         session_id: str = Field(description="Session ID to delete"),
@@ -4571,7 +4537,7 @@ class CellposeFinetune:
         logger.info(f"Deleted training session {session_id} (caller: {caller_id})")
         return {"deleted": session_id}
 
-    @_bioengine_method_arbitrary
+    @bioengine.method
     async def export_model(
         self,
         session_id: str = Field(description="Training session ID to export"),
@@ -5138,7 +5104,7 @@ BSD-3-Clause (Cellpose license)
             logger.error(f"Error listing models by dataset: {e}")
             raise RuntimeError(f"Failed to list models by dataset: {e}") from e
 
-    @_bioengine_method_arbitrary
+    @bioengine.method
     async def infer(
         self,
         artifact: str | None = Field(

--- a/apps/cellpose-finetuning/manifest.yaml
+++ b/apps/cellpose-finetuning/manifest.yaml
@@ -5,7 +5,7 @@ covers: []
 description: A BioEngine service for running Cellpose-SAM 4.0.7 inference and fine-tuning cell segmentation models.
 documentation: "README.md"
 tutorial: "https://imjoy-notebook.netlify.app/lab/index.html?load=https://raw.githubusercontent.com/aicell-lab/bioengine/refs/heads/main/apps/cellpose-finetuning/tutorial_cellpose_finetuning.ipynb&open=1"
-format_version: 0.5.0
+format_version: 0.6.0
 git_repo: "https://github.com/aicell-lab/bioengine/tree/main/apps/cellpose-finetuning"
 id: cellpose-finetuning
 id_emoji: "🧬"
@@ -15,7 +15,6 @@ maintainers: []
 name: Cellpose Fine-Tuning
 tags: [cell-segmentation, deep-learning, biomedical-imaging, fine-tuning]
 type: ray-serve
-version: 0.1.5
-deployments:
-  - main:CellposeFinetune
+version: 0.2.0
+entry: main:CellposeFinetune
 frontend_entry: "frontend/index.html"

--- a/apps/cellpose-finetuning/manifest.yaml
+++ b/apps/cellpose-finetuning/manifest.yaml
@@ -15,6 +15,6 @@ maintainers: []
 name: Cellpose Fine-Tuning
 tags: [cell-segmentation, deep-learning, biomedical-imaging, fine-tuning]
 type: ray-serve
-version: 0.2.0
+version: 1.0.0
 entry: main:CellposeFinetune
 frontend_entry: "frontend/index.html"


### PR DESCRIPTION
## Summary

Migrates `apps/cellpose-finetuning/` to the v0.11/v0.6.0 manifest + decorator API. Scope is intentionally minimal: `main.py` stays monolithic per the v0.11 migration plan ("minimal package wrap; no decomposition of the 11950-line `main.py`"). A proper modularisation is deferred to a follow-up.

**Depends on #118** — relies on the v0.11.3 framework chmod fix (Path.home() writable in replicas) and the new `@bioengine.method` arbitrary-types default. Without #118 merged, `CellposeFinetune.__init__` fails with PermissionError on `~/sessions` and the nine numpy-accepting methods can't be exposed.

## Changes

**Manifest**

- `format_version: 0.5.0` → `0.6.0`
- `deployments: [main:CellposeFinetune]` → `entry: main:CellposeFinetune`
- `version: 0.1.5` → `1.0.0`

**`main.py` decorator migration**

- `@serve.deployment(ray_actor_options={...})` → `@bioengine.app(num_cpus=4, num_gpus=1, memory_mb=12*1024, pip=[...], autoscaling_config={...}, ...)` — args flattened, behaviour identical.
- `@schema_method` / `@schema_method(arbitrary_types_allowed=True)` → plain `@bioengine.method`. The arbitrary-types default in #118 covers the nine methods that accept `numpy.ndarray`.
- `get_sessions_path()` and `artifact_cache_dir()` use `Path.home() / "sessions"` and `Path.home() / "data_cache"`. The chmod fix in #118 makes the per-app `HOME` writable so no per-cluster env-var override is needed.
- `from __future__ import annotations` retained — `make_artifact_client(...) -> AsyncHyphaArtifact` and similar helper signatures reference TYPE_CHECKING-only imports that aren't available at module load time. `@bioengine.method`-decorated endpoints use only builtin types so pydantic resolves their schemas correctly even with string-form annotations.

## Test plan

- [x] Uploaded to `ws-user-github|49943582/cellpose-finetuning` v1.0.0 (after #118 image rolled).
- [x] Deployed on deNBI staging (`0.11.3-patch1`) under `application_id=cellpose-finetuning-v06` — RUNNING in 9.6 s.
- [x] All 13 methods exposed; `list_training_sessions()` returns OK.
- [ ] Full training round-trip (`start_training` → poll → `export_model`) deferred to a separate follow-up exercise.
