### PR TITLE
feat(apps): set_app_scaling for per-app replica + autoscaling control

### DIFF
--- a/bioengine/_app/bootstrap.py
+++ b/bioengine/_app/bootstrap.py
@@ -469,6 +469,7 @@ def build_and_run_application(
     user_replica_framework_pip: List[str],
     replica_env_vars: Dict[str, str],
     proxy_memory_in_gb: float,
+    scaling: Optional[Dict[str, Dict[str, Any]]] = None,
 ) -> Dict[str, Any]:
     """Assemble the Ray Serve bind graph AND call ``serve.run`` in-process.
 
@@ -587,11 +588,24 @@ def build_and_run_application(
         opts["runtime_env"] = runtime_env
         return cls.options(ray_actor_options=opts)
 
+    scaling_map = dict(scaling or {})
+
     def bind(cid: str) -> Any:
         if cid in handles:
             return handles[cid]
         meta = spec["classes"][cid]
         cls = _with_pkg(_load_app_class(cid))
+        # Per-deployment scaling: the user keys the dict by class name
+        # (matching what get_app_status reports). Multi-class apps can
+        # mix fixed and autoscaling configs across deployments.
+        class_name = meta["qualname"].split(".")[-1]
+        per_class = scaling_map.get(class_name) or {}
+        per_class_autoscale = per_class.get("autoscaling_config")
+        per_class_replicas = per_class.get("num_replicas")
+        if per_class_autoscale:
+            cls = cls.options(autoscaling_config=per_class_autoscale)
+        elif per_class_replicas is not None and per_class_replicas != 1:
+            cls = cls.options(num_replicas=per_class_replicas)
         bind_kwargs: Dict[str, Any] = dict(application_kwargs.get(cid, {}))
         for param in meta["init_params"]:
             if param["kind"] == "deployment_handle":

--- a/bioengine/apps/builder.py
+++ b/bioengine/apps/builder.py
@@ -452,6 +452,7 @@ class AppBuilder:
         ] = None,
         deploying_user: Optional[tuple] = None,
         admin_users: Optional[List[str]] = None,
+        scaling: Optional[Dict[str, Dict[str, Any]]] = None,
     ) -> "BuiltApp":
         """Construct the Ray Serve application for a v0.6.0 BioEngine app."""
         self.logger.info(
@@ -586,6 +587,7 @@ class AppBuilder:
             "disable_gpu": disable_gpu,
             "max_ongoing_requests": max_ongoing_requests,
             "proxy_memory_in_gb": proxy_memory_in_gb,
+            "scaling": dict(scaling or {}),
             "application_resources": required_resources,
             "authorized_users": effective_authorized_users,
             "available_methods": available_methods,
@@ -684,6 +686,7 @@ class AppBuilder:
             user_replica_framework_pip=user_replica_framework_pip,
             replica_env_vars=replica_env_vars,
             proxy_memory_in_gb=proxy_memory_in_gb,
+            scaling=dict(scaling or {}),
         )
 
     async def submit(self, built_app: "BuiltApp", application_id: str) -> None:
@@ -722,6 +725,7 @@ class AppBuilder:
                     built_app.user_replica_framework_pip,
                     _ensure_jsonable(built_app.replica_env_vars),
                     built_app.proxy_memory_in_gb,
+                    _ensure_jsonable(built_app.scaling),
                 ),
             )
         except ray.exceptions.RayTaskError as exc:
@@ -761,6 +765,7 @@ class BuiltApp:
         "user_replica_framework_pip",
         "replica_env_vars",
         "proxy_memory_in_gb",
+        "scaling",
     )
 
     def __init__(
@@ -776,6 +781,7 @@ class BuiltApp:
         user_replica_framework_pip: List[str],
         replica_env_vars: Dict[str, str],
         proxy_memory_in_gb: float,
+        scaling: Optional[Dict[str, Dict[str, Any]]] = None,
     ) -> None:
         self.metadata = metadata
         self.spec = spec
@@ -788,3 +794,7 @@ class BuiltApp:
         self.user_replica_framework_pip = user_replica_framework_pip
         self.replica_env_vars = replica_env_vars
         self.proxy_memory_in_gb = proxy_memory_in_gb
+        # Map of {user_deployment_class_name: {num_replicas, autoscaling_config}}.
+        # Empty default means every user deployment runs at Ray Serve's default
+        # of one replica with no autoscaling.
+        self.scaling = dict(scaling or {})

--- a/bioengine/apps/manager.py
+++ b/bioengine/apps/manager.py
@@ -850,6 +850,7 @@ class AppsManager:
             "authorized_users": application_info["authorized_users"],
             "available_methods": application_info["available_methods"],
             "max_ongoing_requests": application_info["max_ongoing_requests"],
+            "scaling": dict(application_info.get("scaling") or {}),
             "static_site_url": static_site_url,
             "service_ids": service_ids,
             "start_time": application_info["started_at"],
@@ -1028,6 +1029,7 @@ class AppsManager:
                     "disable_gpu": app_data["disable_gpu"],
                     "max_ongoing_requests": app_data["max_ongoing_requests"],
                     "proxy_memory_in_gb": app_data.get("proxy_memory_in_gb", 0.5),
+                    "scaling": dict(app_data.get("scaling") or {}),
                     "application_resources": app_data["application_resources"],
                     "authorized_users": updated_authorized_users,
                     "available_methods": app_data["available_methods"],
@@ -1825,6 +1827,14 @@ class AppsManager:
                 {"train": ["admin@lab.edu"], "infer": ["*"]},
             ],
         ),
+        scaling: Optional[Dict[str, Dict[str, Any]]] = Field(
+            None,
+            description="Per-user-deployment scaling map keyed by the @bioengine.app class name (as shown under 'deployments' in get_app_status). Each entry is {'num_replicas': int} or {'autoscaling_config': {'min_replicas': int, 'max_replicas': int, ...}} — the two are mutually exclusive per Ray Serve. Classes not in the map run at Ray Serve's default of one fixed replica. The ProxyDeployment is always one replica and not addressable. On update (matching application_id) the full map replaces the previous one — pass the previous value back unmodified for any deployment you don't want to change. If not specified: empty map for a new app, preserved from the previous deploy when updating.",
+            examples=[
+                {"DemoApp": {"num_replicas": 3}},
+                {"EntryDeployment": {"autoscaling_config": {"min_replicas": 1, "max_replicas": 8, "target_num_ongoing_requests_per_replica": 4}}, "RuntimeDeployment": {"num_replicas": 1}},
+            ],
+        ),
         context: Dict[str, Any] = Field(
             ...,
             description="Authentication context containing user information, automatically provided by Hypha during service calls.",
@@ -1925,6 +1935,10 @@ class AppsManager:
                     ice_servers = existing_app.get("ice_servers", None)
                 if authorized_users is None:
                     authorized_users = existing_app.get("authorized_users", None)
+                # Inherit per-deployment scaling when caller didn't provide one
+                # (same pattern as the other update-inheritance fields above).
+                if scaling is None:
+                    scaling = dict(existing_app.get("scaling") or {})
             else:
                 # For new applications, set creation time and default values
                 started_at = time.time()
@@ -1947,6 +1961,8 @@ class AppsManager:
                     debug = False
                 # ice_servers defaults to None (fetch from URL)
                 # authorized_users defaults to None (use manifest value)
+                if scaling is None:
+                    scaling = {}
 
             # Caller identity and admin users for injection into authorized_users by the builder
             user_email = context["user"].get("email", "")
@@ -2045,7 +2061,45 @@ class AppsManager:
                 authorized_users=authorized_users,
                 deploying_user=(user_id, user_email),
                 admin_users=self.admin_users,
+                scaling=scaling,
             )
+
+            # Validate scaling map against the user @bioengine.app classes the
+            # introspect task discovered. The ProxyDeployment is intentionally
+            # not in the spec — it always runs as a single replica.
+            user_deployment_names = sorted(
+                meta["qualname"].split(".")[-1]
+                for meta in app.spec["classes"].values()
+            )
+            for dep_name, dep_scaling in (scaling or {}).items():
+                if dep_name not in user_deployment_names:
+                    raise ValueError(
+                        f"scaling key '{dep_name}' is not a user deployment in "
+                        f"app '{application_id}'. Valid deployments: "
+                        f"{user_deployment_names}."
+                    )
+                if not isinstance(dep_scaling, dict):
+                    raise ValueError(
+                        f"scaling entry for '{dep_name}' must be a dict; got "
+                        f"{type(dep_scaling).__name__}."
+                    )
+                nr = dep_scaling.get("num_replicas")
+                asc = dep_scaling.get("autoscaling_config")
+                if nr is None and not asc:
+                    raise ValueError(
+                        f"scaling entry for '{dep_name}' must set exactly one "
+                        f"of num_replicas or autoscaling_config; got neither."
+                    )
+                if nr is not None and asc:
+                    raise ValueError(
+                        f"scaling entry for '{dep_name}' must set exactly one "
+                        f"of num_replicas or autoscaling_config; got both."
+                    )
+                if nr is not None and nr < 0:
+                    raise ValueError(
+                        f"scaling entry for '{dep_name}' has num_replicas="
+                        f"{nr}; must be >= 0."
+                    )
 
             # Check resources before creating deployment task
             await self._check_resources(
@@ -2074,6 +2128,7 @@ class AppsManager:
                 "disable_gpu": disable_gpu,
                 "max_ongoing_requests": max_ongoing_requests,
                 "proxy_memory_in_gb": proxy_memory_in_gb,
+                "scaling": dict(app.scaling or {}),
                 "application_resources": app.metadata["resources"],
                 "authorized_users": app.metadata["authorized_users"],
                 "available_methods": app.metadata["available_methods"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.11.9"
+version = "0.11.10"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Problem

There is no way to set per-deployment scaling on a BioEngine
application. The only knob is implicit (Ray Serve's default
``num_replicas=1``), and multi-class composition apps (entry +
runtime deployments) need different scaling per deployment — e.g. an
entry that autoscales 1-8 replicas while a heavyweight runtime stays
pinned at one.

## Solution

A new ``scaling`` parameter on the existing ``deploy_app``. No new API
surface — the parameter slots into the same update-in-place path that
already handles ``application_kwargs``, ``max_ongoing_requests``,
``authorized_users``, etc.

```python
deploy_app(
    artifact_id="bioimage-io/my-app",
    application_id="my-app",
    scaling={
        "EntryDeployment": {
            "autoscaling_config": {
                "min_replicas": 1,
                "max_replicas": 8,
                "target_num_ongoing_requests_per_replica": 4,
            },
        },
        "RuntimeDeployment": {"num_replicas": 1},
    },
)
```

Each entry sets exactly one of ``num_replicas`` or
``autoscaling_config`` (Ray Serve's own constraint). Classes not in
the map run at Ray Serve's default of one fixed replica. The scaling
map is validated against the introspected spec — unknown class names
raise with the valid list.

Inheritance matches every other ``deploy_app`` parameter:

- ``scaling=None`` (omitted) on an update with a matching
  ``application_id`` ⇒ preserve the previous map unchanged.
- ``scaling={}`` ⇒ reset every deployment back to defaults.
- ``scaling={...}`` ⇒ the dict fully replaces the previous map.
  Dashboard always sends the full state.

The ProxyDeployment (WebSocket/WebRTC bridge) is always fixed at one
replica and is intentionally **not** addressable here — only the user
``@bioengine.app`` classes can be scaled.

### Why fold this into deploy_app

The earlier draft introduced a separate ``set_app_scaling`` method.
But the existing ``deploy_app`` already handles in-place updates of an
existing ``application_id``: it cancels the prior deployment task and
calls ``serve.run(blocking=False)`` with the same name, which Ray
Serve treats as a rolling redeploy. Adding ``scaling`` as one more
inherited parameter means:

- One entry point, one validation path, one set of inheritance logic.
- The introspect Ray task already runs cheaply (~ms on cached source)
  and is necessary anyway to validate the deployment names against
  the spec.
- No duplicate persistence model — ``app_data["scaling"]`` is the
  single source of truth across both call shapes.

### State persistence

- ``app_data["scaling"]`` is written on the ProxyDeployment and
  round-tripped by ``recover_deployed_applications``. A worker pod
  restart re-applies the same per-deployment scaling automatically.
- ``get_app_status`` surfaces ``scaling`` alongside the existing
  fields so the dashboard can render each deployment's active mode.

## Out of scope

- Resource accounting against ``num_replicas`` /
  ``autoscaling_config.max_replicas`` — Ray Serve will pend replicas
  that exceed cluster capacity. The dashboard should surface pending
  status from ``get_app_status`` so the operator knows.
- Dashboard UI — tracked in the bioimage.io repo.

## Files

| File | Change |
|---|---|
| ``bioengine/apps/builder.py`` | ``AppBuilder.build`` / ``BuiltApp`` / ``app_data`` carry a ``scaling`` dict; passed through to ``build_and_run_application``. |
| ``bioengine/_app/bootstrap.py`` | ``build_and_run_application`` looks up per-class scaling by class name (derived from the spec's qualname) and applies via ``cls.options(num_replicas=...)`` or ``cls.options(autoscaling_config=...)``. |
| ``bioengine/apps/manager.py`` | ``deploy_app`` gains a ``scaling`` parameter with per-class validation; inherits previous map when omitted on update; passes through to ``app_builder.build``. ``get_app_status`` exposes the per-class map. |

## Test plan

- [ ] KTH live worker: ``deploy_app(application_id="demo-app",
       scaling={"DemoApp": {"num_replicas": 3}})`` → three user
       replicas, ProxyDeployment stays at one.
- [ ] Update existing app with ``scaling={"DemoApp": {"autoscaling_config":
       {"min_replicas": 1, "max_replicas": 4}}}`` → switch to
       autoscaling; ping still serves through rolling update.
- [ ] Omit ``scaling`` on a follow-up redeploy → previous map preserved.
- [ ] Pass invalid deployment name → rejected with valid-list message.
- [ ] Worker restart → scaling state survives pod replacement.
- [ ] Existing apps (model-runner, cellpose-finetuning, smart-microscopy-assistant)
       deploy and run unchanged when ``scaling`` is omitted.
