### PR TITLE
fix(ray_cluster): ray.shutdown() before reconnect in check_connection

### DIFF
--- a/bioengine/cluster/ray_cluster.py
+++ b/bioengine/cluster/ray_cluster.py
@@ -875,6 +875,19 @@ class RayCluster:
 
         if not ray.is_initialized():
             self.logger.warning(f"Ray client disconnected. Reconnecting...")
+            # In external-cluster mode the Ray Client global state retains
+            # `allow_multiple=True` from the previous gRPC session even after
+            # is_initialized() returns False — a bare ray.init() then raises
+            # "client has already connected with allow_multiple=True" and
+            # the auto-recovery loop wedges. Shut down first to clear it.
+            # Skip the shutdown in single-machine / SLURM modes where it
+            # would stop the local cluster itself.
+            if self.mode == "external-cluster":
+                try:
+                    await asyncio.to_thread(ray.shutdown)
+                except Exception as e:
+                    self.logger.debug(f"ray.shutdown() during reconnect raised: {e}")
+                self.proxy_actor_handle = None
             await self._connect_to_cluster()
 
     async def reconnect(self) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.11.13"
+version = "0.11.14"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Problem

In external-cluster mode the worker's monitoring loop saw ``ray.is_initialized()`` return False after a Ray Client gRPC disconnect and went straight to ``_connect_to_cluster`` → ``ray.init``, but Ray Client's **process-global state** retains the previous session's ``allow_multiple=True`` flag. The next ``ray.init`` raises:

```
ValueError: The client has already connected to the cluster with
  allow_multiple=True. Please set allow_multiple=True to proceed
```

The monitoring loop retries every second and never recovers.

**Observed on the KTH worker** after ~3 days of uptime on 0.11.12: 910+ consecutive failures of exactly this shape. The dashboard's "no app services" symptom traced to every ``get_app_status`` call hitting ``check_connection`` → reconnect → error. Apps were still running cluster-side; the worker just couldn't see them. A ``kubectl rollout restart`` of the worker pod restored service in production.

## Solution

The dedicated ``reconnect()`` method already does the right thing — calls ``ray.shutdown()`` first to clear the gRPC session, then re-init. Mirror that pattern in ``check_connection``'s auto-recovery path, gated to external-cluster mode (in single-machine / SLURM modes ``ray.shutdown()`` would stop the local cluster itself, per the existing comment on ``reconnect()``).

## Files

| File | Change |
|---|---|
| ``bioengine/cluster/ray_cluster.py`` | In ``check_connection``, when ``ray.is_initialized()`` is False and mode is ``external-cluster``: call ``ray.shutdown()`` and drop the stale ``proxy_actor_handle`` before ``_connect_to_cluster()``. Single-machine / SLURM behaviour unchanged. |

## Validation (0.11.14-dev1)

**KTH dev worker** (external-cluster, where the fix lives):

- Worker booted cleanly on the dev image — no behavioural change to the happy path (the new code only runs when ``ray.is_initialized()`` is False).
- Functional smoke: deploy + ping a small ``@bioengine.app`` succeeded in ~10 s through the worker's normal ``check_connection`` path.

**Single-machine** validation: not separately exercised. The change is gated to ``self.mode == "external-cluster"``, so single-machine code is byte-identical to ``main``. Cross-mode regression surface is zero.

The actual disconnect-recovery scenario is hard to inject synthetically without modifying running code, but the fix mirrors the existing ``reconnect()`` pattern verbatim — that pattern is already in production use for the stale-handle path. After merge: the next time KTH's Ray Client drops, the worker self-heals instead of wedging in the retry loop.

## Test plan

- [x] KTH dev worker boots cleanly and serves apps; no behavioural change on the healthy path.
- [ ] Long-running validation in production: confirm the next transient Ray Client disconnect on KTH self-heals (no pod restart needed).
