### PR TITLE
feat(app): manual eviction API for @bioengine.multiplexed caches

### DIFF
--- a/bioengine/__init__.py
+++ b/bioengine/__init__.py
@@ -179,6 +179,13 @@ def __getattr__(name: str) -> Any:
         import bioengine.datasets as _datasets_module
 
         return _datasets_module
+    if name == "multiplex":
+        # Public helpers for the ``@bioengine.multiplexed`` cache — manual
+        # LRU / specific-model / evict-all + introspection. Lazy so that
+        # plain ``import bioengine`` doesn't drag in the wrapper class.
+        from bioengine._app import multiplex as _multiplex_module
+
+        return _multiplex_module
     if name == "logger":
         from bioengine._app.accessors import _get_logger
 
@@ -191,4 +198,4 @@ def __getattr__(name: str) -> Any:
 
 
 def __dir__() -> list[str]:
-    return sorted({"__version__", "datasets", "logger", *_LAZY_FROM_APP})
+    return sorted({"__version__", "datasets", "logger", "multiplex", *_LAZY_FROM_APP})

--- a/bioengine/_app/decorators.py
+++ b/bioengine/_app/decorators.py
@@ -179,11 +179,45 @@ def health_check(fn: Callable[..., Any]) -> Callable[..., Any]:
 
 
 def multiplexed(*, max_models: int = 3) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-    """Mark a method as a Ray Serve multiplexed model loader.
+    """Mark a method as an LRU-cached, per-replica multiplexed model loader.
 
     Equivalent to ``@serve.multiplexed(max_num_models_per_replica=N)`` —
     ``@bioengine.app`` applies the underlying Ray Serve decorator at the
-    right point in the pipeline.
+    right point in the pipeline. On cache overflow the least-recently-used
+    model is unloaded automatically; the loaded model's ``__del__`` is
+    called (if defined) so GPU memory / disk handles / etc. are released
+    eagerly.
+
+    Manual cache control is available via the ``bioengine.multiplex``
+    submodule — useful when a downstream call needs the full GPU (e.g.
+    running ``bioimageio.core.test_model`` on a foundation model that
+    won't fit alongside cached siblings):
+
+    .. code-block:: python
+
+        import bioengine
+
+        class RuntimeApp:
+            @bioengine.multiplexed(max_models=3)
+            async def load_model(self, model_id: str): ...
+
+            @bioengine.method
+            async def free_gpu_for_test(self) -> int:
+                # Drop every cached model right now. Each ``__del__`` fires
+                # the same way it does on natural LRU eviction.
+                return await bioengine.multiplex.evict_all_models(self)
+
+    ``bioengine.multiplex`` also exposes ``evict_lru_model``, ``evict_model``,
+    and ``cached_model_ids`` — see that module for details.
+
+    **Only one ``@bioengine.multiplexed`` method per class.** Ray Serve's
+    multiplexing stores its cache wrapper at a single hardcoded attribute
+    on ``self``, so a second decorated method would silently share the
+    first method's cache and loader function — leading to the wrong
+    ``model_id`` being routed to the wrong loader with no error. bioengine
+    rejects a second ``@multiplexed`` at ``@bioengine.app`` scan time. If
+    you need multiple caches, split them into separate deployment classes
+    or use ``functools.lru_cache`` inside a plain ``@bioengine.method``.
     """
     def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
         setattr(fn, _KIND_ATTR, "multiplexed")
@@ -331,6 +365,29 @@ def _scan_class(cls: type) -> tuple[Dict[str, Any], List[Dict[str, Any]]]:
                     f"'{lifecycle[kind]}' and '{attr_name}'. Only one is allowed."
                 )
             lifecycle[kind] = attr_name
+
+    if len(lifecycle["multiplexed"]) > 1:
+        # Ray Serve's ``@serve.multiplexed`` stores its cache wrapper on
+        # ``self`` at a hardcoded attribute name (``__serve_multiplex_wrapper``
+        # in ``ray/serve/api.py``). A second decorated method silently
+        # reuses the first method's wrapper — so calls to the second
+        # method are dispatched to the first method's loader with the
+        # wrong ``model_id``. Ray does not error, just silently produces
+        # wrong results. Raise loudly at ``@bioengine.app`` scan time
+        # instead of letting authors chase the mis-loaded model at runtime.
+        names = ", ".join(f"'{n}'" for n in lifecycle["multiplexed"])
+        raise ReservedMethodNameError(
+            f"{cls.__module__}.{cls.__qualname__} has more than one "
+            f"@bioengine.multiplexed method ({names}). Only one is "
+            f"allowed per deployment class — Ray Serve's underlying "
+            f"multiplexing keeps its LRU cache on a single hardcoded "
+            f"attribute on ``self``, so a second decorated method would "
+            f"silently share the first method's cache and loader. If "
+            f"you need multiple model caches, split the loaders into "
+            f"separate @bioengine.app deployment classes, or use "
+            f"``functools.lru_cache`` inside a plain @bioengine.method "
+            f"if the entries fit CPU memory."
+        )
 
     return lifecycle, method_schemas
 

--- a/bioengine/_app/multiplex.py
+++ b/bioengine/_app/multiplex.py
@@ -1,0 +1,135 @@
+"""Public helpers for interacting with the multiplexed-model cache.
+
+The ``@bioengine.multiplexed`` decorator wraps a class method so Ray Serve's
+``_ModelMultiplexWrapper`` provides LRU-cached model loading with a per-replica
+size cap. Ray keeps the wrapper on the deployment instance under the attribute
+``__serve_multiplex_wrapper``, but does not expose a user-facing way to reach
+in — no manual eviction API, no way to inspect what's currently loaded, no way
+to free the GPU on demand before a heavy call.
+
+This module bridges that gap. Every helper accepts the deployment instance
+(``self``) and calls into the same ``_ModelMultiplexWrapper.unload_model_lru``
+Ray already uses internally when it needs to evict on cache overflow — so
+cleanup semantics (calling the model's ``__del__``, releasing GPU memory,
+metrics accounting) are identical to Ray's own eviction path. That means a
+foundation-model app can drop its cached model right before running an
+expensive ``test()`` and the GPU frees the same way it would if the cache had
+naturally overflowed.
+
+Usage inside a deployment method:
+
+    import bioengine
+
+    class RuntimeApp:
+        @bioengine.multiplexed(max_models=3)
+        async def load_model(self, model_id: str): ...
+
+        @bioengine.method
+        async def free_gpu_for_test(self) -> int:
+            return await bioengine.multiplex.evict_all_models(self)
+
+Ray Serve enforces one ``@serve.multiplexed`` per class (attribute name is
+hardcoded); bioengine surfaces that as a hard rejection at ``_scan_class`` time
+so authors don't hit silently-shared caches. These helpers therefore always
+operate on the single wrapper.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+# Ray stores the multiplex wrapper on the deployment instance under this
+# hardcoded attribute name. See ray/serve/api.py:_multiplex_wrapper — the
+# constant lives inline there rather than being exported, so we mirror it
+# here. If a Ray Serve upgrade ever renames it, this is the only place
+# that needs a change.
+_RAY_MULTIPLEX_ATTR = "__serve_multiplex_wrapper"
+
+
+def _get_wrapper(app_instance: Any) -> Optional[Any]:
+    """Return Ray Serve's ``_ModelMultiplexWrapper`` on ``app_instance``.
+
+    ``None`` when the deployment has no ``@bioengine.multiplexed`` method,
+    or when a decorated method exists but has not yet been called on this
+    replica (Ray creates the wrapper lazily on first call).
+    """
+    return getattr(app_instance, _RAY_MULTIPLEX_ATTR, None)
+
+
+async def evict_lru_model(app_instance: Any) -> Optional[str]:
+    """Evict the least-recently-used model from the multiplexed cache.
+
+    Args:
+        app_instance: the ``self`` of a ``@bioengine.app`` deployment that
+            has a ``@bioengine.multiplexed`` method.
+
+    Returns:
+        The evicted ``model_id``, or ``None`` if the cache is empty or the
+        multiplexed method hasn't been called yet on this replica.
+    """
+    wrapper = _get_wrapper(app_instance)
+    if wrapper is None or not wrapper.models:
+        return None
+    # ``models`` is an OrderedDict ordered LRU → MRU (Ray moves entries to
+    # the end on access in ``load_model``). Peek at the LRU key BEFORE
+    # unload_model_lru mutates the dict so we can return it.
+    lru_id = next(iter(wrapper.models))
+    await wrapper.unload_model_lru()
+    return lru_id
+
+
+async def evict_all_models(app_instance: Any) -> int:
+    """Evict every model from the multiplexed cache.
+
+    Uses the same LRU-unload code path Ray uses for cache-overflow eviction,
+    so per-model cleanup (``__del__``, GPU-memory release) is identical.
+
+    Returns:
+        The number of models evicted (0 if the cache was empty or no
+        wrapper exists yet on this replica).
+    """
+    wrapper = _get_wrapper(app_instance)
+    if wrapper is None:
+        return 0
+    count = len(wrapper.models)
+    while wrapper.models:
+        await wrapper.unload_model_lru()
+    return count
+
+
+async def evict_model(app_instance: Any, model_id: str) -> bool:
+    """Evict a specific model from the multiplexed cache by id.
+
+    Preserves the LRU order of the remaining models. Implemented by moving
+    the target to the LRU end of the ``OrderedDict`` and calling Ray's
+    ``unload_model_lru`` — that path drives the same ``__del__``-hook
+    cleanup Ray uses on natural eviction.
+
+    Args:
+        app_instance: the ``self`` of a ``@bioengine.app`` deployment.
+        model_id: the model to evict.
+
+    Returns:
+        ``True`` if the model was in cache and got evicted; ``False`` if
+        no wrapper exists yet or the model wasn't in cache.
+    """
+    wrapper = _get_wrapper(app_instance)
+    if wrapper is None or model_id not in wrapper.models:
+        return False
+    # Move the target to position 0 (LRU end) so ``unload_model_lru``
+    # picks it. move_to_end(last=False) is O(1) on OrderedDict.
+    wrapper.models.move_to_end(model_id, last=False)
+    await wrapper.unload_model_lru()
+    return True
+
+
+def cached_model_ids(app_instance: Any) -> List[str]:
+    """Return the ids currently in the multiplexed cache, LRU → MRU order.
+
+    Useful for a status endpoint or a health-check that wants to report
+    what's warm. Returns an empty list when no wrapper exists yet.
+    """
+    wrapper = _get_wrapper(app_instance)
+    if wrapper is None:
+        return []
+    return list(wrapper.models.keys())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.11.19"
+version = "0.11.20"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [

--- a/tests/_app/test_multiplex_helpers.py
+++ b/tests/_app/test_multiplex_helpers.py
@@ -1,0 +1,216 @@
+"""Pin the ``bioengine.multiplex`` public helpers.
+
+Ray Serve's ``_ModelMultiplexWrapper`` is where the LRU cache actually lives;
+Ray stores the instance on each replica as ``self.__serve_multiplex_wrapper``
+and does not expose a public way to reach it. The ``bioengine.multiplex``
+submodule bridges that gap:
+
+- ``evict_lru_model`` — evict the least-recently-used entry, return its id
+- ``evict_all_models`` — drain the cache, return count evicted
+- ``evict_model`` — evict a specific id
+- ``cached_model_ids`` — list currently-cached ids in LRU→MRU order
+
+These tests use a stub wrapper (mirroring the OrderedDict + async
+``unload_model_lru`` contract Ray Serve exposes) so they don't need a live
+Ray Serve deployment. If Ray changes the private attribute name in a future
+release, ``_RAY_MULTIPLEX_ATTR`` in ``multiplex.py`` needs to update — the
+"no wrapper found" tests catch that regression.
+"""
+from __future__ import annotations
+
+from collections import OrderedDict
+
+import pytest
+
+import bioengine
+from bioengine._app import multiplex
+from bioengine._app.errors import ReservedMethodNameError
+
+
+class _StubWrapper:
+    """Mimics ``ray.serve.multiplex._ModelMultiplexWrapper`` just enough.
+
+    Ray's ``load_model`` moves the entry to the end of the ``models``
+    OrderedDict on access — so ``next(iter(models))`` is the LRU key, and
+    ``models.popitem(last=False)`` in ``unload_model_lru`` pops it.
+    """
+
+    def __init__(self, initial: dict[str, object] | None = None) -> None:
+        self.models: OrderedDict[str, object] = OrderedDict(initial or {})
+        self.unload_calls: list[str] = []
+
+    async def unload_model_lru(self) -> None:
+        # Match Ray's semantics: pop the LRU (first) entry.
+        model_id, _ = self.models.popitem(last=False)
+        self.unload_calls.append(model_id)
+
+
+def _attach(wrapper: _StubWrapper) -> object:
+    """Return a bare object with the Ray-Serve-private attribute pointing at
+    the stub — mirrors how a real deployment replica exposes its cache."""
+
+    class _Replica:
+        pass
+
+    r = _Replica()
+    setattr(r, multiplex._RAY_MULTIPLEX_ATTR, wrapper)
+    return r
+
+
+# ---------- cached_model_ids ----------
+
+
+def test_cached_model_ids_returns_lru_to_mru_order() -> None:
+    """Order of the returned list must match Ray's LRU→MRU convention so
+    dashboards / status endpoints display the "next-to-be-evicted" entry
+    first."""
+    w = _StubWrapper({"a": 1, "b": 2, "c": 3})
+    r = _attach(w)
+    assert multiplex.cached_model_ids(r) == ["a", "b", "c"]
+
+
+def test_cached_model_ids_returns_empty_when_no_wrapper() -> None:
+    """A deployment without a ``@bioengine.multiplexed`` method — or one
+    that hasn't been called yet — has no wrapper attribute. The helper
+    must degrade to an empty list, not raise."""
+
+    class _Bare:
+        pass
+
+    assert multiplex.cached_model_ids(_Bare()) == []
+
+
+# ---------- evict_lru_model ----------
+
+
+@pytest.mark.asyncio
+async def test_evict_lru_returns_evicted_id_and_removes_it() -> None:
+    w = _StubWrapper({"a": 1, "b": 2, "c": 3})
+    r = _attach(w)
+    evicted = await multiplex.evict_lru_model(r)
+    assert evicted == "a"
+    assert list(w.models.keys()) == ["b", "c"]
+    assert w.unload_calls == ["a"]  # went through Ray's unload path
+
+
+@pytest.mark.asyncio
+async def test_evict_lru_returns_none_on_empty_cache() -> None:
+    w = _StubWrapper({})
+    r = _attach(w)
+    assert await multiplex.evict_lru_model(r) is None
+    assert w.unload_calls == []
+
+
+@pytest.mark.asyncio
+async def test_evict_lru_returns_none_when_no_wrapper() -> None:
+    """No wrapper = no cache = nothing to evict. Must not raise."""
+
+    class _Bare:
+        pass
+
+    assert await multiplex.evict_lru_model(_Bare()) is None
+
+
+# ---------- evict_all_models ----------
+
+
+@pytest.mark.asyncio
+async def test_evict_all_drains_cache_and_returns_count() -> None:
+    w = _StubWrapper({"a": 1, "b": 2, "c": 3})
+    r = _attach(w)
+    n = await multiplex.evict_all_models(r)
+    assert n == 3
+    assert list(w.models.keys()) == []
+    # All three drained via Ray's LRU-unload path, LRU-first.
+    assert w.unload_calls == ["a", "b", "c"]
+
+
+@pytest.mark.asyncio
+async def test_evict_all_returns_zero_on_empty_cache() -> None:
+    r = _attach(_StubWrapper({}))
+    assert await multiplex.evict_all_models(r) == 0
+
+
+@pytest.mark.asyncio
+async def test_evict_all_returns_zero_when_no_wrapper() -> None:
+    class _Bare:
+        pass
+
+    assert await multiplex.evict_all_models(_Bare()) == 0
+
+
+# ---------- evict_model ----------
+
+
+@pytest.mark.asyncio
+async def test_evict_specific_removes_target_and_preserves_others_order() -> None:
+    """Evicting a non-LRU model must not disturb the LRU order of the rest —
+    otherwise the next natural eviction would target the wrong entry."""
+    w = _StubWrapper({"a": 1, "b": 2, "c": 3, "d": 4})
+    r = _attach(w)
+    ok = await multiplex.evict_model(r, "c")
+    assert ok is True
+    assert list(w.models.keys()) == ["a", "b", "d"]
+    # Ray's unload path fired for "c" specifically.
+    assert w.unload_calls == ["c"]
+
+
+@pytest.mark.asyncio
+async def test_evict_specific_returns_false_when_not_cached() -> None:
+    w = _StubWrapper({"a": 1})
+    r = _attach(w)
+    assert await multiplex.evict_model(r, "does-not-exist") is False
+    # Nothing evicted.
+    assert list(w.models.keys()) == ["a"]
+    assert w.unload_calls == []
+
+
+@pytest.mark.asyncio
+async def test_evict_specific_returns_false_when_no_wrapper() -> None:
+    class _Bare:
+        pass
+
+    assert await multiplex.evict_model(_Bare(), "anything") is False
+
+
+# ---------- decorator "one per class" enforcement ----------
+
+
+def test_multiple_multiplexed_methods_raises_at_scan_time() -> None:
+    """Ray Serve stores its multiplex cache on ``self`` at a single
+    hardcoded attribute. A second ``@bioengine.multiplexed`` method would
+    silently share the first one's wrapper — mis-dispatching model_ids
+    to the wrong loader. bioengine rejects the class outright.
+
+    Note: ``pytest.raises(ReservedMethodNameError, ...)`` would be nicer
+    but ``test_decorators_baseline_imports.py`` reloads ``bioengine._app``
+    mid-suite — that gives ``ReservedMethodNameError`` a fresh class
+    identity that mismatches whatever this file imported at collection
+    time. Matching on the class name string is the same failure mode
+    check without the identity trap.
+    """
+    with pytest.raises(Exception) as exc_info:
+
+        @bioengine.app(num_cpus=1, num_gpus=0, memory_mb=128)
+        class TwoCaches:  # noqa: D401 — test fixture
+            @bioengine.multiplexed(max_models=2)
+            async def load_a(self, model_id: str): ...
+
+            @bioengine.multiplexed(max_models=2)
+            async def load_b(self, model_id: str): ...
+
+    assert type(exc_info.value).__name__ == "ReservedMethodNameError"
+    assert "more than one @bioengine.multiplexed" in str(exc_info.value)
+
+
+def test_single_multiplexed_method_is_accepted() -> None:
+    """Regression fence for the enforcement check — a class with exactly
+    one @bioengine.multiplexed method must still decorate cleanly."""
+
+    @bioengine.app(num_cpus=1, num_gpus=0, memory_mb=128)
+    class OneCache:  # noqa: D401 — test fixture
+        @bioengine.multiplexed(max_models=5)
+        async def load(self, model_id: str): ...
+
+    # Decoration succeeded — nothing else to assert.
+    assert OneCache is not None


### PR DESCRIPTION
## Summary

Ray Serve's `@serve.multiplexed` gives us LRU-cached model loading via `_ModelMultiplexWrapper` (`ray/serve/multiplex.py`) but exposes no public way to reach into the cache — no manual eviction, no introspection. This PR adds a small `bioengine.multiplex` submodule that bridges the gap, plus a loud-fail check for the "one multiplexed per class" limitation Ray Serve silently imposes.

## Motivation

Foundation models are the immediate driver: a single one may fill the entire GPU, so a downstream `bioimageio.core.test_model` call needs the cache to be empty first. Previously there was no way for the deployment method to request that — Ray's `_ModelMultiplexWrapper.unload_model_lru` and `unload_model` exist, but not exposed in Ray's public API. Same story for introspection ("which models are warm right now?" for a status endpoint).

## Public surface — `bioengine.multiplex` submodule

```python
import bioengine

class RuntimeApp:
    @bioengine.multiplexed(max_models=3)   # existing decorator, unchanged
    async def load_model(self, model_id: str): ...

    @bioengine.method
    async def free_gpu_for_test(self) -> int:
        return await bioengine.multiplex.evict_all_models(self)
```

| Function | Purpose | Returns |
|---|---|---|
| `evict_lru_model(self)` | evict LRU | `Optional[str]` — model_id or None |
| `evict_all_models(self)` | drain the cache | `int` count |
| `evict_model(self, model_id)` | evict specific id | `bool` |
| `cached_model_ids(self)` | introspect | `list[str]` LRU→MRU |

Under the hood each helper reads `getattr(self, "__serve_multiplex_wrapper", None)` (Ray's private attribute name) and calls `wrapper.unload_model_lru()` — Ray's existing unload path — so per-model cleanup (`__del__` hook, GPU-memory release, metrics accounting) is identical to natural cache-overflow eviction.

## Second change — reject two `@bioengine.multiplexed` per class

Ray Serve stores its cache wrapper at a hardcoded attribute name on `self` (`__serve_multiplex_wrapper` in `ray/serve/api.py:_multiplex_wrapper`). A second decorated method silently shares the first method's wrapper — so calls to the second method get dispatched to the FIRST method's loader with the WRONG `model_id`. No error, just wrong.

`_scan_class` now raises `ReservedMethodNameError` at `@bioengine.app` scan time when it sees more than one `@bioengine.multiplexed` method, with a message pointing at the Ray limitation and suggesting the workaround (split into multiple deployment classes, or use `functools.lru_cache` inside a plain method).

## Test plan

- [x] 13 new unit tests pin the four helpers (`evict_lru_model`, `evict_all_models`, `evict_model`, `cached_model_ids`) using a stub `_ModelMultiplexWrapper` that mirrors Ray's `OrderedDict`+`unload_model_lru` contract, plus the "one per class" enforcement (`test_multiple_multiplexed_methods_raises_at_scan_time`, `test_single_multiplexed_method_is_accepted`).
- [x] Full `tests/_app/` suite: 92 pass.
- [x] Full `tests/apps/` suite: 138 pass; the 32 pre-existing errors are the multi-worker `model-runner` service name-collision integration tests, unrelated to this PR.
- [ ] Single-machine dev-image + KTH validation once merged (I'll dev-tag `0.11.20-dev1`, deploy a scratch app that exercises `evict_all_models`, confirm cache is empty via `cached_model_ids`).

## Not in scope

- Model-runner's OOM-on-test fix (calls `await bioengine.multiplex.evict_all_models(self)` before `test()`). That's a downstream model-runner app change, tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)