### PR TITLE
fix(worker): harden monitor loop + Ray Client reconnect against head restarts

### DIFF
--- a/bioengine/_version.py
+++ b/bioengine/_version.py
@@ -13,4 +13,4 @@ see the same string that ``pip`` sees.
 Must stay in lock-step with ``pyproject.toml``'s ``version`` field.
 The ``version-check.yml`` CI workflow enforces the match.
 """
-__version__ = "0.11.22"
+__version__ = "0.11.23"

--- a/bioengine/cluster/ray_cluster.py
+++ b/bioengine/cluster/ray_cluster.py
@@ -179,6 +179,9 @@ class RayCluster:
         self.address = None
         self.serve_http_url = None
         self.proxy_actor_handle = None
+        # Serializes reconnect paths; concurrent callers each racing into
+        # ray.init() trigger "Ray Client is already connected".
+        self._connect_lock = asyncio.Lock()
         # Version-suffix the actor name so workers on different BioEngine
         # versions get their own detached actor — they don't fight over the
         # same one. Strip characters that aren't safe in a Ray actor name.
@@ -873,8 +876,14 @@ class RayCluster:
         if not self.is_ready.is_set():
             raise RuntimeError("Ray cluster is not running")
 
-        if not ray.is_initialized():
-            self.logger.warning(f"Ray client disconnected. Reconnecting...")
+        if ray.is_initialized():
+            return
+
+        async with self._connect_lock:
+            # Re-check: a peer may have reconnected while we waited.
+            if ray.is_initialized():
+                return
+            self.logger.warning("Ray client disconnected. Reconnecting...")
             # In external-cluster mode the Ray Client global state retains
             # `allow_multiple=True` from the previous gRPC session even after
             # is_initialized() returns False — a bare ray.init() then raises
@@ -912,16 +921,19 @@ class RayCluster:
                 f"current mode is '{self.mode}'."
             )
 
-        self.logger.warning("Reconnecting Ray Client to refresh stale handles...")
-        try:
-            await asyncio.to_thread(ray.shutdown)
-        except Exception as e:
-            self.logger.debug(f"ray.shutdown() during reconnect raised: {e}")
-        # Drop the stale proxy actor handle before re-acquiring it; otherwise
-        # callers racing against the reconnect could hold and use it.
-        self.proxy_actor_handle = None
-        await self._connect_to_cluster()
-        self.logger.info("Ray Client reconnected; handles refreshed.")
+        async with self._connect_lock:
+            self.logger.warning(
+                "Reconnecting Ray Client to refresh stale handles..."
+            )
+            try:
+                await asyncio.to_thread(ray.shutdown)
+            except Exception as e:
+                self.logger.debug(f"ray.shutdown() during reconnect raised: {e}")
+            # Drop the stale proxy actor handle before re-acquiring it; otherwise
+            # callers racing against the reconnect could hold and use it.
+            self.proxy_actor_handle = None
+            await self._connect_to_cluster()
+            self.logger.info("Ray Client reconnected; handles refreshed.")
 
     async def call_with_reconnect(self, fn, *args, **kwargs):
         """Run a blocking Ray API call with one automatic stale-handle recovery.
@@ -957,11 +969,30 @@ class RayCluster:
             await self.reconnect()
             return await asyncio.to_thread(fn, *args, **kwargs)
 
+    async def _get_cluster_state_with_reconnect(self):
+        """Fetch cluster state, recovering once from a stale proxy handle.
+
+        The cached ``proxy_actor_handle`` is invalidated when the head node /
+        proxy actor is recycled; reconnect re-acquires it via
+        ``get_if_exists=True`` so the retry lands on a live actor.
+        """
+        try:
+            return await self.proxy_actor_handle.get_cluster_state.remote()
+        except Exception as exc:
+            if not _is_stale_handle_error(exc):
+                raise
+            self.logger.warning(
+                f"Stale proxy actor handle in monitor_cluster: {exc!s}. "
+                f"Reconnecting and retrying once."
+            )
+            await self.reconnect()
+            return await self.proxy_actor_handle.get_cluster_state.remote()
+
     async def monitor_cluster(self) -> None:
         """Monitor cluster status and update worker nodes history."""
         try:
             # Get the current status of the cluster from the BioEngineProxy
-            cluster_status = await self.proxy_actor_handle.get_cluster_state.remote()
+            cluster_status = await self._get_cluster_state_with_reconnect()
 
             self.cluster_status_history[time.time()] = cluster_status
 

--- a/bioengine/worker/worker.py
+++ b/bioengine/worker/worker.py
@@ -845,38 +845,55 @@ class BioEngineWorker:
 
                     self._last_monitoring = current_time
 
+                    # Each step runs independently so an earlier failure (e.g.
+                    # a stale proxy handle in cluster monitoring) can't skip
+                    # application monitoring, which fires auto-redeploy.
+                    # Failures are re-raised at tick end so backoff still runs.
+                    step_errors: List[tuple] = []
+
+                    async def _step(name, coro):
+                        try:
+                            await coro
+                        except asyncio.CancelledError:
+                            raise
+                        except Exception as step_exc:
+                            step_errors.append((name, step_exc))
+                            self.logger.warning(
+                                f"Monitoring step '{name}' failed: {step_exc}"
+                            )
+
                     # ===== 0. Geo location =====
-                    await self._fetch_geo_location()
+                    await _step("geo_location", self._fetch_geo_location())
 
                     # ===== 1. Hypha server connection check =====
-                    # Check connection to Hypha server
-                    await self._check_hypha_connection()
-
-                    # Check token expiry
-                    await self._check_token_expiry()
+                    await _step("hypha_connection", self._check_hypha_connection())
+                    await _step("token_expiry", self._check_token_expiry())
 
                     # ===== 2. Ray cluster monitoring =====
-                    # Check connection to Ray cluster
-                    await self.ray_cluster.check_connection()
-
-                    # Run cluster monitoring
-                    await self.ray_cluster.monitor_cluster()
+                    await _step(
+                        "ray_check_connection", self.ray_cluster.check_connection()
+                    )
+                    await _step(
+                        "cluster_monitoring", self.ray_cluster.monitor_cluster()
+                    )
 
                     # ===== 3. Data server monitoring =====
+                    await _step("data_server_ping", self._ping_data_server())
+                    await _step("data_server_discover", self._discover_data_server())
+                    await _step("dataset_refresh", self._refresh_datasets())
 
-                    # Ping the data server to verify connectivity
-                    await self._ping_data_server()
+                    # ===== 4. Applications monitoring (auto-redeploy) =====
+                    await _step(
+                        "applications_monitoring",
+                        self.apps_manager.monitor_applications(),
+                    )
 
-                    # If not connected to a data server, attempt discovery
-                    await self._discover_data_server()
-
-                    # Refresh datasets if connected to data server
-                    await self._refresh_datasets()
-
-                    # ===== 4. Applications monitoring =====
-
-                    # Run BioEngine Applications monitoring
-                    await self.apps_manager.monitor_applications()
+                    if step_errors:
+                        names = ", ".join(name for name, _ in step_errors)
+                        raise RuntimeError(
+                            f"{len(step_errors)} monitoring step(s) failed this "
+                            f"tick: {names}"
+                        )
 
                     # Run BioEngine Datasets monitoring
                     # await self.dataset_manager.monitor_datasets()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.11.22"
+version = "0.11.23"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Incident

The KTH production worker had all three apps (`model-runner`, `cellpose-finetuning`, `smart-microscopy-assistant`) **down for ~9 hours** despite `auto_redeploy=True`, and wedged so hard that `get_app_status` intermittently failed and a **manual pod restart was required** to recover.

### Trigger
The biweekly Ray-head-restart CronJob (`raycluster-head-biweekly-restart`) fired, restarting the Ray head + GPU workers. This wiped all Ray Serve deployments and invalidated the worker's cached `BioEngineProxyActor` handle. The worker pod itself stayed up (uptime > restart), so KubeRay never re-bootstrapped it — recovery was left entirely to the worker's in-process monitor loop, which then failed in three compounding ways.

## Root causes fixed here

**1. `monitor_cluster()` had no stale-handle recovery** (`ray_cluster.py`)
It called `proxy_actor_handle.get_cluster_state.remote()` directly, unlike the `serve.*` calls that go through `call_with_reconnect`. A stale proxy handle made it raise `Can't run an actor the server doesn't have a handle for` on **every** monitor tick. Now wrapped in `_get_cluster_state_with_reconnect()` which reconnects (re-acquiring the proxy handle via `get_if_exists=True`) and retries once.

**2. The monitor loop ran all steps in one try-block** (`worker.py`)
Steps ran in order: geo → hypha → **ray cluster (step 2)** → data server → **applications (step 4)**. A throw in step 2 skipped everything after it — including application monitoring, which is what fires `auto_redeploy`. So the stale-handle failure in step 2 **starved app recovery entirely**. Each step now runs under its own guard; application monitoring always gets its turn. A summary error is still raised at tick-end so the existing exponential-backoff/health logging is preserved.

**3. `check_connection()` / `reconnect()` raced into `ray.init()`** (`ray_cluster.py`)
Both did check-then-act on `ray.is_initialized()`. The monitor loop plus concurrent inbound RPC handlers (`get_app_status` → `check_connection`) raced into `ray.init`, producing `RuntimeError: Ray Client is already connected. Maybe you called ray.init twice` — the wedge that made a pod restart necessary. Both paths now serialize on a shared `self._connect_lock` with double-checked `is_initialized()`.

## Known follow-up (NOT in this PR)

Auto-redeploy reuses the pre-built app's **baked-in Hypha token** (`_deploy_application` re-submits the stored `built_app`) instead of re-minting. Startup apps get a 30-day worker-minted token once at boot (`deploy_startup_applications`); after 30 days, even with the fixes above, an auto-redeploy would submit with an **expired** token and fail. A full `deploy_app` re-mints, but the auto-redeploy path does not. Fixing it cleanly needs: distinguishing worker-minted vs user-supplied tokens, a refresh-before-expiry strategy, and re-running the build with a fresh token — its own PR with dedicated validation. Deliberately kept out of this PR to keep the delicate reconnect/monitor changes reviewable and to avoid regressing user-app redeploys.

Separately, the incident's *initial* crash-on-restart was the worker's **own** `HYPHA_TOKEN` (k8s secret `bioengine-secrets`) having expired — a credential-rotation concern, not a code bug. Worth adding expiry alerting.

## Validation

- [ ] Dev-image testing workflow (per maintainer skill): build `<next>-devN`, deploy to a live KTH worker, force a Ray head restart, confirm apps auto-recover without a pod restart and `get_app_status` stays responsive throughout.
- [ ] Single-machine mode smoke test (reconnect paths differ — `reconnect()` is external-cluster-only; confirm the `_connect_lock` change doesn't affect single-machine startup).

Deployment-side change (worker monitoring + Ray client plumbing) → dev-image validation required before marking ready. Opening as **draft**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)