### PR TITLE
feat(apps): filter recovered apps by worker workspace

### DIFF
--- a/bioengine/apps/builder.py
+++ b/bioengine/apps/builder.py
@@ -564,8 +564,15 @@ class AppBuilder:
             json.dumps(spec, sort_keys=True, default=str).encode()
         ).hexdigest()
 
+        # worker_workspace stamps the app with the Hypha workspace of the
+        # worker that deployed it. On recovery after a worker restart,
+        # AppsManager.recover_deployed_applications skips apps whose
+        # worker_workspace differs from this worker's — so multiple
+        # workers from different workspaces sharing a Ray cluster don't
+        # adopt each other's apps.
         app_data = {
             "format_version": SPEC_FORMAT_VERSION,
+            "worker_workspace": self.server.config.workspace,
             "entry": entry_id,
             "spec_hash": spec_hash,
             "display_name": manifest["name"],

--- a/bioengine/apps/manager.py
+++ b/bioengine/apps/manager.py
@@ -25,6 +25,49 @@ from bioengine.utils import (
 )
 
 
+def _belongs_to_worker_workspace(
+    application_id: str,
+    app_data: Dict[str, Any],
+    current_workspace: str,
+    logger: logging.Logger,
+) -> bool:
+    """Whether a Ray Serve app belongs to this worker's Hypha workspace.
+
+    Called during ``AppsManager.recover_deployed_applications`` to filter
+    cluster-wide ``serve.status()`` results down to apps the current worker
+    is allowed to manage. Multiple bioengine workers from different Hypha
+    workspaces can share a Ray cluster; each one should only adopt apps it
+    deployed itself.
+
+    Logs (and returns False) for two skip cases:
+
+    * The ``app_data`` blob has no ``worker_workspace`` marker — the app
+      was deployed by a worker predating this filter. Logged as a warning
+      because the user almost certainly wants to redeploy it.
+    * The marker is present and points at a different workspace — the app
+      belongs to a sibling worker. Logged at DEBUG since this is the
+      expected steady-state when multiple workers share a Ray cluster.
+    """
+    recovered_workspace = app_data.get("worker_workspace")
+    if recovered_workspace is None:
+        logger.warning(
+            f"Refusing to recover application '{application_id}': app_data "
+            "has no worker_workspace marker. Either the app was deployed by "
+            "a worker predating the cross-workspace filter, or it belongs to "
+            "a sibling worker. Redeploy it explicitly to stamp it with the "
+            "current worker's workspace."
+        )
+        return False
+    if recovered_workspace != current_workspace:
+        logger.debug(
+            f"Skipping application '{application_id}' during recovery: "
+            f"belongs to workspace {recovered_workspace!r}, this worker "
+            f"serves {current_workspace!r}."
+        )
+        return False
+    return True
+
+
 class AppsManager:
     """
     Manages Ray Serve deployments using Hypha artifact manager integration.
@@ -893,6 +936,18 @@ class AppsManager:
                         f"BioEngine major version break — redeploy this app "
                         f"explicitly to bring it under the new builder."
                     )
+                    continue
+
+                # When multiple bioengine workers from different Hypha
+                # workspaces share a Ray cluster, serve.status() returns
+                # every workspace's apps. Adopt only the ones stamped with
+                # this worker's workspace.
+                if not _belongs_to_worker_workspace(
+                    application_id=application_id,
+                    app_data=app_data,
+                    current_workspace=self.server.config.workspace,
+                    logger=self.logger,
+                ):
                     continue
 
                 required_keys = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.11.4"
+version = "0.11.5"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [

--- a/tests/apps/test_recovery_workspace_filter.py
+++ b/tests/apps/test_recovery_workspace_filter.py
@@ -1,0 +1,88 @@
+"""Unit tests for the cross-workspace recovery filter.
+
+When several bioengine workers from different Hypha workspaces share a
+Ray cluster, ``serve.status()`` returns every workspace's applications.
+``AppsManager.recover_deployed_applications`` only adopts the apps that
+belong to *this* worker's workspace; the filter is implemented as
+:func:`bioengine.apps.manager._belongs_to_worker_workspace`.
+"""
+
+import logging
+
+import pytest
+
+from bioengine.apps.manager import _belongs_to_worker_workspace
+
+
+@pytest.fixture
+def caplog_at_debug(caplog):
+    caplog.set_level(logging.DEBUG, logger="test")
+    return caplog
+
+
+def _make_logger() -> logging.Logger:
+    return logging.getLogger("test")
+
+
+def test_match_workspace_returns_true(caplog_at_debug) -> None:
+    assert _belongs_to_worker_workspace(
+        application_id="model-runner",
+        app_data={"worker_workspace": "bioimage-io"},
+        current_workspace="bioimage-io",
+        logger=_make_logger(),
+    )
+    assert caplog_at_debug.records == []  # silent success
+
+
+def test_mismatched_workspace_returns_false_and_logs_debug(
+    caplog_at_debug,
+) -> None:
+    assert not _belongs_to_worker_workspace(
+        application_id="model-runner",
+        app_data={"worker_workspace": "bioimage-io"},
+        current_workspace="ws-user-github|49943582",
+        logger=_make_logger(),
+    )
+    debug_records = [r for r in caplog_at_debug.records if r.levelno == logging.DEBUG]
+    assert any(
+        "belongs to workspace" in r.message and "model-runner" in r.message
+        for r in debug_records
+    ), "expected a DEBUG line naming the application and the foreign workspace"
+    # Mismatch is expected when multiple workers share a cluster — no
+    # WARNING or higher should fire.
+    assert all(
+        r.levelno < logging.WARNING for r in caplog_at_debug.records
+    ), "workspace mismatch must stay at DEBUG, not warn"
+
+
+def test_missing_marker_returns_false_and_warns(caplog_at_debug) -> None:
+    assert not _belongs_to_worker_workspace(
+        application_id="legacy-app",
+        app_data={
+            # no worker_workspace key
+            "artifact_id": "ws/legacy-app",
+            "version": "1.0.0",
+        },
+        current_workspace="bioimage-io",
+        logger=_make_logger(),
+    )
+    warning_records = [
+        r for r in caplog_at_debug.records if r.levelno == logging.WARNING
+    ]
+    assert any(
+        "legacy-app" in r.message and "worker_workspace" in r.message
+        for r in warning_records
+    ), "expected a WARNING that names the app and the missing marker"
+
+
+def test_empty_string_marker_treated_as_present_and_mismatched(
+    caplog_at_debug,
+) -> None:
+    # Defensive: an empty-string marker is technically present but doesn't
+    # match any real workspace, so it must NOT be adopted as ours.
+    assert not _belongs_to_worker_workspace(
+        application_id="malformed",
+        app_data={"worker_workspace": ""},
+        current_workspace="bioimage-io",
+        logger=_make_logger(),
+    )


### PR DESCRIPTION
## Problem

Multiple bioengine workers from different Hypha workspaces can share a single Ray cluster. Ray Serve's `serve.status()` is cluster-wide — it returns every workspace's applications, with no way for a caller to identify which worker deployed which app.

On worker restart, `AppsManager.recover_deployed_applications` iterates `serve_status.applications.items()` and adopts every app it finds, calling `app_handle.update_authorized_users.remote(...)` and entering each into `_deployed_applications`. A sibling worker from a *different* Hypha workspace would have its apps silently adopted: monitoring, auth checks, app_data writes, and proxy service registration would all route through the wrong worker. The on-disk per-app directory naming was already workspace-prefixed (`<worker-ws>-<app-id>`), but the Ray Serve recovery path treated the cluster as if it served only one workspace.

## Solution

Stamp every deployed app with its `worker_workspace` in `app_data`, and filter on it during recovery.

* `bioengine/apps/builder.py` — `app_data["worker_workspace"] = self.server.config.workspace`. New field; recovery refuses to adopt apps that lack it.
* `bioengine/apps/manager.py` — small standalone helper `_belongs_to_worker_workspace(application_id, app_data, current_workspace, logger)` returns False (and logs) for the two skip cases, True for the adopt case. `recover_deployed_applications` calls it between the existing `format_version` gate and the `required_keys` validation.

### Skip semantics

| Case | Decision | Log level |
|---|---|---|
| `worker_workspace == self.server.config.workspace` | Adopt | silent |
| `worker_workspace != self.server.config.workspace` | Skip | DEBUG (expected steady-state when workers share a cluster) |
| `worker_workspace` missing | Skip | WARNING (names the application, suggests redeploy) |
| `worker_workspace == ""` | Skip via the mismatch path | DEBUG |

Consistent with the existing `format_version=0.6.0` gate one block above: apps from a worker predating this change must be redeployed.

### Behavioural change in numbers

* New required field: `app_data["worker_workspace"]`.
* `AppsManager._deployed_applications` after recovery is a subset of what it was before (apps from foreign workspaces no longer enter it).
* `list_apps`, `get_app_status`, monitoring loop, etc. flow through `_deployed_applications` and are scoped correctly as a side effect.

## Test plan

- [x] `tests/apps/test_recovery_workspace_filter.py` — 4 unit tests: match, mismatch, missing-marker, empty-string-marker. Pass.
- [x] Full unit suite (`tests/_app/` + `tests/apps/` minus the live-app subdirs) — 83 pass, no regressions.
- [ ] End-to-end: a single worker's own apps still recover after restart (covered by `tests/end_to_end/test_applications.py` once CI runs).
- [ ] Live verification on KTH: production worker (`bioimage-io`) and a dev worker (`ws-user-github|49943582`) sharing the same Ray cluster; restart the dev worker and confirm it does **not** adopt the production apps. To be done before marking the PR ready, per the deployment-side dev-image workflow.

## File-level summary

* `bioengine/apps/builder.py` — adds `worker_workspace` to `app_data`.
* `bioengine/apps/manager.py` — adds the `_belongs_to_worker_workspace` module-level helper and one call site in `recover_deployed_applications`.
* `tests/apps/test_recovery_workspace_filter.py` *(new)* — unit tests for the helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)