### PR TITLE
fix(worker): inject only email from token into admin_users, drop user_id

### DIFF
--- a/bioengine/worker/worker.py
+++ b/bioengine/worker/worker.py
@@ -589,13 +589,12 @@ class BioEngineWorker:
             f"'{self.client_id}' to workspace '{self.workspace}' on server '{self.server_url}'."
         )
 
-        # Update admin users list with authenticated user (ensure at top of list)
-        if user_id in self.admin_users:
-            self.admin_users.remove(user_id)
+        # Inject only the email — generate_token issues a fresh haikunated
+        # `sub` per token, so adding user_id accumulates a new entry on
+        # every reconnect / 3-hour refresh and never matches a human admin.
         if user_email in self.admin_users:
             self.admin_users.remove(user_email)
-        self.admin_users.insert(0, user_id)
-        self.admin_users.insert(1, user_email)
+        self.admin_users.insert(0, user_email)
 
         # Create admin context for internal operations
         self._admin_context = create_context(user_id, user_email)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.11.12"
+version = "0.11.13"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Problem

bioengine workers accumulate stale haikunated user_id entries in ``admin_users`` over their lifetime. A KTH worker that had been up for several days showed:

```
imminent-detective-12911725   ← haikunated sub from current token
oeway007@gmail.com             ← from --admin-users
dull-pull-45623993             ← stale haikunated sub from previous token
prairie-board-72753310         ← stale haikunated sub from token before that
nils.mech@gmail.com
mehdiseifi@gmail.com
thefynnbe@gmail.com
```

## Root cause

Two things stack:

1. ``generate_token`` issues a **fresh haikunated `sub` per token** (sampled four such tokens: ``silk-gardenia-96424531``, ``glacier-gojirasaurus-34123849``, ``separate-molybdenum-03944969``, ``acidic-stitch-98794937``). The token's ``user_id`` is never the underlying Hypha account's stable id, so inserting it into ``admin_users`` grants admin only to that exact token — never to the human behind it.

2. ``_connect_to_server`` runs again on every transient reconnect, and ``_check_token_expiry`` rotates the worker's own token every 3 hours with a brand-new haikunated sub. The dedupe at the top of the function (``remove(user_id)`` before insert) only removes exact matches — a fresh haikunated value never matches the previous one, so each reconnect-or-refresh inserts a NEW haikunated id at position 0 and the previous one drifts down. N reconnect-or-refresh cycles ⇒ N+1 stale haikunated entries at the top of the list.

## Solution

Drop the ``user_id`` insert. Keep the email insert with its existing dedup.

- Email is stable across token refreshes and matches what a human admin presents on OAuth login.
- ``check_permissions`` already matches on either ``user.id`` OR ``user.email``, so the worker's own internal ``_admin_context`` (which still carries the haikunated ``user_id`` from the current session + the stable email) keeps authorising via the email match. Internal call paths are unchanged.
- User-provided ``--admin-users`` values keep accepting both shapes (email or the stable ``ws-user-...`` id), because that list is just a flat membership check.

## Files

| File | Change |
|---|---|
| ``bioengine/worker/worker.py`` | Remove the two lines that remove/insert ``user_id`` in ``admin_users``. Keep email dedup + insert. |

## Validation (0.11.13-dev1)

**Single-machine docker worker** with operator-provided ``--admin-users foo@example.com bar@example.com``:

- Worker boot log: ``Admin users for this BioEngine worker: nils.mech@gmail.com, foo@example.com, bar@example.com``
- ``get_status().admin_users`` → ``['nils.mech@gmail.com', 'foo@example.com', 'bar@example.com']`` — exactly 3 emails, no haikunated entries.
- ``worker.list_app_directories()`` (admin-only method) succeeded via the worker's internal ``_admin_context`` — admin auth still works through the email match path.

**External-cluster (KTH dev) worker** with no operator-provided admins:

- Worker boot log: ``Admin users for this BioEngine worker: nils.mech@gmail.com`` — just the token email, no haikunated.

Both modes confirmed. Compared to the broken 0.11.12 state on prod which still had three stale haikunated entries at the top of admin_users at the time of this PR.

## Test plan

- [x] Single-machine docker worker: only emails after boot; admin auth works.
- [x] External-cluster (KTH dev): only token email after boot.
- [ ] Long-running test after merge: confirm 3-hour token refresh + transient reconnect events do not grow admin_users.
