### PR TITLE
fix(ray_cluster): always upload bioengine py_modules at job init

### DIFF
--- a/bioengine/cluster/ray_cluster.py
+++ b/bioengine/cluster/ray_cluster.py
@@ -745,21 +745,16 @@ class RayCluster:
             Exception: If connection to the Ray cluster fails.
         """
         try:
-            # Connect to the Ray cluster.
-            # For external clusters, upload the bioengine package via py_modules so
-            # remote workers can import it without a pip install. In single-machine
-            # and SLURM modes, the workers share the same environment/container image
-            # where bioengine is already installed, so the upload is unnecessary.
-            job_runtime_env = {}
-            if self.mode == "external-cluster":
-                job_runtime_env["py_modules"] = [os.path.dirname(bioengine.__file__)]
-
+            # bootstrap.py references this upload via a content-hashed GCS URI
+            # in every replica's py_modules; required in all cluster modes.
             context = await asyncio.to_thread(
                 ray.init,
                 address=self.address,
                 namespace="bioengine",
                 logging_format=stream_logging_format,
-                runtime_env=job_runtime_env,
+                runtime_env={
+                    "py_modules": [os.path.dirname(bioengine.__file__)],
+                },
             )
 
             # Update Ray's logger formatters to use timezone-aware date format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.11.11"
+version = "0.11.12"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [

--- a/requirements-worker.txt
+++ b/requirements-worker.txt
@@ -4,6 +4,7 @@ haikunator==2.1.0
 httpx[http2]==0.28.1
 hypha-rpc==0.21.40
 numpy==1.26.4
+protobuf>=4,<7  # Ray Serve 2.55 touches FieldDescriptor.label, removed in protobuf 7
 pydantic==2.12.0
 pydantic-core==2.41.1
 pyyaml==6.0.2


### PR DESCRIPTION
## Problem

Two stacked bugs prevent every user-app deploy on single-machine / SLURM bioengine workers from reaching ``RUNNING`` on 0.11.10.

### 1. ``py_modules`` upload silently skipped

Every deploy dies with:

```
OSError: Failed to download runtime_env file package
  gcs://_ray_pkg_<hash>.zip from the GCS to the Ray worker node.
  The package may have prematurely been deleted from the GCS due
  to a long upload time or a problem with Ray.
```

Root cause: ``dca892a`` (v0.8.9) added a mode guard that skipped the job-level ``runtime_env.py_modules`` upload of bioengine in single-machine and SLURM modes, on the assumption that the shared env / container image already had bioengine pip-installed. That assumption stopped holding when v0.11.4 introduced ``bootstrap.py`` and ``AppBuilder._bioengine_gcs_uri()`` — every Ray Serve replica's ``runtime_env.py_modules`` now references the content-hashed ``gcs://_ray_pkg_<hash>.zip`` URI for bioengine, computed purely from the local directory tree. With no upload at ``ray.init`` time in single-machine / SLURM modes, that GCS lookup fails on every replica.

### 2. Ray Serve 2.55.1 vs protobuf 7 (surfaced while validating #1)

The 0.11.x worker image's ``requirements-worker.txt`` didn't pin protobuf, so the pip resolver picked the latest (``protobuf 7.35.1``). Ray Serve 2.55.1's deploy path still reaches for ``.label`` on ``FieldDescriptor``, which protobuf 7's UPB descriptor no longer exposes. With #1 fixed, deploys then fail immediately with:

```
AppsManager - ERROR - Failed to deploy application '...' with error:
  'google._upb._message.FieldDescriptor' object has no attribute 'label'
```

External-cluster mode doesn't surface either issue — the connected Ray cluster carries its own Ray + protobuf install, so neither the GCS-side bytes nor the local protobuf version matter. Both bugs only bite when ``ray.init`` runs in-process.

## Solution

Two minimal changes:

| File | Change |
|---|---|
| ``bioengine/cluster/ray_cluster.py`` | Drop the ``if self.mode == "external-cluster"`` guard around the job-level ``py_modules`` upload. Single-machine / SLURM workers now upload bioengine to the cluster's GCS at ``ray.init`` time, restoring the invariant the v0.11.4 replica runtime_env depends on. |
| ``requirements-worker.txt`` | Pin ``protobuf>=4,<7`` until an upstream Ray release stops touching the removed UPB attribute. |

Bundling both into one PR because they sit on the same unblock path — one rebuild fixes both — and splitting them would let a partial fix land that still leaves deploys broken.

## Validation (0.11.12-dev2, single-machine docker container)

- ``protobuf == 6.33.6`` resolved (confirmed via ``pip show protobuf`` inside the container).
- ``ray.init`` logged ``Pushing file package 'gcs://_ray_pkg_<hash>.zip' (1.62MiB) to Ray cluster... Successfully pushed file package`` — the original ``Failed to download`` failure no longer reproduces.
- ``deploy_app`` on a CPU-only ``@bioengine.app`` reached **``RUNNING`` in 10 s**; ``svc.ping()`` returned the expected payload over the Hypha proxy.
- The earlier dev1 build (py_modules fix only) reproduced the protobuf error end-to-end, confirming the pin is necessary for the full unblock.

## Why not the cleaner long-term path for #1

A cleaner option would drop the ``bioengine_uri`` append from ``bootstrap.py`` when bioengine is guaranteed installed in the replica's pip env (single-machine / SLURM). That matches ``dca892a``'s stated intent but the bootstrap Ray task doesn't know the cluster mode — it would need either a mode signal piped through every ``deploy_app`` or a replica-side ``importlib.util.find_spec("bioengine")`` check before the append. Bigger change than this regression warrants. Filing as a follow-up if the perf concern from ``dca892a`` re-surfaces.

Closes #129.

## Test plan

- [x] Single-machine docker worker (0.11.12-dev2): full end-to-end deploy reaches RUNNING and serves ping.
- [ ] External-cluster worker (after merge): no behavioural change — apps still recover and serve as before.
- [ ] SLURM worker (after merge): py_modules upload runs at ray.init; deploys reach RUNNING.
