### PR TITLE
feat(worker): add delete_app_version to drop dev pre-releases

### DIFF
--- a/bioengine/_version.py
+++ b/bioengine/_version.py
@@ -13,4 +13,4 @@ see the same string that ``pip`` sees.
 Must stay in lock-step with ``pyproject.toml``'s ``version`` field.
 The ``version-check.yml`` CI workflow enforces the match.
 """
-__version__ = "0.11.29"
+__version__ = "0.11.30"

--- a/bioengine/apps/manager.py
+++ b/bioengine/apps/manager.py
@@ -1904,6 +1904,82 @@ class AppsManager:
         self.logger.info(f"Successfully deleted artifact '{artifact_id}'.")
 
     @schema_method
+    async def delete_app_version(
+        self,
+        artifact_id: str = Field(
+            ...,
+            description="Identifier of the application artifact. Full ID (workspace/artifact-name) or just the name if it belongs to the current workspace.",
+        ),
+        version: str = Field(
+            ...,
+            description="Pre-release version to delete. Its tag must contain 'dev' (e.g. '1.2.3-dev1') — released versions are immutable and cannot be deleted through this method.",
+        ),
+        context: Dict[str, Any] = Field(
+            ...,
+            description="Authentication context containing user information, automatically provided by Hypha during service calls.",
+        ),
+    ) -> None:
+        """
+        Delete a single PRE-RELEASE version of an application artifact.
+
+        For the dev-iteration workflow: iterate on 'X.Y.Z-devN' pre-releases,
+        publish the verified bundle once as 'X.Y.Z', then drop the throwaway
+        pre-releases with this method. Only versions whose tag contains 'dev'
+        are deletable, so released versions stay permanent, and the version
+        must not be currently deployed on this worker.
+
+        Args:
+            artifact_id: The artifact whose version to delete (current workspace).
+            version: The pre-release version tag (must contain 'dev').
+
+        Raises:
+            ValueError: version isn't a 'dev' pre-release, is currently deployed,
+                or the artifact isn't in this workspace.
+            PermissionError: If the caller lacks admin permissions.
+            RuntimeError: If the worker is not initialized.
+        """
+        self._check_initialized()
+
+        check_permissions(
+            context=context,
+            authorized_users=self.admin_users,
+            resource_name=f"deleting version '{version}' of artifact '{artifact_id}'",
+        )
+
+        # Only pre-releases are deletable — a released version is immutable and
+        # something may reference it (test-reports, the website version list).
+        if "dev" not in str(version).lower():
+            raise ValueError(
+                f"Refusing to delete version '{version}': only pre-release versions "
+                f"whose tag contains 'dev' (e.g. '1.2.3-dev1') can be deleted. "
+                f"Released versions are permanent."
+            )
+
+        artifact_id = self._get_full_artifact_id(artifact_id)
+        workspace = self.server.config.workspace
+        if not artifact_id.startswith(f"{workspace}/"):
+            raise ValueError(
+                f"Artifact ID '{artifact_id}' does not belong to the current workspace '{workspace}'."
+            )
+
+        alias = artifact_id.split("/", 1)[1]
+        for app_id, info in self._deployed_applications.items():
+            if (
+                info.get("artifact_id") in (artifact_id, alias)
+                and str(info.get("version")) == str(version)
+                and info["is_deployed"].is_set()
+            ):
+                raise ValueError(
+                    f"Version '{version}' of '{artifact_id}' is currently deployed "
+                    f"as application '{app_id}'. Stop it first with stop_app()."
+                )
+
+        await self.artifact_manager.delete(artifact_id, version=version)
+        self.logger.info(
+            f"Successfully deleted version '{version}' of artifact '{artifact_id}'."
+        )
+
+    @schema_method
     async def deploy_app(
         self,
         artifact_id: str = Field(

--- a/bioengine/worker/worker.py
+++ b/bioengine/worker/worker.py
@@ -638,6 +638,7 @@ class BioEngineWorker:
             "list_apps": self.apps_manager.list_apps,  # Requires admin permissions
             "get_app_manifest": self.apps_manager.get_app_manifest,  # Requires admin permissions
             "delete_app": self.apps_manager.delete_app,  # Requires admin permissions
+            "delete_app_version": self.apps_manager.delete_app_version,  # Requires admin permissions; only 'dev' pre-releases
             "deploy_app": self.apps_manager.deploy_app,  # Requires admin permissions
             "stop_app": self.apps_manager.stop_app,  # Requires admin permissions
             "stop_all_apps": self.apps_manager.stop_all_apps,  # Requires admin permissions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.11.29"
+version = "0.11.30"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Problem

The dev-iteration upload workflow (documented in the user-facing skill) publishes a clean `X.Y.Z` release after iterating on `X.Y.Z-devN` pre-releases, then wants to delete the throwaway pre-releases. Today `delete_app` only deletes the *whole* artifact, so cleanup has to reach past the worker into `artifact_manager.delete(..., version=…)` directly.

## Solution

Add `delete_app_version(artifact_id, version)` to the worker admin API. Guards:
- admin permission (same as `delete_app`);
- **only versions whose tag contains `dev`** are deletable — released versions are immutable and may be referenced by test-reports / the website version list, so they're protected in code, not just docs;
- refuse if that exact version is **currently deployed** on this worker (stop it first).

## Test plan

Dev-image smoke test on a live worker: upload `X.Y.Z-dev1`/`-dev2`, deploy `-dev1`, then confirm `delete_app_version` (a) deletes a non-deployed `-dev` version, (b) refuses a released version, (c) refuses the currently-deployed `-dev` version.

## Files
- `bioengine/apps/manager.py` — the method.
- `bioengine/worker/worker.py` — expose it on the service.