### PR TITLE
feat(method): opt-in context injection via @bioengine.method(context=True)

### DIFF
--- a/bioengine/_app/decorators.py
+++ b/bioengine/_app/decorators.py
@@ -21,6 +21,7 @@ Ray Serve replicas via the ``py_modules`` upload.
 from __future__ import annotations
 
 import inspect
+from functools import wraps
 from typing import Any, Callable, Dict, List, Optional
 
 from bioengine._app.errors import ReservedMethodNameError
@@ -42,11 +43,20 @@ _RESERVED_NAMES = ("check_health", "async_init", "test_deployment")
 # Tag attached to functions by the marker decorators below.
 _KIND_ATTR = "_bioengine_kind"
 
+# Flag attached by ``@bioengine.method(context=True)``; read by the
+# introspect task and surfaced to ProxyDeployment so the proxy knows to
+# forward the Hypha caller's context as a kwarg.
+_WANTS_CONTEXT_ATTR = "_bioengine_wants_context"
+
 
 # ─────────────────────────── method markers ──────────────────────────────
 
 
-def method(fn: Callable[..., Any]) -> Callable[..., Any]:
+def method(
+    fn: Optional[Callable[..., Any]] = None,
+    *,
+    context: bool = False,
+) -> Callable[..., Any]:
     """Expose an instance method as a BioEngine API method.
 
     Equivalent to ``hypha_rpc``'s ``@schema_method(arbitrary_types_allowed=True)``
@@ -54,12 +64,87 @@ def method(fn: Callable[..., Any]) -> Callable[..., Any]:
     to assemble ``_bioengine_method_schemas``. Arbitrary types are allowed by
     default so methods can accept ``numpy.ndarray``, ``PIL.Image``, etc.
     without users having to wire a custom decorator.
-    """
-    from hypha_rpc.utils.schema import schema_method
 
-    wrapped = schema_method(arbitrary_types_allowed=True)(fn)
-    setattr(wrapped, _KIND_ATTR, "method")
-    return wrapped
+    Set ``context=True`` to receive the Hypha caller's context dict as a
+    ``context`` kwarg::
+
+        @bioengine.method(context=True)
+        async def whoami(self, context):
+            return context["user"]["id"]
+
+    The ``context`` parameter is **not** exposed in the schema Hypha
+    publishes to clients — it is auto-injected by Hypha at the service
+    boundary and forwarded by the ProxyDeployment so the user method
+    receives the live caller identity on every call.
+    """
+
+    def _wrap(f: Callable[..., Any]) -> Callable[..., Any]:
+        from hypha_rpc.utils.schema import schema_method
+
+        if not context:
+            wrapped = schema_method(arbitrary_types_allowed=True)(f)
+            setattr(wrapped, _KIND_ATTR, "method")
+            setattr(wrapped, _WANTS_CONTEXT_ATTR, False)
+            return wrapped
+
+        # context=True: the user method must declare a ``context``
+        # parameter. We build the schema from the full signature first
+        # (so the parameter types still pick up annotations), then strip
+        # ``context`` out of the published parameters dict and wrap the
+        # original function in a pass-through that forwards everything —
+        # including the proxy-injected ``context`` kwarg — to the user
+        # code. The wrapped function intentionally bypasses pydantic
+        # validation on the replica side because ``context`` reaches the
+        # replica as an extra kwarg that the public schema does not
+        # describe; the Hypha service boundary still validates the public
+        # parameters before the call ever leaves the proxy.
+        sig = inspect.signature(f)
+        if "context" not in sig.parameters:
+            raise TypeError(
+                f"@bioengine.method(context=True) on "
+                f"'{getattr(f, '__qualname__', f.__name__)}': the method "
+                f"must declare a 'context' parameter (e.g. "
+                f"'async def {f.__name__}(self, ..., context): ...')."
+            )
+
+        full_schema = schema_method(arbitrary_types_allowed=True)(f).__schema__
+        params_schema = dict(full_schema.get("parameters") or {})
+        properties = dict(params_schema.get("properties") or {})
+        properties.pop("context", None)
+        params_schema["properties"] = properties
+        required = [
+            r for r in (params_schema.get("required") or []) if r != "context"
+        ]
+        if required:
+            params_schema["required"] = required
+        else:
+            params_schema.pop("required", None)
+        public_schema = {
+            "name": full_schema.get("name") or f.__name__,
+            "description": full_schema.get("description") or f.__doc__,
+            "parameters": params_schema,
+        }
+
+        if inspect.iscoroutinefunction(f):
+
+            @wraps(f)
+            async def wrapper(self, *args, **kwargs):
+                return await f(self, *args, **kwargs)
+
+        else:
+
+            @wraps(f)
+            def wrapper(self, *args, **kwargs):
+                return f(self, *args, **kwargs)
+
+        wrapper.__schema__ = public_schema
+        setattr(wrapper, _KIND_ATTR, "method")
+        setattr(wrapper, _WANTS_CONTEXT_ATTR, True)
+        return wrapper
+
+    if fn is not None:
+        return _wrap(fn)
+    return _wrap
 
 
 def async_init(fn: Callable[..., Any]) -> Callable[..., Any]:
@@ -227,7 +312,15 @@ def _scan_class(cls: type) -> tuple[Dict[str, Any], List[Dict[str, Any]]]:
         if kind is None:
             continue
         if kind == "method":
-            method_schemas.append(member.__schema__)
+            # Carry the wants_context flag in the schema dict so the
+            # introspect task ships it to the proxy, which uses it to
+            # decide whether to inject the Hypha caller context on each
+            # call. The flag survives JSON serialisation via _sanitise_schemas.
+            entry = dict(member.__schema__)
+            entry["wants_context"] = bool(
+                getattr(member, _WANTS_CONTEXT_ATTR, False)
+            )
+            method_schemas.append(entry)
         elif kind == "multiplexed":
             lifecycle["multiplexed"].append(attr_name)
         elif kind in lifecycle:

--- a/bioengine/apps/proxy_deployment.py
+++ b/bioengine/apps/proxy_deployment.py
@@ -384,6 +384,26 @@ class ProxyDeployment:
         # introspect task; default False keeps legacy methods unchanged.
         wants_context = bool(method_schema.get("wants_context", False))
 
+        def _context_to_plain_dict(obj: Any) -> Any:
+            """Convert Hypha's munch-style context proxy into a plain dict.
+
+            Hypha auto-injects ``context`` as a ``munch.Munch`` (attribute-
+            accessible dict subclass) on the service side. Cloudpickling that
+            across the ServeHandle to a replica that has no ``hypha_rpc``
+            install would leave the user with a broken proxy; walking the
+            tree once here produces a plain dict the replica can
+            ``isinstance(context, dict)``-check, ``json.dumps``-round-trip,
+            and store without surprise.
+            """
+            if isinstance(obj, dict) or hasattr(obj, "items"):
+                try:
+                    return {k: _context_to_plain_dict(v) for k, v in obj.items()}
+                except Exception:
+                    pass
+            if isinstance(obj, (list, tuple)):
+                return [_context_to_plain_dict(v) for v in obj]
+            return obj
+
         async def deployment_function(*args, context: Dict[str, Any], **kwargs) -> Any:
             # Semaphore bounds concurrency for both WebSocket and WebRTC entry paths —
             # they share this single wrapper, so a long-running call from either
@@ -408,7 +428,7 @@ class ProxyDeployment:
                         )
 
                     if wants_context:
-                        kwargs = {**kwargs, "context": context}
+                        kwargs = {**kwargs, "context": _context_to_plain_dict(context)}
 
                     try:
                         result = await method.remote(*args, **kwargs)

--- a/bioengine/apps/proxy_deployment.py
+++ b/bioengine/apps/proxy_deployment.py
@@ -379,6 +379,10 @@ class ProxyDeployment:
             Callable proxy function decorated with @schema_function
         """
         method_name = method_schema["name"]
+        # Methods declared with @bioengine.method(context=True) receive the
+        # Hypha caller context as a kwarg. The flag is set by the
+        # introspect task; default False keeps legacy methods unchanged.
+        wants_context = bool(method_schema.get("wants_context", False))
 
         async def deployment_function(*args, context: Dict[str, Any], **kwargs) -> Any:
             # Semaphore bounds concurrency for both WebSocket and WebRTC entry paths —
@@ -402,6 +406,9 @@ class ProxyDeployment:
                         raise AttributeError(
                             f"Method '{method_name}' not found on entry deployment"
                         )
+
+                    if wants_context:
+                        kwargs = {**kwargs, "context": context}
 
                     try:
                         result = await method.remote(*args, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.11.5"
+version = "0.11.8"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Problem

App authors need access to the Hypha caller's identity (user id, email,
workspace) inside method bodies — for per-user state, audit logging,
or downstream Hypha calls minted with the caller's permissions. There
is no way to surface that context today.

## Solution

New opt-in flag on the method decorator. The wrapper accepts any
positional / keyword args alongside the auto-injected ``context``::

    @bioengine.method(context=True)
    async def whoami(self, context):
        return context["user"]["id"]

    @bioengine.method(context=True)
    async def annotate(self, image, label: str, context) -> dict:
        # Args work normally; context is auto-injected by Hypha and
        # never appears in the public schema. The user can't supply
        # or spoof it from the call site.
        return {"by": context["user"]["id"], "label": label}

When ``context=True``:

- The user method must declare a ``context`` parameter (validated at
  decoration time with a clear error message if missing).
- The schema published to Hypha clients **omits** ``context``, so it
  cannot be supplied or spoofed from the call site.
- The wants_context flag is captured at introspect time and shipped
  to the ProxyDeployment via the existing method_schemas pipeline.
- On every call, the proxy converts Hypha's ``munch.Munch`` context
  proxy into a **plain dict** (deep walk), then injects the live
  context into the ServeHandle.remote() kwargs.
- ``isinstance(context, dict)`` returns True on the replica side;
  ``json.dumps(context)`` round-trips without surprises, even on
  replicas with no ``hypha_rpc`` install.

Default behaviour is unchanged: ``@bioengine.method`` without arguments
generates the same schema and never forwards context.

## Files

| File | Change |
|---|---|
| ``bioengine/_app/decorators.py`` | Accept ``context: bool = False`` on ``method``. When true: validate the user signature, strip ``context`` from the published schema, attach a pass-through wrapper, and tag the function with ``_bioengine_wants_context``. ``_scan_class`` copies the tag into each schema dict. |
| ``bioengine/apps/proxy_deployment.py`` | Read ``wants_context`` from the method_schema; deep-convert the Hypha context proxy to a plain dict; append ``context=<plain_dict>`` to ``method.remote(...)`` kwargs when set. |

## Validation (KTH dev image 0.11.6-dev5)

- ``plain(x=42)`` → ``{"x": 42}`` (unchanged)
- ``with_ctx(x=7)`` → ``{"x": 7, "user_id": "silk-gardenia-...", "email": "...", "context_is_dict": "dict", "context_keys": ["connection_type", "from", "method", "session", "to", "type", "user", "ws"]}``
- ``ctx_only()`` → ``{"user_id": "...", "ctx_type": "dict"}``
- Public schema for ``with_ctx`` shows ``params=['x']`` (context hidden)
- Public schema for ``ctx_only`` shows ``params=[]``
- Spoofed ``context={"user": {"id": "FORGED"}}`` from the client is ignored — Hypha's auto-inject wins
