### PR TITLE
fix(datasets): auto-recover from stale data-server URL on transport error

### DIFF
--- a/bioengine/datasets/datasets.py
+++ b/bioengine/datasets/datasets.py
@@ -1,11 +1,25 @@
 import asyncio
 import logging
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Union
 
 import httpx
 
 from bioengine.datasets.chunk_cache import ChunkCache, _DEFAULT_CACHE_SIZE_GB
+
+# Transport errors that signal the cached data-server URL may now point at
+# the wrong endpoint (container restarted on a new IP, pod rescheduled,
+# bridge re-attached). On any of these we re-discover via refresh() and
+# retry the request once. 4xx/5xx HTTP status errors are deliberately NOT
+# in this list — those indicate the server is reachable but unhappy with
+# the request, and re-discovering wouldn't help.
+_STALE_URL_TRANSPORT_ERRORS = (
+    httpx.ConnectError,
+    httpx.RemoteProtocolError,
+    httpx.ReadError,
+    httpx.ConnectTimeout,
+    httpx.ReadTimeout,
+)
 
 
 class BioEngineDatasets:
@@ -163,6 +177,39 @@ class BioEngineDatasets:
         self._resolve_service_url(initial=False)
         return self.service_url
 
+    async def _with_url_recovery(
+        self, op: Callable[[], Awaitable[Any]]
+    ) -> Any:
+        """Run ``op``; on transport error, refresh the URL and retry once.
+
+        Catches the connection/read/timeout shapes that signal the cached
+        data-server URL has gone stale (data-server container restarted on
+        a new IP, pod rescheduled, etc.) and re-runs ``op`` once after
+        ``refresh()`` updates ``self.service_url`` from the discovery file.
+
+        ``op`` is a zero-arg async callable that must reference
+        ``self.service_url`` at *call time* (not bake it into a literal
+        before invocation), so the retry picks up the refreshed value.
+        4xx/5xx HTTP errors are re-raised without a retry — those mean the
+        server is reachable but unhappy, and re-discovery wouldn't help.
+        """
+        try:
+            return await op()
+        except _STALE_URL_TRANSPORT_ERRORS as exc:
+            self.logger.warning(
+                f"Data server transport error against '{self.service_url}' "
+                f"({type(exc).__name__}: {exc}); forcing re-discovery and "
+                f"retrying once."
+            )
+            new_url = await self.refresh()
+            if new_url is None:
+                # No new URL available; nothing more we can do.
+                raise
+            self.logger.info(
+                f"Data server re-discovered at '{new_url}'; retrying."
+            )
+            return await op()
+
     async def set_chunk_cache_size_gb(self, gb: int) -> None:
         """
         Change the chunk cache size limit at runtime.
@@ -192,13 +239,16 @@ class BioEngineDatasets:
 
         from bioengine.datasets.utils import get_url_with_retry
 
-        try:
+        async def _ping() -> None:
             await get_url_with_retry(
                 url=f"{self.service_url}/ping",
                 raise_for_status=True,
                 http_client=httpx.AsyncClient(timeout=3.0),  # short timeout for ping
                 logger=self.logger,
             )
+
+        try:
+            await self._with_url_recovery(_ping)
         except Exception as e:
             self.logger.error(f"Connection to data server failed: {e}")
             raise RuntimeError("Connection to data server failed")
@@ -225,12 +275,16 @@ class BioEngineDatasets:
         from bioengine.datasets.utils import get_url_with_retry
 
         start_time = asyncio.get_event_loop().time()
-        response = await get_url_with_retry(
-            url=f"{self.service_url}/datasets",
-            raise_for_status=True,
-            http_client=self.http_client,
-            logger=self.logger,
-        )
+
+        async def _list():
+            return await get_url_with_retry(
+                url=f"{self.service_url}/datasets",
+                raise_for_status=True,
+                http_client=self.http_client,
+                logger=self.logger,
+            )
+
+        response = await self._with_url_recovery(_list)
         datasets = response.json()
         end_time = asyncio.get_event_loop().time()
         self.logger.debug(
@@ -282,13 +336,16 @@ class BioEngineDatasets:
         if token is not None:
             params["token"] = token
 
-        response = await get_url_with_retry(
-            url=f"{self.service_url}/datasets/{dataset_id}/files",
-            params=params,
-            raise_for_status=True,
-            http_client=self.http_client,
-            logger=self.logger,
-        )
+        async def _list_files():
+            return await get_url_with_retry(
+                url=f"{self.service_url}/datasets/{dataset_id}/files",
+                params=params,
+                raise_for_status=True,
+                http_client=self.http_client,
+                logger=self.logger,
+            )
+
+        response = await self._with_url_recovery(_list_files)
         files = response.json()
         end_time = asyncio.get_event_loop().time()
         self.logger.debug(
@@ -379,13 +436,17 @@ class BioEngineDatasets:
             from bioengine.datasets.utils import get_url_with_retry
 
             params = {"token": token} if token else {}
-            response = await get_url_with_retry(
-                url=f"{self.service_url}/data/{dataset_id}/{_file_path.as_posix()}",
-                params=params,
-                raise_for_status=True,
-                http_client=self.http_client,
-                logger=self.logger,
-            )
+
+            async def _get():
+                return await get_url_with_retry(
+                    url=f"{self.service_url}/data/{dataset_id}/{_file_path.as_posix()}",
+                    params=params,
+                    raise_for_status=True,
+                    http_client=self.http_client,
+                    logger=self.logger,
+                )
+
+            response = await self._with_url_recovery(_get)
             file_output = response.content
 
         end_time = asyncio.get_event_loop().time()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.11.15"
+version = "0.11.16"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Problem

``BioEngineDatasets`` caches the data-server URL on first resolve and never re-checks. When the data-server container restarts on a new IP (docker compose restart, kube pod reschedule, bridge re-attach), the cached URL points at a dead endpoint and every dataset call hits the transport layer with no recovery:

- ``list_datasets()`` never catches ``ConnectError`` → caller gets a transport exception instead of the empty-or-recovered dict it expected.
- ``ping_data_server()`` wraps the exception in a generic ``RuntimeError`` with no recovery hint.
- ``list_files()`` / ``get_file()`` same shape.
- ``_datasets_singleton`` in ``_app/accessors.py`` lives at module scope, so the only consumer-side workaround is restarting the whole replica.

**Observed in production** on ``chiron-manager.get_datasets_info()``: silent empty dict on every call until the worker pod was restarted a second time, even though the data-server was healthy and discoverable on its new IP. Surfaced during a Chiron demo recording.

## Solution

Add a small ``_with_url_recovery`` helper on ``BioEngineDatasets`` that catches the connection / read / timeout shapes signaling a stale endpoint (``ConnectError``, ``RemoteProtocolError``, ``ReadError``, ``ConnectTimeout``, ``ReadTimeout``), calls ``refresh()`` to re-read the discovery file, and retries the op once. **4xx/5xx HTTP status errors are deliberately NOT caught** — those mean the server is reachable but unhappy, and re-discovery wouldn't help.

The closures used by each method reference ``self.service_url`` at call time, so the retry picks up the new URL after ``refresh()`` updates it.

Applied to:
- ``ping_data_server``
- ``list_datasets``
- ``list_files``
- The non-zarr branch of ``get_file``

**Known limitation, out of scope**: the zarr branch of ``get_file`` returns an ``HttpZarrStore`` that lives in the consumer's hands — its chunk fetches aren't routed through this class, so they remain on the original URL until the next list/get call triggers recovery. Worth a follow-up if the chunk-fetch path also needs auto-recovery (would require ``HttpZarrStore`` to call back into ``BioEngineDatasets`` on transport errors).

## Files

| File | Change |
|---|---|
| ``bioengine/datasets/datasets.py`` | Add module-level ``_STALE_URL_TRANSPORT_ERRORS`` tuple. Add ``BioEngineDatasets._with_url_recovery`` helper. Wrap the four public data-path methods in an inner closure passed through the helper. |

## Validation

Stand-alone behavioural test (mock ``get_url_with_retry``, real ``BioEngineDatasets`` + real discovery file):

1. Initial discovery file = ``http://server-a.example``; client caches it.
2. Discovery file is rewritten to ``http://server-b.example`` (simulating data-server restart on new IP).
3. ``list_datasets()`` → first call to server-a raises ``ConnectError`` → ``refresh()`` re-reads file, gets server-b → retry against server-b succeeds, returns the expected payload.
4. Subsequent ``list_datasets()`` calls hit server-b directly (single HTTP call, no retry needed).
5. When the discovery file is later deleted entirely, ``refresh()`` returns ``None`` and the original ``ConnectError`` propagates cleanly (no infinite retry loop).

All 6 cases PASS. Worker logs show the exact recovery line shape:

```
WARNING bioengine.datasets: Data server transport error against 'http://server-a.example' (ConnectError: connection refused to http://server-a.example/datasets); forcing re-discovery and retrying once.
INFO bioengine.datasets: Data server URL: http://server-b.example
INFO bioengine.datasets: Data server re-discovered at 'http://server-b.example'; retrying.
```

## Test plan

- [x] Stand-alone behavioural test reproduces the recovery flow end-to-end and the no-recovery-possible fallback.
- [ ] KTH dev (external-cluster) smoke: worker boots, dataset listing works through the wrapper (no transport error path exercised in normal operation — purely no-op).
- [ ] Chiron repro after merge: ``docker compose restart data-server`` no longer causes silent empty ``get_datasets_info()`` for the chiron-manager replica.