### PR TITLE
feat(get_app_status): per-deployment logs_tail + n_previous_replica overrides

### DIFF
--- a/bioengine/apps/manager.py
+++ b/bioengine/apps/manager.py
@@ -647,7 +647,9 @@ class AppsManager:
         application_details: Dict[str, Any],
         n_previous_replica: int,
         logs_tail: int,
+        deployment_logs_overrides: Optional[Dict[str, Dict[str, int]]] = None,
     ) -> Dict[str, Dict[str, Any]]:
+        overrides = deployment_logs_overrides or {}
         deployments_info = {}
         for deployment_name, deployment_info in (
             application_details.get("deployments") or {}
@@ -667,12 +669,15 @@ class AppsManager:
                 "logs": None,
             }
 
+            override = overrides.get(deployment_name) or {}
+            this_tail = override.get("logs_tail", logs_tail)
+            this_prev = override.get("n_previous_replica", n_previous_replica)
             try:
                 deployment_logs = await self.ray_cluster.proxy_actor_handle.get_deployment_logs.remote(
                     application_id=application_id,
                     deployment_name=deployment_name,
-                    n_previous_replica=n_previous_replica,
-                    tail=logs_tail,
+                    n_previous_replica=this_prev,
+                    tail=this_tail,
                 )
                 deployments_info[deployment_name]["logs"] = deployment_logs
             except Exception as e:
@@ -772,6 +777,7 @@ class AppsManager:
         instance_details: Dict[str, Any],
         n_previous_replica: int,
         logs_tail: int,
+        deployment_logs_overrides: Optional[Dict[str, Dict[str, int]]] = None,
     ) -> Dict[str, Any]:
         """
         Application States: [NOT_STARTED, DEPLOYING, DEPLOY_FAILED, RUNNING, UNHEALTHY, DELETING]
@@ -803,6 +809,7 @@ class AppsManager:
                 application_details=application_details,
                 n_previous_replica=n_previous_replica,
                 logs_tail=logs_tail,
+                deployment_logs_overrides=deployment_logs_overrides,
             )
         else:
             if application_info["is_deployed"].is_set():
@@ -2335,11 +2342,19 @@ class AppsManager:
         ),
         logs_tail: int = Field(
             30,
-            description="Number of log lines to retrieve for each deployment replica. If set to -1, retrieves all available logs.",
+            description="Default number of log lines to retrieve for each deployment replica. Applied to every deployment unless overridden via deployment_logs. If set to -1, retrieves all available logs.",
         ),
         n_previous_replica: int = Field(
             0,
-            description="Number of previous replicas to include in the status for each deployment. Set to -1 to retrieve all previous replicas.",
+            description="Default number of previous replicas to include in the status for each deployment. Applied to every deployment unless overridden via deployment_logs. Set to -1 to retrieve all previous replicas.",
+        ),
+        deployment_logs: Optional[Dict[str, Dict[str, int]]] = Field(
+            None,
+            description="Per-deployment overrides for logs_tail and n_previous_replica, keyed by the user @bioengine.app class name (e.g. {'RuntimeApp': {'logs_tail': 200, 'n_previous_replica': 3}}). Each entry may set either or both keys; missing keys fall back to the top-level defaults. Overrides naming a deployment that doesn't exist in any queried app are ignored silently — the dashboard may carry stale overrides while the user mutates the app's class set.",
+            examples=[
+                {"RuntimeApp": {"logs_tail": 200, "n_previous_replica": 3}},
+                {"ProxyDeployment": {"logs_tail": 0}},
+            ],
         ),
         context: Dict[str, Any] = Field(
             ...,
@@ -2429,6 +2444,7 @@ class AppsManager:
                 instance_details=instance_details,
                 n_previous_replica=n_previous_replica,
                 logs_tail=logs_tail,
+                deployment_logs_overrides=deployment_logs,
             )
             for application_id in apps_to_check
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.11.10"
+version = "0.11.11"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Problem

The dashboard's Monitor & Manage dialog has per-deployment log + replica controls in each card — operators want to drill into one noisy deployment without disturbing the others (e.g. tail 200 lines from a crashing ``RuntimeApp`` while leaving ``ProxyDeployment`` at 30).

Today ``get_app_status(application_ids, logs_tail, n_previous_replica)`` applies the same depth to every deployment. The dashboard works around this by calling the API per per-deployment Refresh button and discarding the entries it didn't ask about — full fan-out, throw away most of it.

## Solution

New optional ``deployment_logs: Dict[str, {logs_tail, n_previous_replica}]`` parameter on ``get_app_status``. Keyed by the user ``@bioengine.app`` class name (matching what shows up under ``deployments`` in the response):

```python
await worker.get_app_status(
    application_ids=["model-runner"],
    logs_tail=30,             # default for any deployment not in the override map
    n_previous_replica=0,
    deployment_logs={
        "RuntimeApp": {"logs_tail": 200, "n_previous_replica": 3},
        "ProxyDeployment": {"logs_tail": 5},
    },
)
```

- The top-level ``logs_tail`` / ``n_previous_replica`` stay as defaults — common case is fully backward-compatible.
- Each override entry may set either or both keys; missing keys fall back to the defaults.
- Overrides naming a class that doesn't exist in any queried app are ignored silently (the dashboard might pre-populate from state where the class has since been removed via a ``scaling={}`` reset, and a hard error there would be noise).

## Files

| File | Change |
|---|---|
| ``bioengine/apps/manager.py`` | Plumb ``deployment_logs`` through ``get_app_status`` → ``_get_app_status`` → ``_get_deployment_status``. Per-deployment lookup uses ``overrides.get(name, {}).get(key, top_level_default)`` so a missing entry or a missing key both gracefully fall back. |

## Validation (KTH dev image 0.11.11-dev1, 7/7 PASS)

Deployed a tiny ``LogApp`` that emits 300 log lines on request, plus the standard ``ProxyDeployment``:

- ``deployment_logs={"LogApp": {"logs_tail": 200}}`` → LogApp got 203 lines, ProxyDeployment held at 26 (its natural log volume under the default cap).
- ``deployment_logs={"LogApp": {"logs_tail": 150}, "ProxyDeployment": {"logs_tail": 5}}`` → LogApp 153, ProxyDeployment 8 (both overrides applied in one call).
- ``deployment_logs={"NotARealClass": {"logs_tail": 999}, "LogApp": {"logs_tail": 75}}`` → unknown class silently ignored, LogApp respected at 78.
- ``deployment_logs={"LogApp": {"n_previous_replica": 3}}`` → accepted without crash.
- ``deployment_logs={"LogApp": {"logs_tail": 100, "n_previous_replica": 0}}`` → both keys in one entry honored.
- Backward-compat: omitting ``deployment_logs`` returns the same shape and capping as before.
