### PR TITLE
feat(apps): enrich list_app_directories + fix layout drift

### DIFF
--- a/bioengine/apps/_cache_fs_tasks.py
+++ b/bioengine/apps/_cache_fs_tasks.py
@@ -1,0 +1,128 @@
+"""Module-level Ray-task helpers for the app cache API.
+
+Kept in a separate module so the Ray Client server can re-import them by
+reference without pulling in the heavy ``bioengine.apps.manager`` namespace
+(which depends on ``haikunator``, ``hypha_rpc``, ``ray.serve``, etc., not
+guaranteed to be installed in the Ray Client server's base venv).
+
+Imports here must stay limited to Python stdlib.
+"""
+
+from __future__ import annotations
+
+
+def fs_probe_write(apps_workdir: str, marker_name: str, content: str) -> bool:
+    """Write a marker file in ``apps_workdir`` so peer nodes can probe it."""
+    from pathlib import Path
+
+    p = Path(apps_workdir)
+    p.mkdir(parents=True, exist_ok=True)
+    (p / marker_name).write_text(content)
+    return True
+
+
+def fs_probe_read(apps_workdir: str, marker_name: str, expected: str) -> bool:
+    """True iff this node sees the marker file with the expected bytes."""
+    from pathlib import Path
+
+    try:
+        return (Path(apps_workdir) / marker_name).read_text() == expected
+    except (FileNotFoundError, OSError):
+        return False
+
+
+def fs_probe_delete(apps_workdir: str, marker_name: str) -> bool:
+    """Remove the marker file if present (idempotent)."""
+    from pathlib import Path
+
+    try:
+        (Path(apps_workdir) / marker_name).unlink()
+        return True
+    except FileNotFoundError:
+        return False
+
+
+def list_dirs_on_node(
+    apps_workdir_str: str,
+    prefix: str,
+    running_ids: list,
+    node_id: str,
+) -> list:
+    """Walk ``apps_workdir`` on this Ray node, returning per-directory stats."""
+    from pathlib import Path
+
+    apps_workdir = Path(apps_workdir_str)
+    if not apps_workdir.exists():
+        return []
+    running_set = set(running_ids)
+    result = []
+    for entry in sorted(apps_workdir.iterdir()):
+        if not entry.is_dir():
+            continue
+        size = 0
+        latest_mtime = None
+        for f in entry.rglob("*"):
+            if not f.is_file():
+                continue
+            try:
+                st = f.stat()
+            except OSError:
+                continue
+            size += st.st_size
+            if latest_mtime is None or st.st_mtime > latest_mtime:
+                latest_mtime = st.st_mtime
+        application_id = (
+            entry.name[len(prefix):] if entry.name.startswith(prefix) else None
+        )
+        result.append(
+            {
+                "name": entry.name,
+                "application_id": application_id,
+                "path": str(entry),
+                "is_running": application_id in running_set if application_id else False,
+                "size_bytes": size,
+                "last_used_unix": latest_mtime,
+                "node_id": node_id,
+            }
+        )
+    return result
+
+
+def clear_dir_on_node(
+    apps_workdir_str: str,
+    worker_workspace: str,
+    application_id: str,
+    node_id: str,
+) -> dict:
+    """Remove the app cache directory on this Ray node if present."""
+    import shutil
+    from pathlib import Path
+
+    apps_workdir = Path(apps_workdir_str)
+    prefixed = apps_workdir / f"{worker_workspace}-{application_id}"
+    bare = apps_workdir / application_id
+    target = prefixed if prefixed.exists() else bare
+    if not target.exists():
+        return {
+            "ok": False,
+            "error": "not_found",
+            "path": str(target),
+            "node_id": node_id,
+        }
+    if not target.is_dir():
+        return {
+            "ok": False,
+            "error": "not_a_dir",
+            "path": str(target),
+            "node_id": node_id,
+        }
+    try:
+        shutil.rmtree(target)
+    except Exception as e:
+        return {
+            "ok": False,
+            "error": f"rmtree_failed: {e}",
+            "path": str(target),
+            "node_id": node_id,
+        }
+    return {"ok": True, "error": None, "path": str(target), "node_id": node_id}

--- a/bioengine/apps/manager.py
+++ b/bioengine/apps/manager.py
@@ -1281,6 +1281,20 @@ class AppsManager:
 
         return created_artifact_id
 
+    def _resolve_app_directory(self, application_id: str) -> Path:
+        """Return the on-disk cache directory for ``application_id``.
+
+        Prefers the v0.11.4+ ``<worker-workspace>-<app-id>`` layout; falls
+        back to a bare ``<app-id>`` directory for compatibility with caches
+        left over from earlier worker releases.
+        """
+        apps_workdir = self.app_builder.apps_workdir
+        worker_workspace = self.server.config.workspace if self.server else "local"
+        prefixed = apps_workdir / f"{worker_workspace}-{application_id}"
+        if prefixed.exists():
+            return prefixed
+        return apps_workdir / application_id
+
     @schema_method
     async def list_app_directories(
         self,
@@ -1293,14 +1307,21 @@ class AppsManager:
         Lists all application working directories under the BioEngine apps workspace.
 
         Returns one entry per subdirectory found under the apps working directory,
-        including whether that directory belongs to a currently running application.
+        including the resolved application_id (when the directory follows the
+        ``<worker-workspace>-<app-id>`` layout), total size on disk, the latest
+        file modification time (a proxy for "last used"), and whether the
+        directory belongs to a currently running application.
 
         Returns:
             List of dictionaries, each with:
-            - name: directory name (matches application_id for deployed apps)
+            - name: directory name as it exists on disk
+            - application_id: the deployment id (worker-workspace prefix stripped),
+              or None for legacy or unrecognised directories
             - path: absolute path to the directory
-            - is_running: True if the directory belongs to a currently running app
+            - is_running: True if a currently running app maps to this directory
             - size_bytes: total disk usage of the directory in bytes
+            - last_used_unix: the most recent file mtime in the tree, as a
+              Unix timestamp (float seconds). None if the directory is empty.
 
         Raises:
             PermissionError: If the caller is not a worker admin
@@ -1323,17 +1344,40 @@ class AppsManager:
             if info["is_deployed"].is_set()
         }
 
+        worker_workspace = self.server.config.workspace if self.server else "local"
+        prefix = f"{worker_workspace}-"
+
         result = []
         for entry in sorted(apps_workdir.iterdir()):
             if not entry.is_dir():
                 continue
-            size = sum(f.stat().st_size for f in entry.rglob("*") if f.is_file())
+
+            size = 0
+            latest_mtime: Optional[float] = None
+            for f in entry.rglob("*"):
+                if not f.is_file():
+                    continue
+                try:
+                    st = f.stat()
+                except OSError:
+                    continue
+                size += st.st_size
+                if latest_mtime is None or st.st_mtime > latest_mtime:
+                    latest_mtime = st.st_mtime
+
+            if entry.name.startswith(prefix):
+                application_id = entry.name[len(prefix):]
+            else:
+                application_id = None
+
             result.append(
                 {
                     "name": entry.name,
+                    "application_id": application_id,
                     "path": str(entry),
-                    "is_running": entry.name in running,
+                    "is_running": application_id in running if application_id else False,
                     "size_bytes": size,
+                    "last_used_unix": latest_mtime,
                 }
             )
         return result
@@ -1343,7 +1387,7 @@ class AppsManager:
         self,
         application_id: str = Field(
             ...,
-            description="Application ID whose working directory should be deleted. Must match a subdirectory of the apps workspace (e.g. 'model-runner').",
+            description="Application ID whose working directory should be deleted (e.g. 'model-runner'). Resolves to the worker-workspace-prefixed directory created by the builder, with a fallback to a bare directory name for legacy layouts.",
         ),
         context: Dict[str, Any] = Field(
             ...,
@@ -1353,12 +1397,15 @@ class AppsManager:
         """
         Deletes an application working directory from the BioEngine apps workspace.
 
-        The directory is identified by application_id (as returned in the 'name' field
-        of list_app_directories). Raises an error if the application is currently running —
-        stop it first with stop_app() before clearing its directory.
+        Raises an error if the application is currently running — stop it first
+        with stop_app() before clearing its directory.
 
         Args:
-            application_id: ID of the application whose directory should be deleted (e.g. "model-runner").
+            application_id: Deployment id (e.g. ``"model-runner"``). The worker
+                resolves the actual on-disk directory using its own workspace
+                prefix (``<worker-workspace>-<application_id>``); a bare
+                ``<application_id>`` directory is accepted as a fallback for
+                caches created by earlier worker releases.
 
         Raises:
             PermissionError: If the caller is not a worker admin
@@ -1378,14 +1425,6 @@ class AppsManager:
                 f"application_id must be a plain name, not a path: '{application_id}'"
             )
 
-        target = self.app_builder.apps_workdir / application_id
-        if not target.exists():
-            raise ValueError(
-                f"No directory found for application '{application_id}' in the apps workspace."
-            )
-        if not target.is_dir():
-            raise ValueError(f"'{application_id}' is not a directory.")
-
         # Refuse if the app is currently running
         if application_id in self._deployed_applications:
             info = self._deployed_applications[application_id]
@@ -1394,6 +1433,14 @@ class AppsManager:
                     f"Cannot clear directory for '{application_id}': application is currently running. "
                     "Stop it first with stop_app()."
                 )
+
+        target = self._resolve_app_directory(application_id)
+        if not target.exists():
+            raise ValueError(
+                f"No directory found for application '{application_id}' in the apps workspace."
+            )
+        if not target.is_dir():
+            raise ValueError(f"'{application_id}' is not a directory.")
 
         import shutil
         try:

--- a/bioengine/apps/manager.py
+++ b/bioengine/apps/manager.py
@@ -70,117 +70,18 @@ def _belongs_to_worker_workspace(
     return True
 
 
-# ───────────────────── Ray-task helpers for the app cache API ─────────────────
-# These run inside Ray tasks pinned to specific nodes (via
-# NodeAffinitySchedulingStrategy), so they must be plain module-level
-# functions that don't close over the AppsManager instance.
-
-
-def _fs_probe_write(apps_workdir: str, marker_name: str, content: str) -> bool:
-    """Write a marker file in ``apps_workdir`` so peer nodes can probe it."""
-    from pathlib import Path
-
-    p = Path(apps_workdir)
-    p.mkdir(parents=True, exist_ok=True)
-    (p / marker_name).write_text(content)
-    return True
-
-
-def _fs_probe_read(apps_workdir: str, marker_name: str, expected: str) -> bool:
-    """True iff this node sees the marker file with the expected bytes."""
-    from pathlib import Path
-
-    try:
-        return (Path(apps_workdir) / marker_name).read_text() == expected
-    except (FileNotFoundError, OSError):
-        return False
-
-
-def _fs_probe_delete(apps_workdir: str, marker_name: str) -> bool:
-    """Remove the marker file if present (idempotent)."""
-    from pathlib import Path
-
-    try:
-        (Path(apps_workdir) / marker_name).unlink()
-        return True
-    except FileNotFoundError:
-        return False
-
-
-def _list_dirs_on_node(
-    apps_workdir_str: str,
-    prefix: str,
-    running_ids: list,
-    node_id: str,
-) -> list:
-    """Walk ``apps_workdir`` on this Ray node, returning per-directory stats."""
-    from pathlib import Path
-
-    apps_workdir = Path(apps_workdir_str)
-    if not apps_workdir.exists():
-        return []
-    running_set = set(running_ids)
-    result = []
-    for entry in sorted(apps_workdir.iterdir()):
-        if not entry.is_dir():
-            continue
-        size = 0
-        latest_mtime = None
-        for f in entry.rglob("*"):
-            if not f.is_file():
-                continue
-            try:
-                st = f.stat()
-            except OSError:
-                continue
-            size += st.st_size
-            if latest_mtime is None or st.st_mtime > latest_mtime:
-                latest_mtime = st.st_mtime
-        application_id = (
-            entry.name[len(prefix):] if entry.name.startswith(prefix) else None
-        )
-        result.append(
-            {
-                "name": entry.name,
-                "application_id": application_id,
-                "path": str(entry),
-                "is_running": application_id in running_set if application_id else False,
-                "size_bytes": size,
-                "last_used_unix": latest_mtime,
-                "node_id": node_id,
-            }
-        )
-    return result
-
-
-def _clear_dir_on_node(
-    apps_workdir_str: str,
-    worker_workspace: str,
-    application_id: str,
-    node_id: str,
-) -> dict:
-    """Remove the app cache directory on this Ray node if present."""
-    import shutil
-    from pathlib import Path
-
-    apps_workdir = Path(apps_workdir_str)
-    prefixed = apps_workdir / f"{worker_workspace}-{application_id}"
-    bare = apps_workdir / application_id
-    target = prefixed if prefixed.exists() else bare
-    if not target.exists():
-        return {"ok": False, "error": "not_found", "path": str(target), "node_id": node_id}
-    if not target.is_dir():
-        return {"ok": False, "error": "not_a_dir", "path": str(target), "node_id": node_id}
-    try:
-        shutil.rmtree(target)
-    except Exception as e:
-        return {
-            "ok": False,
-            "error": f"rmtree_failed: {e}",
-            "path": str(target),
-            "node_id": node_id,
-        }
-    return {"ok": True, "error": None, "path": str(target), "node_id": node_id}
+# Ray-task helpers for the app cache API live in a stdlib-only sibling
+# module: the Ray Client server unpickles ``ray.remote(fn)`` references by
+# re-importing the function's module, and the manager namespace pulls in
+# haikunator / hypha_rpc / ray.serve which the Ray Client server's base
+# venv doesn't have. Keeping the helpers in their own module sidesteps that.
+from bioengine.apps._cache_fs_tasks import (
+    clear_dir_on_node as _clear_dir_on_node,
+    fs_probe_delete as _fs_probe_delete,
+    fs_probe_read as _fs_probe_read,
+    fs_probe_write as _fs_probe_write,
+    list_dirs_on_node as _list_dirs_on_node,
+)
 
 
 class AppsManager:

--- a/bioengine/apps/manager.py
+++ b/bioengine/apps/manager.py
@@ -10,6 +10,7 @@ from hypha_rpc import connect_to_server
 from hypha_rpc.rpc import RemoteService
 from hypha_rpc.utils.schema import schema_method
 from pydantic import Field
+import ray
 from ray import serve
 
 from bioengine import __version__
@@ -1281,20 +1282,6 @@ class AppsManager:
 
         return created_artifact_id
 
-    def _resolve_app_directory(self, application_id: str) -> Path:
-        """Return the on-disk cache directory for ``application_id``.
-
-        Prefers the v0.11.4+ ``<worker-workspace>-<app-id>`` layout; falls
-        back to a bare ``<app-id>`` directory for compatibility with caches
-        left over from earlier worker releases.
-        """
-        apps_workdir = self.app_builder.apps_workdir
-        worker_workspace = self.server.config.workspace if self.server else "local"
-        prefixed = apps_workdir / f"{worker_workspace}-{application_id}"
-        if prefixed.exists():
-            return prefixed
-        return apps_workdir / application_id
-
     @schema_method
     async def list_app_directories(
         self,
@@ -1306,18 +1293,20 @@ class AppsManager:
         """
         Lists all application working directories under the BioEngine apps workspace.
 
-        Returns one entry per subdirectory found under the apps working directory,
-        including the resolved application_id (when the directory follows the
-        ``<worker-workspace>-<app-id>`` layout), total size on disk, the latest
-        file modification time (a proxy for "last used"), and whether the
-        directory belongs to a currently running application.
+        In v0.11.4+ the worker pod is filesystem-thin — app caches live on the
+        Ray actor pods, not on the worker. This call dispatches a tiny Ray task
+        that walks ``apps_workdir`` on whichever Ray node it lands on and
+        reports per-directory size + latest mtime + the resolved
+        ``application_id`` (the ``<worker-workspace>-`` prefix the builder
+        adds is stripped). Within a single Ray cluster all nodes mount the
+        same NFS PVC at ``apps_workdir``, so one task suffices.
 
         Returns:
             List of dictionaries, each with:
             - name: directory name as it exists on disk
             - application_id: the deployment id (worker-workspace prefix stripped),
               or None for legacy or unrecognised directories
-            - path: absolute path to the directory
+            - path: absolute path to the directory on the Ray actor pod
             - is_running: True if a currently running app maps to this directory
             - size_bytes: total disk usage of the directory in bytes
             - last_used_unix: the most recent file mtime in the tree, as a
@@ -1334,53 +1323,59 @@ class AppsManager:
             resource_name="listing app directories",
         )
 
-        apps_workdir = self.app_builder.apps_workdir
-        if not apps_workdir.exists():
-            return []
-
-        running = {
+        running = sorted(
             app_id
             for app_id, info in self._deployed_applications.items()
             if info["is_deployed"].is_set()
-        }
-
+        )
         worker_workspace = self.server.config.workspace if self.server else "local"
-        prefix = f"{worker_workspace}-"
+        apps_workdir = str(self.app_builder.apps_workdir)
 
-        result = []
-        for entry in sorted(apps_workdir.iterdir()):
-            if not entry.is_dir():
-                continue
+        @ray.remote(num_cpus=0)
+        def _list_dirs(apps_workdir_str: str, prefix: str, running_ids: list) -> list:
+            from pathlib import Path
 
-            size = 0
-            latest_mtime: Optional[float] = None
-            for f in entry.rglob("*"):
-                if not f.is_file():
+            apps_workdir = Path(apps_workdir_str)
+            if not apps_workdir.exists():
+                return []
+            running_set = set(running_ids)
+            result = []
+            for entry in sorted(apps_workdir.iterdir()):
+                if not entry.is_dir():
                     continue
-                try:
-                    st = f.stat()
-                except OSError:
-                    continue
-                size += st.st_size
-                if latest_mtime is None or st.st_mtime > latest_mtime:
-                    latest_mtime = st.st_mtime
+                size = 0
+                latest_mtime = None
+                for f in entry.rglob("*"):
+                    if not f.is_file():
+                        continue
+                    try:
+                        st = f.stat()
+                    except OSError:
+                        continue
+                    size += st.st_size
+                    if latest_mtime is None or st.st_mtime > latest_mtime:
+                        latest_mtime = st.st_mtime
+                application_id = (
+                    entry.name[len(prefix):] if entry.name.startswith(prefix) else None
+                )
+                result.append(
+                    {
+                        "name": entry.name,
+                        "application_id": application_id,
+                        "path": str(entry),
+                        "is_running": application_id in running_set
+                        if application_id
+                        else False,
+                        "size_bytes": size,
+                        "last_used_unix": latest_mtime,
+                    }
+                )
+            return result
 
-            if entry.name.startswith(prefix):
-                application_id = entry.name[len(prefix):]
-            else:
-                application_id = None
-
-            result.append(
-                {
-                    "name": entry.name,
-                    "application_id": application_id,
-                    "path": str(entry),
-                    "is_running": application_id in running if application_id else False,
-                    "size_bytes": size,
-                    "last_used_unix": latest_mtime,
-                }
-            )
-        return result
+        return await asyncio.to_thread(
+            ray.get,
+            _list_dirs.remote(apps_workdir, f"{worker_workspace}-", running),
+        )
 
     @schema_method
     async def clear_app_directory(
@@ -1397,8 +1392,10 @@ class AppsManager:
         """
         Deletes an application working directory from the BioEngine apps workspace.
 
-        Raises an error if the application is currently running — stop it first
-        with stop_app() before clearing its directory.
+        Routes through a Ray task because the cache lives on the Ray actor
+        pods, not on the worker (see ``list_app_directories``). Raises an
+        error if the application is currently running — stop it first with
+        ``stop_app()`` before clearing its directory.
 
         Args:
             application_id: Deployment id (e.g. ``"model-runner"``). The worker
@@ -1434,21 +1431,44 @@ class AppsManager:
                     "Stop it first with stop_app()."
                 )
 
-        target = self._resolve_app_directory(application_id)
-        if not target.exists():
-            raise ValueError(
-                f"No directory found for application '{application_id}' in the apps workspace."
+        apps_workdir = str(self.app_builder.apps_workdir)
+        worker_workspace = self.server.config.workspace if self.server else "local"
+
+        @ray.remote(num_cpus=0)
+        def _clear_dir(apps_workdir_str: str, worker_workspace: str, app_id: str) -> dict:
+            import shutil
+            from pathlib import Path
+
+            apps_workdir = Path(apps_workdir_str)
+            prefixed = apps_workdir / f"{worker_workspace}-{app_id}"
+            bare = apps_workdir / app_id
+            target = prefixed if prefixed.exists() else bare
+            if not target.exists():
+                return {"ok": False, "error": "not_found", "path": str(target)}
+            if not target.is_dir():
+                return {"ok": False, "error": "not_a_dir", "path": str(target)}
+            try:
+                shutil.rmtree(target)
+            except Exception as e:
+                return {"ok": False, "error": f"rmtree_failed: {e}", "path": str(target)}
+            return {"ok": True, "path": str(target)}
+
+        result = await asyncio.to_thread(
+            ray.get,
+            _clear_dir.remote(apps_workdir, worker_workspace, application_id),
+        )
+        if not result["ok"]:
+            if result["error"] == "not_found":
+                raise ValueError(
+                    f"No directory found for application '{application_id}' in the apps workspace."
+                )
+            if result["error"] == "not_a_dir":
+                raise ValueError(f"'{application_id}' is not a directory.")
+            raise RuntimeError(
+                f"Failed to delete directory for '{application_id}': {result['error']}"
             )
-        if not target.is_dir():
-            raise ValueError(f"'{application_id}' is not a directory.")
 
-        import shutil
-        try:
-            shutil.rmtree(target)
-        except Exception as e:
-            raise RuntimeError(f"Failed to delete directory for '{application_id}': {e}")
-
-        self.logger.info(f"Cleared app directory: {target}")
+        self.logger.info(f"Cleared app directory: {result['path']}")
 
     @schema_method
     async def list_apps(

--- a/bioengine/apps/manager.py
+++ b/bioengine/apps/manager.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import os
 import time
+import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
@@ -67,6 +68,119 @@ def _belongs_to_worker_workspace(
         )
         return False
     return True
+
+
+# ───────────────────── Ray-task helpers for the app cache API ─────────────────
+# These run inside Ray tasks pinned to specific nodes (via
+# NodeAffinitySchedulingStrategy), so they must be plain module-level
+# functions that don't close over the AppsManager instance.
+
+
+def _fs_probe_write(apps_workdir: str, marker_name: str, content: str) -> bool:
+    """Write a marker file in ``apps_workdir`` so peer nodes can probe it."""
+    from pathlib import Path
+
+    p = Path(apps_workdir)
+    p.mkdir(parents=True, exist_ok=True)
+    (p / marker_name).write_text(content)
+    return True
+
+
+def _fs_probe_read(apps_workdir: str, marker_name: str, expected: str) -> bool:
+    """True iff this node sees the marker file with the expected bytes."""
+    from pathlib import Path
+
+    try:
+        return (Path(apps_workdir) / marker_name).read_text() == expected
+    except (FileNotFoundError, OSError):
+        return False
+
+
+def _fs_probe_delete(apps_workdir: str, marker_name: str) -> bool:
+    """Remove the marker file if present (idempotent)."""
+    from pathlib import Path
+
+    try:
+        (Path(apps_workdir) / marker_name).unlink()
+        return True
+    except FileNotFoundError:
+        return False
+
+
+def _list_dirs_on_node(
+    apps_workdir_str: str,
+    prefix: str,
+    running_ids: list,
+    node_id: str,
+) -> list:
+    """Walk ``apps_workdir`` on this Ray node, returning per-directory stats."""
+    from pathlib import Path
+
+    apps_workdir = Path(apps_workdir_str)
+    if not apps_workdir.exists():
+        return []
+    running_set = set(running_ids)
+    result = []
+    for entry in sorted(apps_workdir.iterdir()):
+        if not entry.is_dir():
+            continue
+        size = 0
+        latest_mtime = None
+        for f in entry.rglob("*"):
+            if not f.is_file():
+                continue
+            try:
+                st = f.stat()
+            except OSError:
+                continue
+            size += st.st_size
+            if latest_mtime is None or st.st_mtime > latest_mtime:
+                latest_mtime = st.st_mtime
+        application_id = (
+            entry.name[len(prefix):] if entry.name.startswith(prefix) else None
+        )
+        result.append(
+            {
+                "name": entry.name,
+                "application_id": application_id,
+                "path": str(entry),
+                "is_running": application_id in running_set if application_id else False,
+                "size_bytes": size,
+                "last_used_unix": latest_mtime,
+                "node_id": node_id,
+            }
+        )
+    return result
+
+
+def _clear_dir_on_node(
+    apps_workdir_str: str,
+    worker_workspace: str,
+    application_id: str,
+    node_id: str,
+) -> dict:
+    """Remove the app cache directory on this Ray node if present."""
+    import shutil
+    from pathlib import Path
+
+    apps_workdir = Path(apps_workdir_str)
+    prefixed = apps_workdir / f"{worker_workspace}-{application_id}"
+    bare = apps_workdir / application_id
+    target = prefixed if prefixed.exists() else bare
+    if not target.exists():
+        return {"ok": False, "error": "not_found", "path": str(target), "node_id": node_id}
+    if not target.is_dir():
+        return {"ok": False, "error": "not_a_dir", "path": str(target), "node_id": node_id}
+    try:
+        shutil.rmtree(target)
+    except Exception as e:
+        return {
+            "ok": False,
+            "error": f"rmtree_failed: {e}",
+            "path": str(target),
+            "node_id": node_id,
+        }
+    return {"ok": True, "error": None, "path": str(target), "node_id": node_id}
 
 
 class AppsManager:
@@ -194,6 +308,12 @@ class AppsManager:
         self.worker_service_id = None
         self._deployment_lock = asyncio.Lock()
         self._deployed_applications = {}
+
+        # Cache the result of the one-time FS-topology probe across Ray
+        # nodes. None until the first list/clear-cache call from the
+        # dashboard triggers the probe; never re-runs automatically.
+        self._fs_topology_mode: Optional[str] = None  # "shared" | "per_node"
+        self._fs_topology_lock = asyncio.Lock()
         self.debug = debug
 
     def _check_initialized(self) -> None:
@@ -1282,6 +1402,80 @@ class AppsManager:
 
         return created_artifact_id
 
+    async def _detect_fs_topology(self) -> str:
+        """One-time probe: do all Ray nodes share ``apps_workdir`` on disk?
+
+        Writes a unique marker file on one node, reads it from a Ray task on
+        every other live node, and infers ``"shared"`` iff every node sees
+        the same bytes. Falls back to ``"per_node"`` if any read disagrees
+        or fails. Cleans up the marker on all nodes regardless of outcome.
+
+        The result is cached for the AppsManager's lifetime — the probe is
+        only triggered lazily by the first ``list_app_directories`` or
+        ``clear_app_directory`` call from the dashboard, never at worker
+        startup or anywhere else.
+        """
+        if self._fs_topology_mode is not None:
+            return self._fs_topology_mode
+        async with self._fs_topology_lock:
+            if self._fs_topology_mode is not None:
+                return self._fs_topology_mode
+
+            from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
+
+            apps_workdir = str(self.app_builder.apps_workdir)
+            alive_nodes = [n for n in ray.nodes() if n.get("Alive")]
+            alive_node_ids = [n["NodeID"] for n in alive_nodes]
+
+            if len(alive_node_ids) <= 1:
+                self._fs_topology_mode = "shared"
+                self.logger.info(
+                    f"FS topology: single Ray node ⇒ shared (trivially)."
+                )
+                return self._fs_topology_mode
+
+            marker_name = f".bioengine_fs_probe_{uuid.uuid4().hex}.txt"
+            marker_content = uuid.uuid4().hex
+
+            def _affinity(node_id: str):
+                return NodeAffinitySchedulingStrategy(node_id=node_id, soft=False)
+
+            try:
+                write_ref = ray.remote(num_cpus=0)(
+                    _fs_probe_write
+                ).options(scheduling_strategy=_affinity(alive_node_ids[0])).remote(
+                    apps_workdir, marker_name, marker_content
+                )
+                await asyncio.to_thread(ray.get, write_ref)
+
+                read_refs = [
+                    ray.remote(num_cpus=0)(_fs_probe_read)
+                    .options(scheduling_strategy=_affinity(nid))
+                    .remote(apps_workdir, marker_name, marker_content)
+                    for nid in alive_node_ids
+                ]
+                read_results = await asyncio.to_thread(ray.get, read_refs)
+                mode = "shared" if all(read_results) else "per_node"
+            finally:
+                cleanup_refs = [
+                    ray.remote(num_cpus=0)(_fs_probe_delete)
+                    .options(scheduling_strategy=_affinity(nid))
+                    .remote(apps_workdir, marker_name)
+                    for nid in alive_node_ids
+                ]
+                try:
+                    await asyncio.to_thread(ray.get, cleanup_refs)
+                except Exception as exc:
+                    self.logger.warning(
+                        f"FS probe marker cleanup raised (continuing): {exc}"
+                    )
+
+            self._fs_topology_mode = mode
+            self.logger.info(
+                f"FS topology probe across {len(alive_node_ids)} Ray nodes ⇒ {mode}."
+            )
+            return mode
+
     @schema_method
     async def list_app_directories(
         self,
@@ -1293,13 +1487,19 @@ class AppsManager:
         """
         Lists all application working directories under the BioEngine apps workspace.
 
-        In v0.11.4+ the worker pod is filesystem-thin — app caches live on the
-        Ray actor pods, not on the worker. This call dispatches a tiny Ray task
-        that walks ``apps_workdir`` on whichever Ray node it lands on and
-        reports per-directory size + latest mtime + the resolved
-        ``application_id`` (the ``<worker-workspace>-`` prefix the builder
-        adds is stripped). Within a single Ray cluster all nodes mount the
-        same NFS PVC at ``apps_workdir``, so one task suffices.
+        In v0.11.4+ the worker pod is filesystem-thin — app caches live on
+        the Ray actor pods, not on the worker. The first call probes whether
+        ``apps_workdir`` is shared across every Ray node (NFS RWX) or
+        per-node (local disk), caches the result, then:
+
+        - **shared FS**: dispatches one Ray task on any node and returns
+          its entries directly.
+        - **per-node FS**: dispatches one Ray task per Ray node, tags each
+          entry with the source node, and returns the union (so the same
+          ``application_id`` can appear once per node that cached it).
+
+        This call is meant to be invoked on-demand from the BioEngine
+        dashboard. The worker never runs it automatically.
 
         Returns:
             List of dictionaries, each with:
@@ -1311,6 +1511,8 @@ class AppsManager:
             - size_bytes: total disk usage of the directory in bytes
             - last_used_unix: the most recent file mtime in the tree, as a
               Unix timestamp (float seconds). None if the directory is empty.
+            - node_id: Ray node ID where this entry was observed (useful in
+              per-node FS topologies; identifies which node holds the cache).
 
         Raises:
             PermissionError: If the caller is not a worker admin
@@ -1330,52 +1532,36 @@ class AppsManager:
         )
         worker_workspace = self.server.config.workspace if self.server else "local"
         apps_workdir = str(self.app_builder.apps_workdir)
+        prefix = f"{worker_workspace}-"
 
-        @ray.remote(num_cpus=0)
-        def _list_dirs(apps_workdir_str: str, prefix: str, running_ids: list) -> list:
-            from pathlib import Path
+        mode = await self._detect_fs_topology()
+        from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
-            apps_workdir = Path(apps_workdir_str)
-            if not apps_workdir.exists():
-                return []
-            running_set = set(running_ids)
-            result = []
-            for entry in sorted(apps_workdir.iterdir()):
-                if not entry.is_dir():
-                    continue
-                size = 0
-                latest_mtime = None
-                for f in entry.rglob("*"):
-                    if not f.is_file():
-                        continue
-                    try:
-                        st = f.stat()
-                    except OSError:
-                        continue
-                    size += st.st_size
-                    if latest_mtime is None or st.st_mtime > latest_mtime:
-                        latest_mtime = st.st_mtime
-                application_id = (
-                    entry.name[len(prefix):] if entry.name.startswith(prefix) else None
+        alive_nodes = [n for n in ray.nodes() if n.get("Alive")]
+        if not alive_nodes:
+            return []
+
+        if mode == "shared":
+            target_nodes = [alive_nodes[0]]
+        else:
+            target_nodes = alive_nodes
+
+        refs = [
+            ray.remote(num_cpus=0)(_list_dirs_on_node)
+            .options(
+                scheduling_strategy=NodeAffinitySchedulingStrategy(
+                    node_id=n["NodeID"], soft=False
                 )
-                result.append(
-                    {
-                        "name": entry.name,
-                        "application_id": application_id,
-                        "path": str(entry),
-                        "is_running": application_id in running_set
-                        if application_id
-                        else False,
-                        "size_bytes": size,
-                        "last_used_unix": latest_mtime,
-                    }
-                )
-            return result
-
-        return await asyncio.to_thread(
-            ray.get,
-            _list_dirs.remote(apps_workdir, f"{worker_workspace}-", running),
-        )
+            )
+            .remote(apps_workdir, prefix, running, n["NodeID"])
+            for n in target_nodes
+        ]
+        per_node_results = await asyncio.to_thread(ray.get, refs)
+        merged: List[Dict[str, Any]] = []
+        for chunk in per_node_results:
+            merged.extend(chunk)
+        merged.sort(key=lambda e: (e["name"], e.get("node_id") or ""))
+        return merged
 
     @schema_method
     async def clear_app_directory(
@@ -1388,14 +1574,18 @@ class AppsManager:
             ...,
             description="Authentication context containing user information, automatically provided by Hypha during service calls.",
         ),
-    ) -> None:
+    ) -> Dict[str, Any]:
         """
         Deletes an application working directory from the BioEngine apps workspace.
 
-        Routes through a Ray task because the cache lives on the Ray actor
-        pods, not on the worker (see ``list_app_directories``). Raises an
-        error if the application is currently running — stop it first with
-        ``stop_app()`` before clearing its directory.
+        Routes through Ray tasks because the cache lives on the Ray actor
+        pods, not on the worker (see ``list_app_directories``). On shared
+        FS the deletion runs once on any node; on per-node FS it fans out
+        to every node and deletes the directory wherever it exists.
+
+        Refuses to delete if the application is currently running — stop it
+        first with ``stop_app()``. Meant to be invoked on-demand from the
+        BioEngine dashboard; the worker never runs it automatically.
 
         Args:
             application_id: Deployment id (e.g. ``"model-runner"``). The worker
@@ -1404,11 +1594,18 @@ class AppsManager:
                 ``<application_id>`` directory is accepted as a fallback for
                 caches created by earlier worker releases.
 
+        Returns:
+            Dict with ``mode`` (shared|per_node), ``deleted_on`` (list of node
+            IDs where a directory was actually removed), and ``not_found_on``
+            (list of node IDs that had no matching directory).
+
         Raises:
             PermissionError: If the caller is not a worker admin
-            RuntimeError: If the worker is not initialized, the app is currently running,
-                         or deletion fails
-            ValueError: If the directory does not exist or application_id contains path separators
+            RuntimeError: If the worker is not initialized, the app is currently
+                running, or every node's delete failed for a reason other than
+                "not_found".
+            ValueError: If no node had a matching directory, or
+                application_id contains path separators.
         """
         self._check_initialized()
         check_permissions(
@@ -1434,41 +1631,54 @@ class AppsManager:
         apps_workdir = str(self.app_builder.apps_workdir)
         worker_workspace = self.server.config.workspace if self.server else "local"
 
-        @ray.remote(num_cpus=0)
-        def _clear_dir(apps_workdir_str: str, worker_workspace: str, app_id: str) -> dict:
-            import shutil
-            from pathlib import Path
+        mode = await self._detect_fs_topology()
+        from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
-            apps_workdir = Path(apps_workdir_str)
-            prefixed = apps_workdir / f"{worker_workspace}-{app_id}"
-            bare = apps_workdir / app_id
-            target = prefixed if prefixed.exists() else bare
-            if not target.exists():
-                return {"ok": False, "error": "not_found", "path": str(target)}
-            if not target.is_dir():
-                return {"ok": False, "error": "not_a_dir", "path": str(target)}
-            try:
-                shutil.rmtree(target)
-            except Exception as e:
-                return {"ok": False, "error": f"rmtree_failed: {e}", "path": str(target)}
-            return {"ok": True, "path": str(target)}
-
-        result = await asyncio.to_thread(
-            ray.get,
-            _clear_dir.remote(apps_workdir, worker_workspace, application_id),
-        )
-        if not result["ok"]:
-            if result["error"] == "not_found":
-                raise ValueError(
-                    f"No directory found for application '{application_id}' in the apps workspace."
-                )
-            if result["error"] == "not_a_dir":
-                raise ValueError(f"'{application_id}' is not a directory.")
+        alive_nodes = [n for n in ray.nodes() if n.get("Alive")]
+        if not alive_nodes:
             raise RuntimeError(
-                f"Failed to delete directory for '{application_id}': {result['error']}"
+                f"No Ray nodes alive — cannot clear directory for '{application_id}'."
             )
 
-        self.logger.info(f"Cleared app directory: {result['path']}")
+        target_nodes = [alive_nodes[0]] if mode == "shared" else alive_nodes
+        refs = [
+            ray.remote(num_cpus=0)(_clear_dir_on_node)
+            .options(
+                scheduling_strategy=NodeAffinitySchedulingStrategy(
+                    node_id=n["NodeID"], soft=False
+                )
+            )
+            .remote(apps_workdir, worker_workspace, application_id, n["NodeID"])
+            for n in target_nodes
+        ]
+        results = await asyncio.to_thread(ray.get, refs)
+
+        deleted_on = [r["node_id"] for r in results if r["ok"]]
+        not_found_on = [r["node_id"] for r in results if r["error"] == "not_found"]
+        hard_failures = [
+            r for r in results if not r["ok"] and r["error"] != "not_found"
+        ]
+
+        if hard_failures:
+            details = "; ".join(
+                f"node={r['node_id']}: {r['error']}" for r in hard_failures
+            )
+            raise RuntimeError(
+                f"Failed to delete directory for '{application_id}': {details}"
+            )
+        if not deleted_on:
+            raise ValueError(
+                f"No directory found for application '{application_id}' on any Ray node."
+            )
+
+        self.logger.info(
+            f"Cleared app directory for '{application_id}' on nodes: {deleted_on}"
+        )
+        return {
+            "mode": mode,
+            "deleted_on": deleted_on,
+            "not_found_on": not_found_on,
+        }
 
     @schema_method
     async def list_apps(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.11.5"
+version = "0.11.9"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Problem

The dashboard needs to surface stale app caches so a maintainer can free
disk space without ssh'ing into a worker pod. The existing
``list_app_directories`` exposed name / path / ``is_running`` /
``size_bytes`` but no recency signal, and on v0.11.4+ workers it
silently returned empty because in the FS-thin worker design app
caches live on the Ray actor pods, not on the worker.

Once the cache lookup moves to a Ray task, a second problem appears:
multi-node Ray clusters might not share a filesystem at ``apps_workdir``
(KTH worker mounts a NetApp Trident PVC; the ray-cluster pods may
mount a different export, or local disk). A single Ray task only sees
its node's view.

## Solution

### One-time FS-topology probe

On the first ``list_app_directories`` or ``clear_app_directory`` call
from the dashboard, ``AppsManager._detect_fs_topology()``:

1. Writes a unique marker file in ``apps_workdir`` on one node.
2. Reads the marker via a Ray task on every other alive node.
3. All match ⇒ ``"shared"``; any mismatch / read failure ⇒
   ``"per_node"``.
4. Deletes the marker from every node.

Result cached for the AppsManager lifetime. **Never** re-probes
automatically — the worker doesn't trigger this from startup,
recovery, or any monitoring loop. Purely on-demand from the dashboard.

### list_app_directories

- **shared FS**: one Ray task on any alive node → returns its entries.
- **per-node FS**: one Ray task per alive node → returns the union
  (same ``application_id`` can appear once per node that cached it).

Every returned entry includes:

- ``name``, ``application_id``, ``path``, ``is_running``,
  ``size_bytes``, ``last_used_unix`` (latest file mtime, proxy for
  "last used"), plus
- ``node_id`` — the Ray node where this entry was observed (useful in
  per-node topologies to identify which node holds the cache).

### clear_app_directory

- **shared FS**: one Ray task ⇒ deletes once.
- **per-node FS**: one Ray task per alive node ⇒ deletes wherever the
  directory exists; raises ``ValueError`` if no node had it.

Returns ``{"mode", "deleted_on": [node_ids], "not_found_on": [node_ids]}``
so the dashboard can show which nodes were affected. Hard delete
errors propagate.

The running-app guard is unchanged — refuses to delete a directory
whose app is currently RUNNING (stop_app first).

### Why a separate helper module

``bioengine.apps._cache_fs_tasks`` holds the Ray-task helpers. Keeping
them stdlib-only sidesteps the Ray-Client-server's by-reference
unpickle path through ``bioengine.apps.manager`` (which depends on
haikunator / hypha_rpc / ray.serve — not guaranteed in the head pod's
base venv).

## Files

| File | Change |
|---|---|
| ``bioengine/apps/manager.py`` | New ``_detect_fs_topology`` helper; ``list_app_directories`` + ``clear_app_directory`` rewritten to dispatch via Ray tasks with ``NodeAffinitySchedulingStrategy``; returns enriched entries with ``node_id`` / ``last_used_unix``; ``clear_app_directory`` returns ``{mode, deleted_on, not_found_on}``. |
| ``bioengine/apps/_cache_fs_tasks.py`` *(new)* | Stdlib-only Ray-task functions: ``fs_probe_write/read/delete``, ``list_dirs_on_node``, ``clear_dir_on_node``. |

## Validation (KTH dev image 0.11.6-dev5)

- First call worked, probe detected ``mode=shared`` across all 3 alive
  Ray nodes (KTH NetApp Trident shares ``apps_workdir`` via NFS RWX);
  marker file cleaned up.
- Listed 54 baseline entries.
- After deploying a test app, the matching entry appeared with
  ``size_bytes=937``, real ``last_used_unix``, ``is_running=True``,
  prefix stripped correctly to ``application_id=cache-test``.
- ``clear_app_directory`` on running app → correctly refused.
- ``clear_app_directory`` after stop → returned
  ``{mode: "shared", deleted_on: [<one node>]}``; dir absent from
  subsequent list.
- ``clear_app_directory`` on unknown app → ``ValueError`` raised.

## Test plan

- [x] KTH dev image (shared-FS path).
- [ ] Multi-node cluster with non-shared local disk (per-node path) —
      tested locally only; deNBI / SLURM clusters are the natural
      production surface to confirm.
