### PR TITLE
fix(core): expose __version__ on Ray Serve replicas via _version.py

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -98,6 +98,26 @@ jobs:
         fi
         echo "✅ Version updated from $PREVIOUS_VERSION to $NEW_VERSION."
 
+    - name: Ensure bioengine/_version.py matches pyproject.toml
+      if: env.RELEVANT_CHANGE == 'true'
+      # ``bioengine/_version.py`` is the version string that Ray Serve
+      # replicas see (``pyproject.toml`` is not on the replica; only the
+      # module source is, via ``runtime_env.py_modules``). It MUST stay
+      # in lock-step with pyproject.toml or ``__version__`` diverges
+      # between worker and replicas.
+      run: |
+        VERSION_PY=$(python3 -c "import re; m = re.search(r'^__version__\s*=\s*[\"\\'](.*?)[\"\\']', open('bioengine/_version.py').read(), re.M); print(m.group(1) if m else '')")
+        PROJECT_VERSION=$(grep -E '^version\s*=' pyproject.toml | sed -E 's/version\s*=\s*"(.*)"/\1/')
+        if [ -z "$VERSION_PY" ]; then
+          echo "❌ Could not extract __version__ from bioengine/_version.py"
+          exit 1
+        fi
+        if [ "$VERSION_PY" != "$PROJECT_VERSION" ]; then
+          echo "❌ bioengine/_version.py __version__ ($VERSION_PY) does not match pyproject.toml version ($PROJECT_VERSION). Bump both together."
+          exit 1
+        fi
+        echo "✅ bioengine/_version.py in sync with pyproject.toml ($PROJECT_VERSION)."
+
     - name: Skip version check (no relevant changes)
       if: env.RELEVANT_CHANGE == 'false'
       run: echo "✅ No relevant files changed. Skipping version check."

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -99,12 +99,13 @@ jobs:
         echo "✅ Version updated from $PREVIOUS_VERSION to $NEW_VERSION."
 
     - name: Ensure bioengine/_version.py matches pyproject.toml
-      if: env.RELEVANT_CHANGE == 'true'
       # ``bioengine/_version.py`` is the version string that Ray Serve
       # replicas see (``pyproject.toml`` is not on the replica; only the
       # module source is, via ``runtime_env.py_modules``). It MUST stay
       # in lock-step with pyproject.toml or ``__version__`` diverges
-      # between worker and replicas.
+      # between worker and replicas. Always runs — even for docs-only
+      # PRs — so a stray edit to ``_version.py`` in an unrelated PR
+      # can never slip through.
       run: |
         VERSION_PY=$(python3 -c "import re; m = re.search(r'^__version__\s*=\s*[\"\\'](.*?)[\"\\']', open('bioengine/_version.py').read(), re.M); print(m.group(1) if m else '')")
         PROJECT_VERSION=$(grep -E '^version\s*=' pyproject.toml | sed -E 's/version\s*=\s*"(.*)"/\1/')

--- a/bioengine/__init__.py
+++ b/bioengine/__init__.py
@@ -20,8 +20,9 @@ imports only happen when the decorators are actually applied.
 
 from __future__ import annotations
 
-import importlib.metadata as _md
 from typing import TYPE_CHECKING, Any
+
+from bioengine._version import __version__
 
 if TYPE_CHECKING:
     # Type-checker-only re-exports so editors auto-complete bioengine.app etc.
@@ -40,17 +41,6 @@ if TYPE_CHECKING:
         ReservedMethodNameError,
     )
     from bioengine._app.runtime_handle import BioEngineRuntimeHandle
-
-
-def _get_version() -> str | None:
-    try:
-        return _md.metadata("bioengine")["Version"]
-    except Exception:
-        print("Could not get version from package metadata. Is the package installed?")
-        return None
-
-
-__version__ = _get_version()
 
 
 def _install_replica_bootstrap_finder() -> None:

--- a/bioengine/_version.py
+++ b/bioengine/_version.py
@@ -1,0 +1,16 @@
+"""Static version string for the ``bioengine`` package.
+
+Ray Serve replicas import ``bioengine`` via ``runtime_env.py_modules``,
+which ships only the module source directory — not the sibling
+``bioengine-*.dist-info/METADATA`` file. That leaves
+``importlib.metadata.metadata("bioengine")`` failing on the replica
+side and ``__version__`` silently becoming ``None`` (test reports,
+``get_version()`` responses, and cache-invalidation keys all lose
+signal). Baking the version into a real source file sidesteps the
+transport limitation — ``py_modules`` ships this file, so replicas
+see the same string that ``pip`` sees.
+
+Must stay in lock-step with ``pyproject.toml``'s ``version`` field.
+The ``version-check.yml`` CI workflow enforces the match.
+"""
+__version__ = "0.11.20"

--- a/bioengine/_version.py
+++ b/bioengine/_version.py
@@ -13,4 +13,4 @@ see the same string that ``pip`` sees.
 Must stay in lock-step with ``pyproject.toml``'s ``version`` field.
 The ``version-check.yml`` CI workflow enforces the match.
 """
-__version__ = "0.11.20"
+__version__ = "0.11.21"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.11.20"
+version = "0.11.21"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Summary

Ray Serve replicas were seeing `bioengine.__version__ == None`. Root cause: `bioengine/__init__.py` used `importlib.metadata.metadata("bioengine")["Version"]`, which requires a `dist-info/METADATA` file next to the module. The worker has it (pip-installed); replicas don't — the framework ships via `runtime_env.py_modules = [os.path.dirname(bioengine.__file__)]` (`bioengine/cluster/ray_cluster.py:756`), and Ray's `py_modules` transport copies only source, no sibling dist-info. The lookup raised `PackageNotFoundError`, got swallowed, `__version__` became `None`.

Observed downstream:
- model-runner test reports show `env: ["bioengine", null, "", ""]` — breaks the bioimage.io CI cache-invalidation key that reads bioengine identity from that row.
- `get_version()` API returns `bioengine_version: None`.
- Every replica boot prints `Could not get version from package metadata. Is the package installed?` to stderr.

## What changes

- **New file** `bioengine/_version.py` — a 3-line source file carrying `__version__ = "0.11.20"`. `py_modules` ships this file, so replicas see the same string that `pip` sees.
- `bioengine/__init__.py` — drop `_get_version()` + `import importlib.metadata`, replace with `from bioengine._version import __version__`.
- `.github/workflows/version-check.yml` — new step that fails the PR if `_version.py`'s `__version__` diverges from `pyproject.toml`'s `version`. Prevents the two from drifting.

## Test plan

- [x] Local: `python3 -c "import bioengine; assert bioengine.__version__ == '0.11.20'"` — passes.
- [x] Local: simulated CI check confirms `_version.py` == `pyproject.toml` version.
- [ ] Dev image `0.11.21-dev1` built and deployed to KTH; verify:
  - `get_version()` on `bioimage-io/bioengine-worker-kth-*:bioengine-worker` returns `bioengine_version: "0.11.21-dev1"`.
  - model-runner `test(...)` output `env` row shows `["bioengine", "0.11.21-dev1", "", ""]` instead of `[..., null, ...]`.
  - No `Could not get version from package metadata` line in replica stderr.
- [ ] Bump `pyproject.toml` + `bioengine/_version.py` to `0.11.21` in a follow-up commit before marking ready.
- [ ] `version-check.yml` (fires on ready-for-review) passes.