### PR TITLE
feat(upload_app): require strictly increasing manifest version

### DIFF
--- a/bioengine/utils/artifact_utils.py
+++ b/bioengine/utils/artifact_utils.py
@@ -8,11 +8,54 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import httpx
 import yaml
+from packaging.version import InvalidVersion, Version
 
 if TYPE_CHECKING:
     from hypha_rpc.rpc import ObjectProxy
 
 from .logger import create_logger
+
+
+def _enforce_version_increases(
+    new_version: Optional[str],
+    existing_versions: List[str],
+    artifact_id: str,
+) -> None:
+    """Reject uploads that would overwrite or downgrade an existing version.
+
+    The manifest version must be strictly greater than every existing tag on
+    the artifact, using PEP 440 ordering (``packaging.version.Version``). If
+    either side is not PEP-440-parseable, fall back to rejecting any exact
+    match by string.
+    """
+    if not new_version:
+        raise ValueError(
+            f"Cannot upload '{artifact_id}': manifest is missing a 'version' "
+            f"field. Add a semver-style version (e.g. '1.2.3') to manifest.yaml."
+        )
+    if not existing_versions:
+        return
+
+    try:
+        new_parsed = Version(str(new_version))
+        existing_parsed = [(v, Version(str(v))) for v in existing_versions]
+    except InvalidVersion:
+        if str(new_version) in {str(v) for v in existing_versions}:
+            raise ValueError(
+                f"Cannot upload '{artifact_id}' at version '{new_version}': "
+                f"that version already exists. Bump the version in "
+                f"manifest.yaml (existing: {existing_versions})."
+            )
+        return
+
+    highest_str, highest_parsed = max(existing_parsed, key=lambda x: x[1])
+    if new_parsed <= highest_parsed:
+        raise ValueError(
+            f"Cannot upload '{artifact_id}' at version '{new_version}': "
+            f"must be strictly greater than the highest existing version "
+            f"'{highest_str}'. Bump the version in manifest.yaml "
+            f"(existing: {existing_versions})."
+        )
 
 
 def create_file_list_from_directory(
@@ -371,17 +414,15 @@ async def stage_artifact(
     manifest: Dict[str, Any],
     logger: Optional[logging.Logger] = None,
     permissions: Optional[Dict[str, Any]] = None,
-) -> tuple:
+) -> "ObjectProxy":
     """
     Put an artifact into stage mode. Creates a new artifact if it doesn't exist.
 
-    Versioning behaviour:
-    - New artifact or version tag not yet present → branches a new version snapshot
-      (``edit(version='new')``); the caller should commit with the version tag.
-    - Version tag already exists → stages on top of the current head without
-      branching (``edit(version=None)``); the caller should commit *without* a tag
-      so the existing named version is updated in place and other versions are
-      left untouched.
+    Always branches a fresh version snapshot (``edit(version='new')``); the
+    caller commits with the manifest version as the tag. The manifest version
+    must be strictly greater than every existing tag on the artifact — same
+    or lower versions are rejected to prevent silent overwrites of published
+    releases.
 
     Args:
         artifact_manager: Hypha artifact manager service instance
@@ -391,11 +432,12 @@ async def stage_artifact(
         permissions: Optional permissions to set on the artifact
 
     Returns:
-        Tuple of (artifact, version_is_new) where version_is_new is True when the
-        manifest version did not previously exist and should be tagged on commit.
+        The staged artifact handle.
 
     Raises:
-        RuntimeError: If artifact creation fails
+        ValueError: If the manifest is missing a version or the version is not
+            strictly greater than every existing version of the artifact.
+        RuntimeError: If artifact creation fails.
     """
     if logger is None:
         logger = create_logger("ArtifactUtils")
@@ -421,7 +463,6 @@ async def stage_artifact(
 
     # Check if artifact exists and handle collection placement
     artifact = None
-    version_is_new = True  # new artifact always gets a version tag on commit
     manifest_version = manifest.get("version")
 
     try:
@@ -447,52 +488,33 @@ async def stage_artifact(
             if view_config is not None:
                 artifact_config["view_config"] = view_config
 
-            # Decide how to stage based on whether the manifest version is new:
-            #
-            # - New version tag: edit(version='new') branches a fresh snapshot so
-            #   all previous versions stay intact; caller commits with the tag.
-            # - Same version as the LATEST: edit(version=None) stages on the
-            #   current head; caller commits without a tag — updates in place.
-            # - Same version as an OLDER (non-latest) tag: not supported by Hypha
-            #   (edit always targets the latest head), so raise a clear error.
+            # Enforce strict version monotonicity — uploading the same or a
+            # lower version than the highest existing tag would overwrite a
+            # published release. Force the author to bump manifest.yaml.
             existing_versions = [
                 v["version"] for v in (existing_artifact.versions or [])
             ]
-            version_is_new = bool(
-                manifest_version and manifest_version not in existing_versions
+            _enforce_version_increases(
+                new_version=manifest_version,
+                existing_versions=existing_versions,
+                artifact_id=artifact_id,
             )
-
-            if not version_is_new and existing_versions:
-                latest_version = existing_versions[-1]
-                if manifest_version and manifest_version != latest_version:
-                    raise ValueError(
-                        f"Cannot re-save artifact '{artifact_id}' at version "
-                        f"'{manifest_version}': a newer version '{latest_version}' "
-                        f"already exists. Bump the version in manifest.yaml to save "
-                        f"changes (existing versions: {existing_versions})."
-                    )
 
             edit_kwargs = {
                 "artifact_id": artifact_id,
                 "manifest": manifest,
                 "type": "application",
                 "stage": True,
-                "version": "new" if version_is_new else None,
+                "version": "new",
             }
             if artifact_config:
                 edit_kwargs["config"] = artifact_config
 
             artifact = await artifact_manager.edit(**edit_kwargs)
-            if version_is_new:
-                logger.info(
-                    f"Editing existing artifact '{artifact_id}' "
-                    f"(new version: {manifest_version})"
-                )
-            else:
-                logger.info(
-                    f"Editing existing artifact '{artifact_id}' "
-                    f"(updating existing version: {manifest_version or 'latest'})"
-                )
+            logger.info(
+                f"Editing existing artifact '{artifact_id}' "
+                f"(new version: {manifest_version})"
+            )
 
     except Exception as e:
         expected_error = f"KeyError: \"Artifact with ID '{artifact_id}' does not exist."
@@ -523,7 +545,7 @@ async def stage_artifact(
         except Exception as e:
             raise RuntimeError(f"Failed to create artifact '{artifact_id}': {e}")
 
-    return artifact, version_is_new
+    return artifact
 
 
 async def upload_file_to_artifact(
@@ -752,9 +774,10 @@ async def create_application_from_files(
     # Add created_by field to the manifest
     application_manifest["created_by"] = user_id
 
-    # Edit or create artifact, put in stage mode.
-    # version_is_new tells us whether to tag the commit with the manifest version.
-    artifact, version_is_new = await stage_artifact(
+    # Edit or create artifact, put in stage mode. Strict version monotonicity
+    # is enforced inside stage_artifact, so the staged snapshot always gets a
+    # fresh manifest-version tag on commit.
+    artifact = await stage_artifact(
         artifact_manager=artifact_manager,
         workspace=workspace,
         manifest=application_manifest,
@@ -823,15 +846,12 @@ async def create_application_from_files(
                     f"Failed to remove old file '{file_name}': {e}. Continuing anyway..."
                 )
 
-    # Commit the artifact.
-    # Only tag with the manifest version when it is genuinely new; if the version
-    # tag already existed we commit without a tag (updates the artifact in place
-    # without creating a duplicate version entry).
-    commit_version = application_manifest.get("version") if version_is_new else None
+    # Commit the artifact under the manifest version tag (always a new tag —
+    # stage_artifact rejects same-or-lower versions before we reach this point).
     await commit_artifact(
         artifact_manager=artifact_manager,
         artifact_id=artifact.id,
-        version=commit_version,
+        version=application_manifest.get("version"),
         logger=logger,
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.11.5"
+version = "0.11.7"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "httpx[http2]>=0.28.1",
     "hypha-rpc>=0.21.40",
     "numpy==1.26.4",
+    "packaging>=21.0",
     "pyyaml>=6.0.2",
 ]
 

--- a/tests/test_artifact_version.py
+++ b/tests/test_artifact_version.py
@@ -1,16 +1,17 @@
 """
-Targeted test for artifact version commit behaviour.
+Targeted tests for ``upload_app`` artifact version handling.
 
-Verifies that upload_app commits the artifact under the version
-declared in manifest.yaml instead of always defaulting to "latest".
+The worker enforces strict version monotonicity on upload: the manifest
+``version`` must be strictly greater than every existing tag on the artifact.
+This file verifies four cases:
 
-Three cases are tested:
-1. New version tag → creates an isolated snapshot (previous versions intact)
-2. Re-saving the latest version → updates in place (no duplicate tag)
-3. Re-saving an older non-latest version → raises ValueError
+1. New artifact → committed under the manifest version tag.
+2. Bumping the version → both tags are independently readable.
+3. Re-saving the same version → rejected (would overwrite a published release).
+4. Saving an older version → rejected.
 
 Run with:
-    conda activate bioengine-worker
+    conda activate bioengine
     source .env
     pytest tests/test_artifact_version.py -v
 """
@@ -34,25 +35,23 @@ id: {artifact_id}
 id_emoji: "🧪"
 description: "Temporary app used to test artifact version commits"
 type: ray-serve
-format_version: 0.5.0
+format_version: 0.6.0
 version: {version}
+entry: test_dep:TestDep
 authors:
   - {{name: "Test"}}
 license: MIT
-deployments:
-  - test_dep:TestDep
 authorized_users:
   - "*"
 """
 
 DEPLOYMENT_SRC = """\
-from ray import serve
+import bioengine
 
-@serve.deployment(ray_actor_options={"num_cpus": 0, "num_gpus": 0, "memory": 128*1024**2, "runtime_env": {"pip": []}})
+
+@bioengine.app(ray_actor_options={"num_cpus": 0, "num_gpus": 0})
 class TestDep:
-    async def async_init(self): pass
-    async def test_deployment(self): pass
-    async def check_health(self): pass
+    pass
 """
 
 
@@ -108,13 +107,9 @@ async def test_upload_app_commits_manifest_version(worker, artifact_manager):
         saved_id = await worker.upload_app(files=_make_files(artifact_alias, test_version))
         assert saved_id == artifact_id, f"Unexpected artifact ID: {saved_id}"
 
-        # The artifact must be retrievable by its version tag
         artifact = await artifact_manager.read(artifact_id=artifact_id, version=test_version)
-        assert artifact is not None, "Artifact not found at expected version tag"
-        assert artifact.manifest.get("version") == test_version, (
-            f"Manifest version mismatch: expected {test_version!r}, "
-            f"got {artifact.manifest.get('version')!r}"
-        )
+        assert artifact is not None
+        assert artifact.manifest.get("version") == test_version
     finally:
         try:
             await artifact_manager.delete(artifact_id)
@@ -124,11 +119,7 @@ async def test_upload_app_commits_manifest_version(worker, artifact_manager):
 
 @pytest.mark.asyncio
 async def test_upload_app_new_version_creates_isolated_snapshot(worker, artifact_manager):
-    """Bumping the version in manifest.yaml creates a new isolated snapshot.
-
-    After saving v1 and then v2, both version tags must be independently
-    readable and reflect the manifest version they were saved with.
-    """
+    """Bumping the version creates a new isolated snapshot; old tag still readable."""
     artifact_alias = "version-bump-test-pytest"
     artifact_id = f"bioimage-io/{artifact_alias}"
     v1, v2 = "1.0.0", "1.1.0"
@@ -141,20 +132,14 @@ async def test_upload_app_new_version_creates_isolated_snapshot(worker, artifact
     try:
         await worker.upload_app(files=_make_files(artifact_alias, v1))
         a1 = await artifact_manager.read(artifact_id=artifact_id, version=v1)
-        assert a1 is not None, f"Artifact not found at version {v1}"
         assert a1.manifest.get("version") == v1
 
         await worker.upload_app(files=_make_files(artifact_alias, v2))
         a2 = await artifact_manager.read(artifact_id=artifact_id, version=v2)
-        assert a2 is not None, f"Artifact not found at version {v2}"
         assert a2.manifest.get("version") == v2
 
-        # v1 must still be independently readable
         a1_after = await artifact_manager.read(artifact_id=artifact_id, version=v1)
-        assert a1_after is not None, f"v1 disappeared after saving v2"
-        assert a1_after.manifest.get("version") == v1, (
-            f"v1 manifest was mutated after saving v2: got {a1_after.manifest.get('version')!r}"
-        )
+        assert a1_after.manifest.get("version") == v1
     finally:
         try:
             await artifact_manager.delete(artifact_id)
@@ -163,12 +148,8 @@ async def test_upload_app_new_version_creates_isolated_snapshot(worker, artifact
 
 
 @pytest.mark.asyncio
-async def test_upload_app_resave_latest_version_updates_inplace(worker, artifact_manager):
-    """Re-saving the same (latest) version updates the artifact in place.
-
-    No new version tag is created; the existing version tag reflects the
-    updated content.
-    """
+async def test_upload_app_resave_same_version_rejected(worker, artifact_manager):
+    """Re-saving the same version must be rejected (would overwrite a release)."""
     artifact_alias = "version-resave-pytest"
     artifact_id = f"bioimage-io/{artifact_alias}"
     version = "1.0.0"
@@ -180,12 +161,8 @@ async def test_upload_app_resave_latest_version_updates_inplace(worker, artifact
 
     try:
         await worker.upload_app(files=_make_files(artifact_alias, version))
-        # Re-saving the same version must not raise
-        await worker.upload_app(files=_make_files(artifact_alias, version))
-
-        artifact = await artifact_manager.read(artifact_id=artifact_id, version=version)
-        assert artifact is not None
-        assert artifact.manifest.get("version") == version
+        with pytest.raises(Exception, match=r"strictly greater|already exists"):
+            await worker.upload_app(files=_make_files(artifact_alias, version))
     finally:
         try:
             await artifact_manager.delete(artifact_id)
@@ -194,13 +171,9 @@ async def test_upload_app_resave_latest_version_updates_inplace(worker, artifact
 
 
 @pytest.mark.asyncio
-async def test_upload_app_resave_older_version_raises(worker, artifact_manager):
-    """Re-saving an older (non-latest) version must raise a ValueError.
-
-    Once a newer version exists, trying to overwrite an older version is
-    not supported by Hypha. The worker must surface a clear error.
-    """
-    artifact_alias = "version-older-resave-pytest"
+async def test_upload_app_older_version_rejected(worker, artifact_manager):
+    """Saving a lower version than the highest existing tag must be rejected."""
+    artifact_alias = "version-older-pytest"
     artifact_id = f"bioimage-io/{artifact_alias}"
     v1, v2 = "1.0.0", "1.1.0"
 
@@ -213,8 +186,7 @@ async def test_upload_app_resave_older_version_raises(worker, artifact_manager):
         await worker.upload_app(files=_make_files(artifact_alias, v1))
         await worker.upload_app(files=_make_files(artifact_alias, v2))
 
-        # Attempting to re-save v1 when v2 is the latest must raise
-        with pytest.raises(Exception, match=r"[Cc]annot re-save|newer version|already exists"):
+        with pytest.raises(Exception, match=r"strictly greater|already exists"):
             await worker.upload_app(files=_make_files(artifact_alias, v1))
     finally:
         try:

--- a/tests/test_artifact_version_guard.py
+++ b/tests/test_artifact_version_guard.py
@@ -1,0 +1,89 @@
+"""Unit tests for the version-monotonicity guard in stage_artifact.
+
+These tests exercise the pure helper ``_enforce_version_increases`` directly
+so they need no Hypha server. See ``test_artifact_version.py`` for the live
+end-to-end coverage of ``upload_app``.
+"""
+
+import pytest
+
+from bioengine.utils.artifact_utils import _enforce_version_increases
+
+
+def test_missing_version_rejected():
+    with pytest.raises(ValueError, match="missing a 'version' field"):
+        _enforce_version_increases(
+            new_version=None,
+            existing_versions=["1.0.0"],
+            artifact_id="ws/app",
+        )
+
+
+def test_empty_existing_versions_passes():
+    _enforce_version_increases(
+        new_version="0.0.1",
+        existing_versions=[],
+        artifact_id="ws/app",
+    )
+
+
+def test_strictly_greater_passes():
+    _enforce_version_increases(
+        new_version="1.1.0",
+        existing_versions=["1.0.0", "1.0.5"],
+        artifact_id="ws/app",
+    )
+
+
+def test_patch_bump_passes():
+    _enforce_version_increases(
+        new_version="1.0.6",
+        existing_versions=["1.0.5"],
+        artifact_id="ws/app",
+    )
+
+
+def test_equal_to_highest_rejected():
+    with pytest.raises(ValueError, match="strictly greater"):
+        _enforce_version_increases(
+            new_version="1.0.0",
+            existing_versions=["1.0.0"],
+            artifact_id="ws/app",
+        )
+
+
+def test_lower_than_highest_rejected():
+    with pytest.raises(ValueError, match="strictly greater"):
+        _enforce_version_increases(
+            new_version="0.9.0",
+            existing_versions=["1.0.0", "1.1.0"],
+            artifact_id="ws/app",
+        )
+
+
+def test_highest_is_not_last_in_list():
+    """List order doesn't matter — comparison is against the parsed max."""
+    with pytest.raises(ValueError, match="strictly greater"):
+        _enforce_version_increases(
+            new_version="1.1.0",
+            existing_versions=["1.2.0", "1.0.0"],
+            artifact_id="ws/app",
+        )
+
+
+def test_non_pep440_exact_match_rejected():
+    with pytest.raises(ValueError, match="already exists"):
+        _enforce_version_increases(
+            new_version="demo",
+            existing_versions=["demo", "v2"],
+            artifact_id="ws/app",
+        )
+
+
+def test_non_pep440_different_string_passes():
+    """If parsing fails and the new tag isn't an exact match, accept it."""
+    _enforce_version_increases(
+        new_version="rc-3",
+        existing_versions=["demo", "v2"],
+        artifact_id="ws/app",
+    )


### PR DESCRIPTION
## Problem

`upload_app` accepted re-saves of the latest manifest version, silently
updating the snapshot in place. A maintainer could overwrite a
published release without leaving a trail, and consumers pinned to that
version tag would silently get different code.

## Solution

`stage_artifact` now requires the manifest version to be **strictly
greater** than every existing tag on the artifact (PEP 440 ordering).
Same or lower versions are rejected with a clear error pointing to the
manifest.yaml field that needs to be bumped.

`stage_artifact` always branches a fresh version snapshot and no longer
returns the `version_is_new` flag; the caller commits with the manifest
version unconditionally. The behaviour for brand-new artifacts is
unchanged. PEP-440-unparseable strings (e.g. `"demo"`, `"rc-3"`) fall
back to a strict exact-match check.

## Migration note

Apps that previously relied on re-uploading the same version (e.g. the
in-repo `demo-app` / `composition-demo` convention of "always keep
version at 1.0.0") must now bump the manifest version on each upload.
This convention should be updated alongside the next change to those
apps.

## Files

| File | Change |
|---|---|
| `bioengine/utils/artifact_utils.py` | Add `_enforce_version_increases` helper; call it from `stage_artifact`; drop the `version_is_new` return tuple and always tag the commit with the manifest version. |
| `pyproject.toml` | Add `packaging>=21.0` to base dependencies (used by the helper; previously pulled in transitively via Ray). |
| `tests/test_artifact_version.py` | Update live-worker tests to assert the new strict-monotonicity behaviour; refresh manifest to `format_version: 0.6.0`. |
| `tests/test_artifact_version_guard.py` *(new)* | Pure unit tests for `_enforce_version_increases` (9 cases). |

## Test plan

- [x] Unit tests pass for the helper (verified locally — 9/9 cases).
- [ ] CI: `pytest tests/test_artifact_version_guard.py` (no env deps).
- [ ] Live worker: `pytest tests/test_artifact_version.py` (asserts the worker accepts a bump, rejects a re-save, rejects an older version).