### PR TITLE
fix(datasets): HttpZarrStore exposes dataset_id + zarr_path on the instance

### DIFF
--- a/bioengine/datasets/datasets.py
+++ b/bioengine/datasets/datasets.py
@@ -372,6 +372,8 @@ class BioEngineDatasets:
                 token=token,
                 chunk_cache=self.chunk_cache,
                 logger=self.logger,
+                dataset_id=dataset_id,
+                zarr_path=zarr_path,
             )
         else:
             from bioengine.datasets.utils import get_url_with_retry

--- a/bioengine/datasets/http_zarr_store.py
+++ b/bioengine/datasets/http_zarr_store.py
@@ -56,8 +56,8 @@ class HttpZarrStore(Store):
     An optional ``token`` is appended as ``?token=`` for the local-server case.
     """
 
-    dataset_id: str
-    zarr_path: str
+    dataset_id: Optional[str] = None
+    zarr_path: Optional[str] = None
     _read_only: bool = True
 
     supports_writes: bool = False
@@ -77,6 +77,8 @@ class HttpZarrStore(Store):
             os.getenv("BIOENGINE_DATASETS_ZARR_STORE_CONNECTIONS", 100)
         ),
         logger: logging.Logger = logging.getLogger("HttpZarrStore"),
+        dataset_id: Optional[str] = None,
+        zarr_path: Optional[str] = None,
     ):
         """
         Initialize the HTTP-based Zarr store for remote dataset access.
@@ -95,12 +97,20 @@ class HttpZarrStore(Store):
             max_concurrent_requests: Maximum number of concurrent HTTP requests
             max_connections: Maximum number of HTTP connections in pool
             logger: Logger instance for logging messages
+            dataset_id: BioEngine dataset id this store points at, when the
+                URL came from ``BioEngineDatasets.get_file`` — exposed for
+                downstream consumers that need to round-trip the identifier.
+                Left as ``None`` for arbitrary external Zarr roots.
+            zarr_path: Zarr path within the dataset, complementary to
+                ``dataset_id``. ``None`` for external roots.
         """
         super().__init__(read_only=True)
         self.base_url = base_url.rstrip("/")
         self.token = token
         self.logger = logger
         self._chunk_cache = chunk_cache
+        self.dataset_id = dataset_id
+        self.zarr_path = zarr_path
 
         # Concurrency control
         self._request_semaphore = Semaphore(max_concurrent_requests)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.11.5"
+version = "0.11.6"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Problem

``bioengine.datasets.http_zarr_store.HttpZarrStore`` declares
``dataset_id: str`` and ``zarr_path: str`` as class-level dataclass
annotations (lines ~59-60), but the custom ``__init__`` overrides the
dataclass-generated ``__init__`` and never assigns either to ``self``.
Consumers reading ``store.dataset_id`` or ``store.zarr_path`` get
``AttributeError`` even though ``BioEngineDatasets.get_file`` knows
both values at construction time.

bioengine itself never reads either attribute off the store, so the
bug is invisible inside the package — but external consumers
(reported by the Chiron / tabula-trainer integration on bioengine
0.10.13) that round-trip the dataset identity hit it immediately.

## Solution

- Add ``dataset_id: Optional[str] = None`` and
  ``zarr_path: Optional[str] = None`` as explicit kwargs on
  ``__init__``; assign both to ``self``.
- ``BioEngineDatasets.get_file`` passes both for local-data-server
  URLs.
- External Zarr roots (BioImage Archive, public OME-Zarr) keep them
  as ``None`` — they don't have a BioEngine identifier.

## Files

| File | Change |
|---|---|
| ``bioengine/datasets/http_zarr_store.py`` | Promote class-level annotations to ``Optional[str] = None``; accept + assign both kwargs in ``__init__``. |
| ``bioengine/datasets/datasets.py`` | Pass ``dataset_id`` and ``zarr_path`` to the HttpZarrStore constructor in ``get_file``. |

## Test plan

- [x] Smoke test: external Zarr root → both attrs ``None``; local
      data-server URL → both attrs set.
- [ ] CI ``pytest``.