### PR TITLE
fix(worker): run introspect/build Ray tasks in a fresh process (max_calls=1)

### DIFF
--- a/bioengine/_app/bootstrap.py
+++ b/bioengine/_app/bootstrap.py
@@ -113,9 +113,11 @@ def introspect_app_in_ray_task(
     from bioengine._app.replica_init import _ensure_source
 
     # Apply env_vars from runtime_env onto the process so _ensure_source
-    # reads the same keys as the eventual replicas.
+    # reads the same keys as the eventual replicas. Overwrite (not
+    # setdefault): this build's version/URI must win even on a worker whose
+    # process env somehow already carries a prior build's values.
     for key, value in env_vars.items():
-        os.environ.setdefault(key, value)
+        os.environ[key] = value
 
     app_dir = Path(env_vars["BIOENGINE_APP_DIR"])
     version = env_vars.get("BIOENGINE_ARTIFACT_VERSION", "")
@@ -510,11 +512,12 @@ def build_and_run_application(
 
     # Re-apply env_vars from the task's runtime_env so the source loader
     # below sees the same BIOENGINE_* keys as the eventual replicas.
+    # Overwrite (not setdefault) so this build's values win.
     for key, value in replica_env_vars.items():
-        os.environ.setdefault(key, value)
+        os.environ[key] = value
     # The Ray-GCS source URI lives on the task env explicitly; replicas
     # get it via per-deployment env_vars injected in `_with_pkg`.
-    os.environ.setdefault("BIOENGINE_APP_SOURCE_URI", app_source_uri)
+    os.environ["BIOENGINE_APP_SOURCE_URI"] = app_source_uri
 
     head_app_dir = Path(replica_env_vars["BIOENGINE_APP_DIR"])
     head_version = replica_env_vars.get("BIOENGINE_ARTIFACT_VERSION") or spec.get(

--- a/bioengine/_version.py
+++ b/bioengine/_version.py
@@ -13,4 +13,4 @@ see the same string that ``pip`` sees.
 Must stay in lock-step with ``pyproject.toml``'s ``version`` field.
 The ``version-check.yml`` CI workflow enforces the match.
 """
-__version__ = "0.11.27"
+__version__ = "0.11.28"

--- a/bioengine/apps/builder.py
+++ b/bioengine/apps/builder.py
@@ -301,7 +301,14 @@ class AppBuilder:
         try:
             return await asyncio.to_thread(
                 ray.get,
-                ray.remote(num_cpus=0, runtime_env=submit_runtime_env)(
+                # max_calls=1 forces a fresh worker process per introspect:
+                # Ray pools task workers, and _load_app_class imports the user
+                # modules into that process's sys.modules. A reused worker
+                # would return a stale cached module (Python resolves imports
+                # from sys.modules before sys.path), so the spec — and the
+                # by-value-pickled deployment class — would capture old code
+                # even after the on-disk source is refreshed.
+                ray.remote(num_cpus=0, max_calls=1, runtime_env=submit_runtime_env)(
                     introspect_app_in_ray_task
                 ).remote(entry_id, task_env_vars),
             )
@@ -734,7 +741,12 @@ class AppBuilder:
         try:
             await asyncio.to_thread(
                 ray.get,
-                ray.remote(num_cpus=0, runtime_env=built_app.runtime_env)(
+                # max_calls=1: same reason as the introspect task — a fresh
+                # process guarantees the deployment class is imported from the
+                # refreshed source, not a stale sys.modules entry cached on a
+                # reused worker (the class is cloudpickled by value to the
+                # replicas, so the build worker's import is what they run).
+                ray.remote(num_cpus=0, max_calls=1, runtime_env=built_app.runtime_env)(
                     build_and_run_application
                 ).remote(
                     _ensure_jsonable(built_app.spec),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.11.27"
+version = "0.11.28"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Problem

Even after #144, a redeploy could keep running old code. The introspect and build Ray tasks import the user's deployment modules into their worker process, and Ray **pools task workers**. `_load_app_class` uses `importlib.import_module`, which returns a cached `sys.modules` entry (Python resolves imports from `sys.modules` before `sys.path`). So a worker that built an earlier version keeps that version's classes cached:

- `introspect_app` captures the stale class in the spec;
- `build_and_run_application` binds the stale class — and because the `@bioengine.app` class carries closure methods (`wrap_init` / `check_health` / `bioengine_runtime_version`), cloudpickle serialises it **by value** to the replicas.

The replicas therefore run the stale class even though `app_dir/source` and the content-addressed `app_source_uri` package on disk are the correct new version. This is upstream of #144's source-materialisation fixes (`sys.path` insertion is bypassed by `sys.modules`), and can make running code *older than files on disk*.

## Solution

- Add `max_calls=1` to the introspect and build `ray.remote` tasks so each runs in a **fresh process** — empty `sys.modules`, so the import reads the refreshed source, and `runtime_env` env_vars are applied fresh.
- Switch the per-build env application in `bootstrap.py` from `os.environ.setdefault` to direct assignment, so a build's `BIOENGINE_ARTIFACT_VERSION` / `BIOENGINE_APP_SOURCE_URI` always win (a reused worker would otherwise keep a prior build's values).

## Behavioural changes

Each deploy spawns a fresh short-lived Ray worker for its introspect and build tasks (content-addressed `runtime_env` packages are already cached, so no re-upload/reinstall). No API changes.

## Test plan

- No-regression on the #144 validation suite (single-deployment version bump, cross-artifact same-version, and a 3-deployment composition via `stop_app` → fresh `deploy_app`) on a dev image in single-machine mode.
- Confirm each deploy's introspect/build runs in a distinct worker process.

## Files

- `bioengine/apps/builder.py` — `max_calls=1` on both Ray tasks.
- `bioengine/_app/bootstrap.py` — per-build env applied with overwrite semantics.