### PR TITLE
feat(proxy): reject at capacity instead of queueing unboundedly

### DIFF
--- a/bioengine/_version.py
+++ b/bioengine/_version.py
@@ -13,4 +13,4 @@ see the same string that ``pip`` sees.
 Must stay in lock-step with ``pyproject.toml``'s ``version`` field.
 The ``version-check.yml`` CI workflow enforces the match.
 """
-__version__ = "0.11.25"
+__version__ = "0.11.26"

--- a/bioengine/apps/proxy_deployment.py
+++ b/bioengine/apps/proxy_deployment.py
@@ -445,8 +445,8 @@ class ProxyDeployment:
                 )
                 raise RuntimeError(
                     f"Application '{self.application_id}' has reached its maximum "
-                    f"of {self.max_ongoing_requests} concurrent requests and is "
-                    f"currently very busy. Please try again in a moment."
+                    f"of {self.max_ongoing_requests} concurrent requests. Please "
+                    f"try again in a moment."
                 )
             async with self.service_semaphore:
                 try:

--- a/bioengine/apps/proxy_deployment.py
+++ b/bioengine/apps/proxy_deployment.py
@@ -428,6 +428,26 @@ class ProxyDeployment:
             # Semaphore bounds concurrency for both WebSocket and WebRTC entry paths —
             # they share this single wrapper, so a long-running call from either
             # transport consumes one slot until it returns.
+            #
+            # Fail fast instead of queueing unboundedly when at capacity: a
+            # blocked caller still holds its decoded payload (e.g. an inference
+            # image) in this actor's memory while it waits, so an open-ended
+            # backlog grows proxy memory without limit. Because we reject rather
+            # than await, the semaphore never accumulates waiters — so
+            # ``.locked()`` means "no free slot", and there is no ``await``
+            # between this check and the acquire below, making the decision
+            # race-free.
+            if self.service_semaphore.locked():
+                logger.warning(
+                    f"⚠️ '{self.application_id}' at capacity "
+                    f"({self.max_ongoing_requests} concurrent requests); "
+                    f"rejecting '{method_name}'."
+                )
+                raise RuntimeError(
+                    f"Application '{self.application_id}' has reached its maximum "
+                    f"of {self.max_ongoing_requests} concurrent requests and is "
+                    f"currently very busy. Please try again in a moment."
+                )
             async with self.service_semaphore:
                 try:
                     await self._check_permissions(context, method_name=method_name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.11.25"
+version = "0.11.26"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## What

When an app's `ProxyDeployment` semaphore is full, the per-method proxy function now raises a `RuntimeError` telling the caller the app is at capacity, instead of silently awaiting a free slot.

> `Application '<id>' has reached its maximum of N concurrent requests and is currently very busy. Please try again in a moment.`

The cap is the existing per-app `max_ongoing_requests` knob (deploy-time `deploy_app(max_ongoing_requests=…)`, default 10; decorator default `@bioengine.app(max_ongoing_requests=…)`). No new parameter.

## Why

Every user call (WebSocket + WebRTC) funnels through `deployment_function`, which held `async with self.service_semaphore`. When full, request N+1 *awaited* a slot — an unbounded queue of coroutines, each already holding its decoded payload (e.g. an inference image) in the proxy actor's memory. Under load this grows proxy memory without bound and gives the caller no signal. Failing fast returns capacity pressure to the caller and frees the payload immediately.

Behaviour changes from "queue when full" to "reject when full" for **every** app. It does not touch the inner Entry/Runtime deployments' own Ray Serve `max_ongoing_requests` (the autoscaling-signal queue) — only the proxy's Hypha-facing semaphore.

## Safety

`.locked()` is race-free here: because we reject rather than await, the semaphore never accumulates waiters, so `.locked()` reduces to "no free slot", and there is no `await` between the check and the acquire.

## Validation

Deployment-side change → validated on a dev image on a live cluster before marking ready (deploy an app with `max_ongoing_requests=1`, fire concurrent calls, confirm the excess returns the busy `RuntimeError` while in-flight calls still succeed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)