### PR TITLE
feat(worker): pass --server-url through to apps + ProxyDeployment

### DIFF
--- a/bioengine/apps/builder.py
+++ b/bioengine/apps/builder.py
@@ -64,6 +64,7 @@ class AppBuilder:
     def __init__(
         self,
         apps_workdir: Union[str, Path],
+        server_url: str,
         log_file: Optional[str] = None,
         proxy_actor_name: Optional[str] = None,
         debug: bool = False,
@@ -78,6 +79,7 @@ class AppBuilder:
         self.artifact_manager: Optional[ObjectProxy] = None
         self.worker_service_id: Optional[str] = None
         self.proxy_actor_name: Optional[str] = proxy_actor_name
+        self.server_url: str = server_url
         self.data_server_url: Optional[str] = None
 
         self._sweep_runtime_env_tmp_files()
@@ -254,7 +256,7 @@ class AppBuilder:
         env_vars["TMP"] = tmp_dir
 
         if self.server is not None:
-            env_vars["HYPHA_SERVER_URL"] = self.server.config.public_base_url
+            env_vars["HYPHA_SERVER_URL"] = self.server_url
             env_vars["HYPHA_WORKSPACE"] = self.server.config.workspace
         env_vars["HYPHA_ARTIFACT_ID"] = artifact_id
         if version is not None:
@@ -834,7 +836,7 @@ class AppBuilder:
             "application_description": manifest["description"],
             "app_data": app_data,
             "max_ongoing_requests": max_ongoing_requests,
-            "server_url": self.server.config.public_base_url,
+            "server_url": self.server_url,
             "workspace": self.server.config.workspace,
             "worker_client_id": self.server.config.client_id,
             "proxy_service_token": proxy_service_token,

--- a/bioengine/apps/manager.py
+++ b/bioengine/apps/manager.py
@@ -80,6 +80,7 @@ class AppsManager:
     def __init__(
         self,
         ray_cluster: RayCluster,
+        server_url: str,
         apps_workdir: Union[str, Path] = f"{os.environ['HOME']}/.bioengine/apps",
         startup_applications: Optional[List[dict]] = None,
         # Logger
@@ -125,6 +126,7 @@ class AppsManager:
 
         self.app_builder = AppBuilder(
             apps_workdir=apps_workdir,
+            server_url=server_url,
             log_file=log_file,
             proxy_actor_name=self.ray_cluster.proxy_actor_name,
             debug=debug,

--- a/bioengine/worker/__main__.py
+++ b/bioengine/worker/__main__.py
@@ -187,7 +187,9 @@ For detailed documentation, visit: https://github.com/aicell-lab/bioengine
         type=str,
         metavar="URL",
         help="URL of the Hypha server for service registration and remote access. "
-        "Must be accessible from the deployment environment.",
+        "Used both by the worker itself and by deployed apps (HYPHA_SERVER_URL env "
+        "var + ProxyDeployment's connection URL), so it must be reachable from every "
+        "node hosting an app — including Ray worker pods.",
     )
     hypha_group.add_argument(
         "--workspace",

--- a/bioengine/worker/worker.py
+++ b/bioengine/worker/worker.py
@@ -341,6 +341,7 @@ class BioEngineWorker:
             self.apps_manager = AppsManager(
                 ray_cluster=self.ray_cluster,
                 apps_workdir=apps_workdir,
+                server_url=server_url,
                 startup_applications=startup_applications,
                 log_file=self.log_file,
                 debug=debug,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.11.1"
+version = "0.11.2"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Motivation

The Hypha URL passed to deployed apps — both `HYPHA_SERVER_URL` injected as an env var and `server_url=` passed into the managed `ProxyDeployment` constructor — was sourced from `server.config.public_base_url`. Hypha sets `public_base_url` server-side from its own `--public-base-url` config and does not change it based on which URL the client connected through. As a result, apps always received the publicly-configured Hypha URL regardless of how the worker itself was configured, and there was no way to make apps use a different URL (for example, a cluster-internal Service when the public URL is unreachable from some pods).

## Change

Thread the worker's existing `--server-url` (the `server_url` constructor argument on `BioEngineWorker`) through `AppsManager` → `AppBuilder`, and use it at the two sites that emit the URL for app use:

- `env_vars["HYPHA_SERVER_URL"]` set on every deployment's runtime_env (used by apps that read the env var, e.g. cellpose-finetuning's `connect_to_server` calls).
- `server_url=` passed into the managed `ProxyDeployment` constructor (used by `ProxyDeployment._register_services` to open its own WebSocket to Hypha).

`static_site_url` generation, `view_config` URLs, and other places that produce externally-addressable URLs (browser frontends, registered service IDs visible to outside clients) intentionally keep using `server.config.public_base_url` — those need to remain reachable from outside the cluster.

## Behavioural impact

When the worker is started with `--server-url=https://hypha.aicell.io` and connects to a Hypha server whose `public_base_url` is `https://hypha.aicell.io`, app-facing behaviour is unchanged: apps receive `https://hypha.aicell.io`, exactly as they did before.

When the worker is started with `--server-url=<other>` (e.g. `http://hypha-server.<ns>.svc.cluster.local:9520`) the change becomes visible: apps now receive that URL instead of `public_base_url`. This is the new, useful behaviour — it allows deployments in environments where the public Hypha URL is unreachable from app pods (NGINX Gateway Fabric with `externalTrafficPolicy: Local` + data-plane pods on only some nodes, for example) to route in-cluster traffic to Hypha through a cluster-internal Service.

If a deployment was relying on the previous mismatch (worker connects via one URL, apps receive a different `public_base_url`), this PR is a behavioural change for that deployment — apps would now receive the worker's `--server-url` instead. We're not aware of any deployment that depended on the divergence, and `--server-url` defaults to `https://hypha.aicell.io`, matching the typical `public_base_url`.

## Verification

- `--help` shows the updated `--server-url` help text noting it's used by apps too.
- Tested directly against the in-cluster `hypha-server` Service from a Ray task on a pod whose node cannot reach the public Gateway VIP: `GET http://hypha-server.hypha.svc.cluster.local:9520/health/readiness` returns HTTP 200 with the full Hypha health payload (`{"status":"OK","store":"ready","redis":"connected","event_bus":"ready","pubsub":"healthy"}`); WebSocket upgrade against `/ws` returns `HTTP/1.1 101 Switching Protocols` from `uvicorn`. The in-cluster URL is therefore a valid drop-in for the public WSS endpoint at the protocol level.
- `AppBuilder` unit-level check: `server_url` is stored from the constructor argument and read back unchanged.

## File-level summary

- `bioengine/worker/__main__.py` — update `--server-url` help text to document that the value flows through to apps and ProxyDeployment.
- `bioengine/worker/worker.py` — pass `server_url` to `AppsManager`.
- `bioengine/apps/manager.py` — accept `server_url` and pass it to `AppBuilder`.
- `bioengine/apps/builder.py` — accept `server_url`, store it as `self.server_url`, and use it at the two sites that previously read `self.server.config.public_base_url`.
