### PR TITLE
feat(0.11.3): chmod app workdir + arbitrary-types method default

### DIFF
--- a/bioengine/_app/decorators.py
+++ b/bioengine/_app/decorators.py
@@ -49,13 +49,15 @@ _KIND_ATTR = "_bioengine_kind"
 def method(fn: Callable[..., Any]) -> Callable[..., Any]:
     """Expose an instance method as a BioEngine API method.
 
-    Equivalent to ``hypha_rpc``'s ``@schema_method`` plus a tag the
-    ``@bioengine.app`` decorator reads at class-creation time to assemble
-    ``_bioengine_method_schemas``.
+    Equivalent to ``hypha_rpc``'s ``@schema_method(arbitrary_types_allowed=True)``
+    plus a tag the ``@bioengine.app`` decorator reads at class-creation time
+    to assemble ``_bioengine_method_schemas``. Arbitrary types are allowed by
+    default so methods can accept ``numpy.ndarray``, ``PIL.Image``, etc.
+    without users having to wire a custom decorator.
     """
     from hypha_rpc.utils.schema import schema_method
 
-    wrapped = schema_method(fn)
+    wrapped = schema_method(arbitrary_types_allowed=True)(fn)
     setattr(wrapped, _KIND_ATTR, "method")
     return wrapped
 

--- a/bioengine/apps/builder.py
+++ b/bioengine/apps/builder.py
@@ -157,6 +157,19 @@ class AppBuilder:
         if target_dir.exists():
             shutil.rmtree(target_dir)
         target_dir.mkdir(parents=True, exist_ok=True)
+        # The app workdir doubles as HOME for the replica (see _build_env_vars).
+        # On shared-NFS workers with root_squash the worker pod's mkdir lands
+        # owned by nobody:nogroup (65534), so the replica's UID can't create
+        # subdirs under Path.home(). Sticky + world-writable lets any replica
+        # UID create state while preventing cross-UID deletes.
+        app_workdir = target_dir.parent
+        try:
+            app_workdir.chmod(0o1777)
+        except OSError as exc:
+            self.logger.warning(
+                f"Could not chmod app workdir {app_workdir}: {exc}. "
+                "Replicas may fail to create subdirectories under Path.home()."
+            )
 
         local_root = self._local_artifact_root(artifact_id)
         if local_root and local_root.is_dir():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.11.2"
+version = "0.11.3"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Summary

Two framework fixes that make the v0.6 app contract self-consistent on shared-NFS workers and remove the need for per-method workarounds when a method accepts a numpy array. Apps stay on their own PRs (#115, #116).

## Changes

### `bioengine/apps/builder.py` — `chmod` the app workdir to `0o1777`

After creating `apps_workdir/<application_id>/`, the worker now chmods it to sticky world-writable. On shared-NFS workers with root_squash the worker pod's `mkdir` lands owned by `uid 65534` (nobody) with mode `0o755`. The replica runs as `uid 1000` (ray) and silently cannot create subdirs under `Path.home()` — apps had to redirect state to a hand-picked NFS path via env vars to work around this.

Verified on deNBI staging: `mkdir(/home/bioengine/staging/apps/cellpose-finetuning-v06/<subdir>)` from `uid 1000` failed with EACCES on the pre-fix workdir; after the chmod, the workdirs show as `0o1777` and replicas can create state under `Path.home()` as the `_ensure_working_directory` docstring already promises.

### `bioengine/_app/decorators.py` — `@bioengine.method` defaults `arbitrary_types_allowed=True`

`@bioengine.method` now wraps `schema_method(arbitrary_types_allowed=True)` so methods that accept `numpy.ndarray`, `PIL.Image`, etc. work without a user-side decorator helper. Builtin / `Optional[…]` / `pydantic.BaseModel` signatures are unaffected.

### `pyproject.toml`

`0.11.2` → `0.11.3`.

## Test plan

- [x] `0.11.3-patch1` image (`sha256:b9995fd4054c2f01d930c3b24fc3cfacb12850d14559a18bf4bb0e146808b941`) rolled on deNBI staging.
- [x] `model-runner-v06` and `cellpose-finetuning-v06` redeployed against the patched worker — both RUNNING, `infer` round-trips end-to-end via shared `~/models/` cache, `list_training_sessions` returns OK.
- [x] App workdirs verified as `0o1777` via probe (was `0o755` pre-fix).
- [x] Both apps' `@bioengine.method`-decorated endpoints introspect cleanly with the new default; no PydanticUserError.

## Follow-ups in #115 and #116

Both app PRs can now drop their `MODEL_CACHE_DIR` / `CELLPOSE_DATA_DIR` `env_vars` blocks and their `_arbitrary_types_method` / `_bioengine_method_arbitrary` helpers, going back to plain `Path.home()` and plain `@bioengine.method`. They land independently of this PR.
