### PR TITLE
fix(worker): guarantee & verify running code matches requested version on redeploy

### DIFF
--- a/bioengine/_app/decorators.py
+++ b/bioengine/_app/decorators.py
@@ -25,7 +25,7 @@ from functools import wraps
 from typing import Any, Callable, Dict, List, Optional
 
 from bioengine._app.errors import ReservedMethodNameError
-from bioengine._app.mixin import _make_check_health, wrap_init
+from bioengine._app.mixin import _make_check_health, _make_runtime_version, wrap_init
 
 # Top-level imports of hypha_rpc and ray.serve were moved inside the
 # decorator function bodies. The introspection task in
@@ -38,7 +38,12 @@ from bioengine._app.mixin import _make_check_health, wrap_init
 # Method names the framework owns. User code cannot define them as plain
 # methods — the new contract is to mark a method with @bioengine.<hook>
 # and let the name be whatever the user wants.
-_RESERVED_NAMES = ("check_health", "async_init", "test_deployment")
+_RESERVED_NAMES = (
+    "check_health",
+    "async_init",
+    "test_deployment",
+    "bioengine_runtime_version",
+)
 
 # Tag attached to functions by the marker decorators below.
 _KIND_ATTR = "_bioengine_kind"
@@ -234,6 +239,7 @@ def app(
         orig_init = cls.__init__
         cls.__init__ = wrap_init(cls, orig_init)
         cls.check_health = _make_check_health(cls, lifecycle)
+        cls.bioengine_runtime_version = _make_runtime_version(cls)
 
         opts = _build_ray_actor_options(
             num_cpus=num_cpus,

--- a/bioengine/_app/mixin.py
+++ b/bioengine/_app/mixin.py
@@ -220,6 +220,26 @@ def _make_check_health(
     return check_health
 
 
+def _make_runtime_version(user_cls: type) -> Callable[..., Any]:
+    """Build the ``bioengine_runtime_version`` method installed on the class.
+
+    Returns the artifact identity this replica *actually booted with*, read
+    from the process env the worker set in the replica's runtime_env. The
+    worker queries it (through the ProxyDeployment) to verify that a running
+    replica loaded the requested version rather than stale in-memory code
+    left over from a reused replica.
+    """
+
+    async def bioengine_runtime_version(self: Any) -> Dict[str, Optional[str]]:
+        return {
+            "artifact_id": os.environ.get("BIOENGINE_ARTIFACT_ID"),
+            "version": os.environ.get("BIOENGINE_ARTIFACT_VERSION"),
+            "app_source_uri": os.environ.get("BIOENGINE_APP_SOURCE_URI"),
+        }
+
+    return bioengine_runtime_version
+
+
 async def _invoke_lifecycle(
     instance: Any, method_name: str, label: str, logger: logging.Logger
 ) -> None:

--- a/bioengine/_app/replica_init.py
+++ b/bioengine/_app/replica_init.py
@@ -196,6 +196,12 @@ def _ensure_source(app_dir: Path, version: str, logger: logging.Logger) -> Path:
     # holding ``<artifact_alias>/`` subdirs with the raw app sources.
     local_root_env = os.environ.get("BIOENGINE_LOCAL_ARTIFACT_PATH")
     artifact_id = os.environ.get("BIOENGINE_ARTIFACT_ID", "")
+    # Cache identity keys on the artifact too, not just the version string:
+    # two different artifacts (or a reused application_id) can share a version
+    # string, and a bare-version marker would serve the first one's stale
+    # source. Same content ⇒ same identity in both the introspect and replica
+    # branches, so the flock skip still short-circuits correctly.
+    identity = f"{artifact_id}@{version}"
     if local_root_env and artifact_id:
         alias = artifact_id.split("/")[-1]
         candidate = Path(local_root_env) / alias
@@ -205,7 +211,7 @@ def _ensure_source(app_dir: Path, version: str, logger: logging.Logger) -> Path:
             shutil.copytree(
                 candidate, source, ignore=shutil.ignore_patterns("__pycache__", ".git")
             )
-            version_marker.write_text(version)
+            version_marker.write_text(identity)
             logger.info(f"BioEngine: source mirrored from local path {candidate}")
             return source
 
@@ -216,16 +222,16 @@ def _ensure_source(app_dir: Path, version: str, logger: logging.Logger) -> Path:
         fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
         try:
             current = version_marker.read_text().strip() if version_marker.exists() else None
-            if current == version and source.is_dir():
+            if current == identity and source.is_dir():
                 logger.info(
-                    f"BioEngine: source already at version {version} — skip download"
+                    f"BioEngine: source already at {identity} — skip download"
                 )
                 return source
 
             gcs_uri = os.environ.get("BIOENGINE_APP_SOURCE_URI")
             if gcs_uri:
                 _download_from_ray_gcs(gcs_uri, source, logger)
-                version_marker.write_text(version)
+                version_marker.write_text(identity)
                 return source
 
             url = os.environ.get("BIOENGINE_ARTIFACT_DOWNLOAD_URL")
@@ -239,7 +245,7 @@ def _ensure_source(app_dir: Path, version: str, logger: logging.Logger) -> Path:
                 )
             token = os.environ.get("BIOENGINE_ARTIFACT_DOWNLOAD_TOKEN") or None
             _download_and_extract(url, token, source, logger)
-            version_marker.write_text(version)
+            version_marker.write_text(identity)
             return source
         finally:
             fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)

--- a/bioengine/_version.py
+++ b/bioengine/_version.py
@@ -13,4 +13,4 @@ see the same string that ``pip`` sees.
 Must stay in lock-step with ``pyproject.toml``'s ``version`` field.
 The ``version-check.yml`` CI workflow enforces the match.
 """
-__version__ = "0.11.26"
+__version__ = "0.11.27"

--- a/bioengine/apps/builder.py
+++ b/bioengine/apps/builder.py
@@ -188,6 +188,7 @@ class AppBuilder:
             env_vars["HYPHA_SERVER_URL"] = self.server_url
             env_vars["HYPHA_WORKSPACE"] = worker_workspace
         env_vars["HYPHA_ARTIFACT_ID"] = artifact_id
+        env_vars["BIOENGINE_ARTIFACT_ID"] = artifact_id
         if version is not None:
             env_vars["HYPHA_ARTIFACT_VERSION"] = version
             env_vars["BIOENGINE_ARTIFACT_VERSION"] = version

--- a/bioengine/apps/manager.py
+++ b/bioengine/apps/manager.py
@@ -799,6 +799,30 @@ class AppsManager:
             "webrtc_service_id": f"{workspace}/{proxy_client_id}:{application_id}-rtc",
         }
 
+    async def _get_running_version(
+        self, application_id: str
+    ) -> Optional[Dict[str, Any]]:
+        """Ask the live ProxyDeployment what version its entry replica booted
+        with. Best-effort — returns None if the app/handle is unreachable.
+
+        Ray Serve can keep an old replica serving after a version bump (an
+        in-place update with no surge headroom), so the stored version is not
+        proof of what is actually running; this reads it from the replica's
+        own env.
+        """
+        try:
+            app_handle = await self.ray_cluster.call_with_reconnect(
+                serve.get_app_handle, application_id
+            )
+            return await asyncio.wait_for(
+                app_handle.get_running_version.remote(), timeout=10.0
+            )
+        except Exception as exc:
+            self.logger.debug(
+                f"Could not read running version for '{application_id}': {exc}"
+            )
+            return None
+
     async def _get_app_status(
         self,
         application_id: str,
@@ -854,6 +878,17 @@ class AppsManager:
 
         service_ids = await self._get_application_service_ids(application_id)
 
+        # Report what the entry replica actually loaded, not just the
+        # requested version — a stale reused replica reads as "healthy"
+        # otherwise. version_verified is None when it can't be determined.
+        running_version = None
+        version_verified = None
+        if status == "RUNNING":
+            rv = await self._get_running_version(application_id)
+            if rv is not None:
+                running_version = rv.get("version")
+                version_verified = running_version == application_info["version"]
+
         # Build static site URL with runtime config params so the frontend
         # knows which Hypha server and service to connect to.
         base_static_url = application_info.get("static_site_url")
@@ -872,6 +907,8 @@ class AppsManager:
             "description": application_info["description"],
             "artifact_id": application_info["artifact_id"],
             "version": application_info["version"] or "latest",
+            "running_version": running_version,
+            "version_verified": version_verified,
             "recovered_app": application_info["recovered_app"],
             "status": status,
             "message": message,
@@ -1242,6 +1279,26 @@ class AppsManager:
                         f"Application '{application_id}' recovered; "
                         f"auto-redeploy backoff cleared."
                     )
+                # RUNNING is not proof the new code is live: a reused replica
+                # can serve stale code after a version bump. If the entry
+                # replica loaded the wrong version, delete so the next tick
+                # sees it missing and redeploys fresh replicas.
+                rv = await self._get_running_version(application_id)
+                if rv is not None and rv.get("version") != application_info["version"]:
+                    self.logger.warning(
+                        f"Application '{application_id}' reports RUNNING but its "
+                        f"entry replica loaded version {rv.get('version')!r} != "
+                        f"requested {application_info['version']!r}; deleting to "
+                        f"force fresh replicas."
+                    )
+                    try:
+                        await self.ray_cluster.call_with_reconnect(
+                            serve.delete, application_id
+                        )
+                    except Exception as del_err:
+                        self.logger.error(
+                            f"Error deleting stale '{application_id}': {del_err}"
+                        )
                 continue
 
             unhealthy = application is None or state in (
@@ -2134,6 +2191,35 @@ class AppsManager:
                     f"version '{version}'; kwargs: {kwargs_str}; env_vars: {env_vars_str}"
                 )
                 await self._cancel_deployment_process(application_id=application_id)
+
+                # A content change (new version, or a different artifact under
+                # this application_id) must reach every replica. serve.run's
+                # in-place update can silently reuse replicas — at
+                # num_replicas=1 with no surge headroom (e.g. a single GPU)
+                # the old replica keeps serving stale in-memory code. Delete
+                # first so the slot frees and fresh replicas load the new
+                # source. Clear is_deployed so the monitor loop doesn't fire a
+                # redundant redeploy during the delete→rebuild window.
+                content_changed = (
+                    version != existing_app["version"]
+                    or artifact_id != existing_app["artifact_id"]
+                )
+                if content_changed:
+                    existing_app["is_deployed"].clear()
+                    try:
+                        await self.ray_cluster.call_with_reconnect(
+                            serve.delete, application_id
+                        )
+                        self.logger.info(
+                            f"Deleted Ray Serve application '{application_id}' "
+                            f"before redeploy so replicas are recreated with "
+                            f"the new source."
+                        )
+                    except Exception as delete_err:
+                        self.logger.error(
+                            f"Error deleting Ray Serve application "
+                            f"'{application_id}' before redeploy: {delete_err}"
+                        )
             else:
                 # Create a new application
                 self.logger.info(

--- a/bioengine/apps/proxy_deployment.py
+++ b/bioengine/apps/proxy_deployment.py
@@ -294,6 +294,15 @@ class ProxyDeployment:
         """Return non-secret application metadata used for worker recovery."""
         return self.app_data
 
+    async def get_running_version(self) -> Dict[str, Any]:
+        """Return the artifact identity the entry replica actually booted with.
+
+        Internal method — called via Ray actor handle from the manager only.
+        The worker compares this against the requested version to detect a
+        reused replica still running stale in-memory code.
+        """
+        return await self.entry_deployment_handle.bioengine_runtime_version.remote()
+
     async def update_authorized_users(
         self, authorized_users: Dict[str, List[str]]
     ) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.11.26"
+version = "0.11.27"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Problem

A `deploy_app` update could report the new version `RUNNING`/`HEALTHY` while replicas kept executing the previous version's code. Three interacting causes:

1. **In-place update reuses replicas.** On an update, the worker cancelled the async deploy task and relied on same-named `serve.run` to overwrite. Ray Serve performs a rolling update, but at `num_replicas=1` with no surge headroom (e.g. a single time-sliced GPU) the new replica stays `PENDING` and the old replica keeps serving stale in-memory code. On CPU (free capacity) the same bump reloads; on a saturated GPU it silently does not.
2. **Status echoes the request.** `get_app_status` reported the *requested* version and never asked replicas what they had actually loaded, so a stale deployment read as healthy.
3. **Version-string source cache key.** `_ensure_source` short-circuited its download when the on-disk `.version` marker equalled the requested version *string*, and the source directory is keyed on `application_id` only. A different artifact (or a reused `application_id`) sharing a version string served the first one's source to a brand-new replica.

## Solution

- **Force fresh replicas on a content change (fix 1).** When an update changes the version or the artifact, `serve.delete` the application before rebuilding so the slot frees and every replica is recreated from the new source. `is_deployed` is cleared across the delete→rebuild window so the monitor loop does not fire a redundant redeploy.
- **Verify what replicas actually loaded (fix 2).** `@bioengine.app` now injects a `bioengine_runtime_version` method on every deployment that returns its boot-time `BIOENGINE_ARTIFACT_*` identity. `ProxyDeployment.get_running_version` reads it from the entry replica; the worker surfaces `running_version` / `version_verified` in `get_app_status`, and the monitor loop deletes a `RUNNING`-but-stale application so the next tick redeploys fresh.
- **Content-identity source cache key (fix 3).** `_ensure_source` keys its marker on `artifact_id@version` instead of the bare version string, computed identically in the introspect and replica branches so the same content still short-circuits the flock download.

## Behavioural changes

- A `deploy_app` update whose version or artifact changed now briefly deregisters the app's Hypha service while replicas are recreated (previously an in-place rolling update). Updates that change neither are unaffected.
- `get_app_status` gains `running_version` and `version_verified` fields.
- Every user deployment gains a reserved `bioengine_runtime_version` method (name added to the reserved list).

## Test plan

- Worker-free unit checks: `_ensure_source` short-circuits on an identical `artifact_id@version` and re-materialises when the artifact differs at the same version string; `_make_runtime_version` returns the booted identity from env; `@bioengine.app` injects and reserves `bioengine_runtime_version`.
- Live-cluster validation (single-machine + external-cluster) via the dev-image workflow before this PR is marked ready: deploy an app, bump its version, and confirm the served behaviour and `version_verified` reflect the new code on a fresh replica.

## Files

- `bioengine/apps/manager.py` — `serve.delete` on content-changing updates; `_get_running_version` helper; monitor mismatch self-heal; `running_version`/`version_verified` in status.
- `bioengine/apps/proxy_deployment.py` — `get_running_version` accessor.
- `bioengine/_app/decorators.py`, `bioengine/_app/mixin.py` — inject/reserve `bioengine_runtime_version`.
- `bioengine/_app/replica_init.py` — `artifact_id@version` source cache key.