### PR TITLE
feat(worker): sync app source per-file from Hypha instead of Ray GCS

### DIFF
--- a/bioengine/__init__.py
+++ b/bioengine/__init__.py
@@ -70,8 +70,10 @@ def _install_replica_bootstrap_finder() -> None:
       1. Sets a sentinel so the bootstrap can't recurse if any of its
          own imports also miss.
       2. Runs ``setup_replica_environment()`` which calls
-         ``_ensure_source`` (Ray-GCS download via
-         ``BIOENGINE_APP_SOURCE_URI``) and ``sys.path.insert(0, source/)``.
+         ``_ensure_source`` (per-file Hypha sync via
+         ``BIOENGINE_ARTIFACT_FILES_URL``) and ``sys.path.insert(0, source/)``.
+         The app source is no longer shipped as a Ray py_module, so this
+         finder is the *sole* mechanism that puts user modules on sys.path.
       3. Delegates back to ``importlib.machinery.PathFinder`` to resolve
          the name against the now-populated ``sys.path`` — so the import
          that triggered us succeeds without the caller knowing.

--- a/bioengine/_app/bootstrap.py
+++ b/bioengine/_app/bootstrap.py
@@ -3,20 +3,17 @@
 The BioEngine worker never imports user app code directly. The flow is:
 
 1. Worker submits :func:`introspect_app_in_ray_task` as a short Ray task. The
-   task materialises the user package into ``<app_dir>/source/`` (Hypha
-   download, short-TTL token), walks the type-hint composition graph via
-   :func:`introspect_app`, packages the source dir into Ray's internal
-   GCS package store, and returns ``{spec, app_source_uri}``.
+   task materialises the user package into ``<app_dir>/source/`` (per-file
+   Hypha sync), walks the type-hint composition graph via
+   :func:`introspect_app`, and returns ``{spec}``.
 2. Worker checks resources against the spec.
 3. Worker submits :func:`build_and_run_application` as a second Ray task. The
-   task re-materialises source (no-op on shared-FS clusters; a Ray-GCS pull
-   via ``BIOENGINE_APP_SOURCE_URI`` on non-shared ones — no Hypha auth at
-   this point) and calls ``cls.bind`` + ``serve.run(blocking=False)``.
+   task re-materialises source (per-file Hypha sync; incremental — a no-op
+   when unchanged) and calls ``cls.bind`` + ``serve.run(blocking=False)``.
 
-Replicas don't run any function in this module directly; they boot with
-``BIOENGINE_APP_SOURCE_URI`` in their env_vars and call the same
-``_ensure_source`` to materialise their copy of the source, bypassing
-Hypha entirely.
+Replicas don't run any function in this module directly; they boot with the
+Hypha ``BIOENGINE_ARTIFACT_FILES_URL`` (+ optional token) in their env_vars and
+call the same ``_ensure_source`` to sync their copy of the source per file.
 """
 
 from __future__ import annotations
@@ -95,16 +92,14 @@ def introspect_app_in_ray_task(
     entry_id: str,
     env_vars: Dict[str, str],
 ) -> Dict[str, Any]:
-    """Phase-1 Ray task: download user source, introspect, package to Ray-GCS.
+    """Phase-1 Ray task: download user source and introspect it.
 
-    Returns ``{"spec": …, "app_source_uri": "gcs://_ray_pkg_<hash>.zip"}``.
+    Returns ``{"spec": …}``.
 
-    The download uses the Hypha ``BIOENGINE_ARTIFACT_DOWNLOAD_URL`` +
-    ``_TOKEN`` env vars (short-TTL). Once source is on disk, we hash and
-    upload it to Ray's internal package store; the resulting URI is what
-    every replica's ``runtime_env`` ships so they can re-materialise the
-    same bytes without going back through Hypha (token expires before
-    most replicas finish their pip install).
+    The download uses the Hypha ``BIOENGINE_ARTIFACT_FILES_URL`` (+ optional
+    ``_DOWNLOAD_TOKEN``) env vars via ``_ensure_source``. Replicas materialise
+    their own copy the same way (per-file Hypha sync) — no Ray-GCS package is
+    produced or shipped.
     """
     import logging
     import os
@@ -136,71 +131,7 @@ def introspect_app_in_ray_task(
         sys.path.insert(0, src_str)
 
     spec = introspect_app(entry_id)
-    app_source_uri = _package_source_to_ray_gcs(source)
-    return {"spec": spec, "app_source_uri": app_source_uri}
-
-
-def _package_source_to_ray_gcs(source_dir: "Path") -> str:  # type: ignore[name-defined]
-    """Hash + upload ``source_dir`` to Ray's internal package store.
-
-    Returns the ``gcs://_ray_pkg_<hash>.zip`` URI replicas pass to
-    :func:`ray._private.runtime_env.packaging.download_and_unpack_package`
-    to re-materialise the same bytes.
-
-    Why not use ``runtime_env.py_modules=[<local_path>]`` and let Ray
-    Serve upload for us? Because the bootstrap puts source at a stable
-    ``<app_dir>/source/`` (so cellpose's ``home/`` checkpoints survive
-    version bumps), not Ray's per-process ``runtime_resources/`` dir.
-    Explicit upload here decouples the GCS URI from runtime_env handling.
-
-    Ray patch versions disagree on whether ``include_gitignore`` is a
-    required argument on these packaging APIs; the inspect gates keep us
-    cross-compatible.
-    """
-    from ray._private.runtime_env.packaging import (
-        get_uri_for_directory,
-        upload_package_if_needed,
-    )
-
-    src = str(source_dir.resolve())
-
-    get_kwargs: Dict[str, Any] = {}
-    if "include_gitignore" in inspect.signature(get_uri_for_directory).parameters:
-        get_kwargs["include_gitignore"] = False
-    uri = get_uri_for_directory(src, **get_kwargs)
-
-    upload_kwargs: Dict[str, Any] = {}
-    upload_sig = inspect.signature(upload_package_if_needed)
-    if "include_gitignore" in upload_sig.parameters:
-        upload_kwargs["include_gitignore"] = False
-    # Belt-and-braces: exclude any leftover Ray package zip from the
-    # source tree. Earlier dev iterations of v0.11.4 wrote temp zips
-    # into ``src`` itself (when ``base_directory == src``), Ray's walker
-    # then included its own output back into the package and looped to
-    # 360 GiB on shared NFS before the task was killed. The fix below
-    # uses a scratch ``base_directory``, but if any artifact / pod still
-    # has a stale ``_ray_pkg_*.zip`` sitting in ``source/`` from history,
-    # this exclude keeps it out of the new package.
-    upload_kwargs["excludes"] = ["*.zip", "_ray_pkg_*.zip"]
-    # ``base_directory`` is a scratch dir where Ray writes the temporary
-    # zip file before pushing to GCS. Must not point at the source dir
-    # itself.
-    import tempfile
-    base_dir = tempfile.mkdtemp(prefix="bioengine-pkg-")
-    try:
-        # Ray patches disagree on the third positional name:
-        # Ray 2.5x ships ``(pkg_uri, base_directory, module_path, ...)``;
-        # earlier patches expose ``(pkg_uri, base_directory, ...)`` only.
-        if "module_path" in upload_sig.parameters:
-            upload_package_if_needed(uri, base_dir, src, **upload_kwargs)
-        elif "package_path" in upload_sig.parameters:
-            upload_package_if_needed(uri, base_dir, src, **upload_kwargs)
-        else:
-            upload_package_if_needed(uri, base_dir, **upload_kwargs)
-    finally:
-        import shutil as _shutil
-        _shutil.rmtree(base_dir, ignore_errors=True)
-    return uri
+    return {"spec": spec}
 
 
 def _walk(
@@ -466,7 +397,6 @@ def build_and_run_application(
     application_id: str,
     route_prefix: str,
     bioengine_uri: str,
-    app_source_uri: str,
     proxy_pip: List[str],
     user_replica_framework_pip: List[str],
     replica_env_vars: Dict[str, str],
@@ -483,18 +413,16 @@ def build_and_run_application(
     Runs in a Ray task on whatever node Ray schedules — no head-node pin.
     ``bioengine`` is available via the task's ``runtime_env.py_modules =
     [bioengine_uri]``. The user's app source is materialised here by
-    :func:`bioengine._app.replica_init._ensure_source` using the Ray-GCS
-    branch (``BIOENGINE_APP_SOURCE_URI``) which was just uploaded by the
-    introspect Ray task — the Hypha short-TTL token is not needed and
-    isn't in ``replica_env_vars``.
+    :func:`bioengine._app.replica_init._ensure_source`, which syncs it per
+    file from Hypha using ``BIOENGINE_ARTIFACT_FILES_URL`` (+ optional token)
+    from ``replica_env_vars`` — no Ray-GCS package.
 
     Each deployment's ``runtime_env`` is augmented with
-    ``py_modules=[bioengine_uri]`` and ``env_vars`` carrying
-    ``BIOENGINE_APP_SOURCE_URI`` + ``BIOENGINE_APP_DIR`` + secrets. The
-    actual source download on each replica runs via the
-    ``sys.meta_path`` finder installed in :mod:`bioengine.__init__`,
-    which triggers the same ``_ensure_source`` call before the user
-    module's import is retried.
+    ``py_modules=[bioengine_uri]`` (bioengine only — the app source is NOT a
+    py_module) and ``env_vars`` carrying the Hypha coords + ``BIOENGINE_APP_DIR``
+    + secrets. The source download on each replica runs via the ``sys.meta_path``
+    finder installed in :mod:`bioengine.__init__`, which triggers the same
+    ``_ensure_source`` call before the user module's import is retried.
 
     ``proxy_memory_in_gb`` overrides ``ProxyDeployment.ray_actor_options
     .memory`` so the scheduler is biased toward a node with at least
@@ -515,9 +443,6 @@ def build_and_run_application(
     # Overwrite (not setdefault) so this build's values win.
     for key, value in replica_env_vars.items():
         os.environ[key] = value
-    # The Ray-GCS source URI lives on the task env explicitly; replicas
-    # get it via per-deployment env_vars injected in `_with_pkg`.
-    os.environ["BIOENGINE_APP_SOURCE_URI"] = app_source_uri
 
     head_app_dir = Path(replica_env_vars["BIOENGINE_APP_DIR"])
     head_version = replica_env_vars.get("BIOENGINE_ARTIFACT_VERSION") or spec.get(
@@ -556,16 +481,10 @@ def build_and_run_application(
         py_modules = list(runtime_env.get("py_modules") or [])
         if bioengine_uri not in py_modules:
             py_modules.append(bioengine_uri)
-        # Ship the user source via py_modules too. Ray extracts py_modules
-        # to ``/tmp/ray/.../runtime_resources/py_modules_files/<hash>/``
-        # and adds that dir to PYTHONPATH BEFORE the replica's Python
-        # interpreter runs cloudpickle.loads — so ``import main``
-        # (cellpose) or ``import entry`` (model-runner) resolves natively
-        # without any hook / finder / pickle-by-value trick. The source
-        # is content-hashed in Ray's GCS package store by the introspect
-        # task; replicas pull from there.
-        if app_source_uri not in py_modules:
-            py_modules.append(app_source_uri)
+        # The user app source is NOT shipped via py_modules — it's synced per
+        # file from Hypha into ``<app_dir>/source/`` by ``_ensure_source``,
+        # triggered by the ``sys.meta_path`` finder (installed on
+        # ``import bioengine``) before ``import main``/``import entry`` resolves.
         runtime_env["py_modules"] = py_modules
         # Ray's default_worker.py honours ``worker_process_setup_hook``
         # *before* Ray Serve's ServeReplica.__init__ runs cloudpickle.loads.
@@ -587,13 +506,12 @@ def build_and_run_application(
             list(runtime_env.get("pip") or []),
             user_replica_framework_pip,
         )
-        # Merge the worker-side env_vars + the app-source URI into
+        # Merge the worker-side env_vars (incl. the Hypha source coords) into
         # whatever static ``env_vars`` the author declared via
         # ``@bioengine.app(env_vars=…)``. The author's entries take
         # precedence on key collision.
         deploy_env_vars = {
             **replica_env_vars,
-            "BIOENGINE_APP_SOURCE_URI": app_source_uri,
             **(runtime_env.get("env_vars") or {}),
         }
         runtime_env["env_vars"] = deploy_env_vars
@@ -644,13 +562,10 @@ def build_and_run_application(
     proxy_py_modules = list(proxy_runtime_env.get("py_modules") or [])
     if bioengine_uri not in proxy_py_modules:
         proxy_py_modules.append(bioengine_uri)
-    if app_source_uri not in proxy_py_modules:
-        proxy_py_modules.append(app_source_uri)
     proxy_runtime_env["py_modules"] = proxy_py_modules
     proxy_runtime_env["worker_process_setup_hook"] = _REPLICA_SETUP_HOOK
     proxy_runtime_env["env_vars"] = {
         **replica_env_vars,
-        "BIOENGINE_APP_SOURCE_URI": app_source_uri,
         **(proxy_runtime_env.get("env_vars") or {}),
     }
     proxy_actor_options["runtime_env"] = proxy_runtime_env

--- a/bioengine/_app/mixin.py
+++ b/bioengine/_app/mixin.py
@@ -234,7 +234,6 @@ def _make_runtime_version(user_cls: type) -> Callable[..., Any]:
         return {
             "artifact_id": os.environ.get("BIOENGINE_ARTIFACT_ID"),
             "version": os.environ.get("BIOENGINE_ARTIFACT_VERSION"),
-            "app_source_uri": os.environ.get("BIOENGINE_APP_SOURCE_URI"),
         }
 
     return bioengine_runtime_version

--- a/bioengine/_app/replica_init.py
+++ b/bioengine/_app/replica_init.py
@@ -1,47 +1,45 @@
 """Replica-side (and build-task-side) artifact materialisation.
 
-Materialises the user's app source into ``<app_dir>/source/`` before any
-user code is imported. Two backends:
-
-1. **Ray-internal GCS** (``BIOENGINE_APP_SOURCE_URI`` set) — preferred on
-   replicas. The :mod:`bioengine._app.bootstrap` introspect task uploaded
-   the source bytes to Ray's content-addressed package store; replicas
-   re-materialise them by URI via
-   :func:`ray._private.runtime_env.packaging.download_and_unpack_package`.
-   No Hypha auth involved — the short-TTL token has typically expired by
-   replica launch time.
-
-2. **Hypha** (``BIOENGINE_ARTIFACT_DOWNLOAD_URL`` + ``_TOKEN`` set) — used
-   by the introspect Ray task which has a fresh short-TTL token. Single
-   ``fcntl`` lock per node serialises concurrent same-node starts; the
-   second caller sees the up-to-date ``.version`` marker and skips.
+Materialises the user's app source into ``<app_dir>/source/`` before any user
+code is imported, by downloading it **per file directly from Hypha** (the
+durable artifact store) with an incremental sync keyed on each file's remote
+``last_modified``. A snapshot at ``<app_dir>/.source_snapshot.json`` records
+``{relpath: last_modified}`` so a redeploy re-downloads only changed/new files
+and deletes files removed from the artifact — big unchanged files (e.g. model
+weights) are never re-fetched. There is no Ray-GCS intermediary: the Ray head's
+in-memory package store is neither an OOM sink (a package per app×version) nor a
+single point of failure across a head restart.
 
 Reads its configuration from env_vars set by the BioEngine worker:
 
-* ``BIOENGINE_APP_DIR``                — ``<apps_workdir>/<worker-ws>-<app-id>``
-* ``BIOENGINE_ARTIFACT_VERSION``       — cache-invalidation marker
-* ``BIOENGINE_APP_SOURCE_URI``         — ``gcs://_ray_pkg_<hash>.zip`` (replicas)
-* ``BIOENGINE_ARTIFACT_DOWNLOAD_URL``  — Hypha ``create-zip-file`` URL (introspect)
-* ``BIOENGINE_ARTIFACT_DOWNLOAD_TOKEN``— short-TTL read-only Hypha token
+* ``BIOENGINE_APP_DIR``                 — ``<apps_workdir>/<worker-ws>-<app-id>``
+* ``BIOENGINE_ARTIFACT_ID``             — artifact id (cache identity)
+* ``BIOENGINE_ARTIFACT_VERSION``        — committed version to materialise
+* ``BIOENGINE_ARTIFACT_FILES_URL``      — Hypha ``/files`` listing endpoint
+* ``BIOENGINE_ARTIFACT_DOWNLOAD_TOKEN`` — read token (absent ⇒ anonymous/public)
+
+Hypha is already a hard dependency (an app cannot register its service without
+it), so pulling source from Hypha at replica start adds no new availability
+surface: if Hypha is unreachable the replica fails to materialise, the
+deployment fails, and ``auto_redeploy`` retries.
 """
 
 from __future__ import annotations
 
 import fnmatch
+import json
 import logging
 import os
 import shutil
 import sys
 import urllib.parse
 import urllib.request
-import zipfile
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 #: Excludes mirror v0.11.3's ``AppBuilder._PY_MODULES_EXCLUDES`` with one
-#: addition (``.dotfiles`` per user request) — the artifact zip carries
-#: everything in the artifact, but only Python/config content should be
-#: extracted to ``source/``.
+#: addition (``.dotfiles`` per user request) — the artifact carries everything,
+#: but only Python/config content should be materialised into ``source/``.
 _SOURCE_EXCLUDES = [
     "manifest.yaml",
     "manifest.yml",
@@ -75,131 +73,41 @@ def _is_excluded(rel_path: str) -> bool:
     return False
 
 
-def _authed_url(url: str, token: Optional[str]) -> str:
-    if not token:
-        return url
-    sep = "&" if urllib.parse.urlparse(url).query else "?"
-    return f"{url}{sep}token={urllib.parse.quote(token, safe='')}"
+def _artifact_url(
+    files_url: str, subpath: str, version: str, token: Optional[str]
+) -> str:
+    """Build a Hypha ``/files`` URL for a listing subpath or a single file."""
+    url = f"{files_url}/{subpath}"
+    query = []
+    if version:
+        query.append(f"version={urllib.parse.quote(version)}")
+    if token:
+        query.append(f"token={urllib.parse.quote(token, safe='')}")
+    if query:
+        url = f"{url}?{'&'.join(query)}"
+    return url
 
 
-def _download_and_extract(
-    url: str, token: Optional[str], dest: Path, logger: logging.Logger
-) -> None:
-    """Download the artifact zip to a temp file, extract filtered entries, atomic rename into dest."""
-    url = _authed_url(url, token)
-
-    app_root = dest.parent
-    tmp_zip = app_root / f".source.tmp.{os.getpid()}.zip"
-    tmp_dir = app_root / f".source.new.{os.getpid()}"
-    try:
-        if tmp_dir.exists():
-            shutil.rmtree(tmp_dir)
-        tmp_dir.mkdir(parents=True)
-
-        logger.info(f"BioEngine: downloading artifact zip → {tmp_zip}")
-        with urllib.request.urlopen(url, timeout=120) as r:
-            with open(tmp_zip, "wb") as out:
-                shutil.copyfileobj(r, out, length=1024 * 1024)
-
-        kept = 0
-        with zipfile.ZipFile(tmp_zip, "r") as zf:
-            for info in zf.infolist():
-                if info.is_dir():
-                    continue
-                if _is_excluded(info.filename):
-                    continue
-                zf.extract(info, tmp_dir)
-                kept += 1
-
-        if dest.exists():
-            shutil.rmtree(dest)
-        os.replace(tmp_dir, dest)
-        logger.info(
-            f"BioEngine: extracted {kept} source files → {dest}"
-        )
-    finally:
-        try:
-            tmp_zip.unlink(missing_ok=True)
-        except OSError:
-            pass
-        if tmp_dir.exists():
-            try:
-                shutil.rmtree(tmp_dir)
-            except OSError:
-                pass
-
-
-def _download_from_ray_gcs(uri: str, dest: Path, logger: logging.Logger) -> None:
-    """Materialise ``dest`` from a ``gcs://_ray_pkg_<hash>.zip`` URI.
-
-    Wraps :func:`ray._private.runtime_env.packaging.download_and_unpack_package`
-    (which is async) in a synchronous facade since both the replica
-    bootstrap and the build Ray task are sync callers. The unpack target
-    Ray picks is its own scratch dir; we copy the result into ``dest``
-    with the same filter logic ``_download_and_extract`` uses for Hypha
-    zips so the on-disk layout is identical across backends.
-    """
-    import asyncio
-    import tempfile
-
-    from ray._private.runtime_env.packaging import download_and_unpack_package
-
-    logger.info(f"BioEngine: downloading source from Ray-GCS {uri} → {dest}")
-    with tempfile.TemporaryDirectory(prefix="bioengine-rayfetch-") as scratch:
-        unpacked = asyncio.run(download_and_unpack_package(uri, scratch))
-        unpacked_path = Path(unpacked)
-
-        app_root = dest.parent
-        tmp_dir = app_root / f".source.new.{os.getpid()}"
-        if tmp_dir.exists():
-            shutil.rmtree(tmp_dir)
-        tmp_dir.mkdir(parents=True)
-        kept = 0
-        for root, _dirs, files in os.walk(unpacked_path):
-            root_p = Path(root)
-            rel_root = root_p.relative_to(unpacked_path)
-            for fname in files:
-                rel = (rel_root / fname).as_posix()
-                if _is_excluded(rel):
-                    continue
-                out = tmp_dir / rel
-                out.parent.mkdir(parents=True, exist_ok=True)
-                shutil.copyfile(root_p / fname, out)
-                kept += 1
-        if dest.exists():
-            shutil.rmtree(dest)
-        os.replace(tmp_dir, dest)
-        logger.info(f"BioEngine: extracted {kept} source files → {dest}")
-
-
-def _artifact_source_signature(
+def _list_source_files(
     files_url: str, version: str, token: Optional[str], logger: logging.Logger
-) -> Optional[str]:
-    """Content signature over the artifact's non-excluded (source) files.
+) -> Dict[str, str]:
+    """Recursively list the artifact's non-excluded source files.
 
-    Walks the artifact file listing (cheap metadata, not the content) and
-    hashes each kept file's ``(path, size, last_modified)``. Only files that
-    would actually be extracted into ``source/`` are included, so a change to
-    an excluded file (README, notebook, cover image, manifest) does not force
-    a re-download. Returns ``None`` if the listing can't be fetched — the
-    caller then falls back to an unconditional download.
+    The Hypha ``/files`` endpoint is not recursive — it returns, per item,
+    ``name`` / ``type`` (``"directory"`` vs file) / ``size`` / ``last_modified``
+    — so we walk directories ourselves by re-requesting each subpath. Returns
+    ``{relpath: last_modified}`` for exactly the files that would land in
+    ``source/`` (excluded files are never listed or fetched). Raises on any
+    fetch/parse failure so the caller fails the deployment and ``auto_redeploy``
+    retries rather than silently serving a partial sync.
     """
-    import hashlib
-    import json as _json
 
-    def _list(subpath: str) -> Optional[List[Dict[str, Any]]]:
-        url = f"{files_url}/{subpath}"
-        query = []
-        if version:
-            query.append(f"version={urllib.parse.quote(version)}")
-        if token:
-            query.append(f"token={urllib.parse.quote(token, safe='')}")
-        if query:
-            url = f"{url}?{'&'.join(query)}"
+    def _list(subpath: str) -> Optional[List[dict]]:
+        url = _artifact_url(files_url, subpath, version, token)
         with urllib.request.urlopen(url, timeout=30) as resp:
-            return _json.loads(resp.read().decode())
+            return json.loads(resp.read().decode())
 
-    entries: List[tuple] = []
+    files: Dict[str, str] = {}
 
     def _walk(subpath: str) -> None:
         for item in _list(subpath) or []:
@@ -211,53 +119,122 @@ def _artifact_source_signature(
                 if _is_excluded(f"{rel}/_"):
                     continue
                 _walk(f"{rel}/")
-            else:
-                if _is_excluded(rel):
-                    continue
-                entries.append((rel, item.get("size"), item.get("last_modified")))
+            elif not _is_excluded(rel):
+                files[rel] = str(item.get("last_modified"))
 
+    _walk("")
+    return files
+
+
+def _download_file(
+    files_url: str,
+    relpath: str,
+    version: str,
+    token: Optional[str],
+    dest: Path,
+    logger: logging.Logger,
+) -> None:
+    """Stream one artifact file to ``dest`` (temp file + atomic rename)."""
+    url = _artifact_url(files_url, relpath, version, token)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.parent / f".{dest.name}.tmp.{os.getpid()}"
     try:
-        _walk("")
-    except Exception as exc:
-        logger.info(f"BioEngine: artifact file listing failed ({exc}); will re-download")
-        return None
+        with urllib.request.urlopen(url, timeout=120) as r:
+            with open(tmp, "wb") as out:
+                shutil.copyfileobj(r, out, length=1024 * 1024)
+        os.replace(tmp, dest)
+    finally:
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
 
-    entries.sort()
-    digest = hashlib.sha256()
-    for rel, size, last_modified in entries:
-        digest.update(f"{rel}\t{size}\t{last_modified}\n".encode())
-    return digest.hexdigest()
+
+def _prune_empty_dirs(start: Path, stop_at: Path) -> None:
+    """Remove now-empty directories from ``start`` up to (not incl.) ``stop_at``."""
+    d = start
+    while d != stop_at and stop_at in d.parents:
+        try:
+            d.rmdir()
+        except OSError:
+            break
+        d = d.parent
+
+
+def _sync_source_from_hypha(
+    files_url: str,
+    version: str,
+    token: Optional[str],
+    source: Path,
+    snapshot_path: Path,
+    logger: logging.Logger,
+) -> None:
+    """Incrementally sync ``source/`` to the artifact's committed ``version``.
+
+    Downloads files whose remote ``last_modified`` differs from the local
+    snapshot (or that are missing on disk), deletes files that vanished from the
+    artifact, and rewrites the snapshot only after every download succeeds so a
+    partial failure re-syncs cleanly on the next attempt.
+    """
+    remote = _list_source_files(files_url, version, token, logger)
+
+    snapshot: Dict[str, str] = {}
+    if snapshot_path.exists():
+        try:
+            snapshot = json.loads(snapshot_path.read_text())
+        except (OSError, ValueError):
+            snapshot = {}
+
+    source.mkdir(parents=True, exist_ok=True)
+
+    downloaded = 0
+    for relpath, last_modified in remote.items():
+        if snapshot.get(relpath) != last_modified or not (source / relpath).is_file():
+            _download_file(files_url, relpath, version, token, source / relpath, logger)
+            downloaded += 1
+
+    # Reconcile against the whole source tree, not just the snapshot: delete any
+    # file no longer in the artifact — covers files removed between versions AND
+    # leftovers from a prior transport scheme on a migrated app_dir.
+    removed = 0
+    for path in list(source.rglob("*")):
+        if path.is_file():
+            relpath = path.relative_to(source).as_posix()
+            if relpath not in remote:
+                path.unlink()
+                _prune_empty_dirs(path.parent, source)
+                removed += 1
+
+    snapshot_path.write_text(json.dumps(remote))
+    logger.info(
+        f"BioEngine: synced source from Hypha "
+        f"({downloaded} downloaded, {removed} removed, {len(remote)} total) → {source}"
+    )
 
 
 def _ensure_source(app_dir: Path, version: str, logger: logging.Logger) -> Path:
-    """Atomically populate ``app_dir/source`` so it matches ``version``.
+    """Populate ``app_dir/source`` so it matches the artifact's ``version``.
 
-    Three backends, picked in order:
+    Backends, picked in order:
 
     1. ``BIOENGINE_LOCAL_ARTIFACT_PATH`` — dev override, short-circuits to a
        locally-mounted artifact root.
-    2. ``BIOENGINE_APP_SOURCE_URI`` — Ray-internal GCS download via
-       :func:`_download_from_ray_gcs`. Preferred on replicas because the
-       Hypha short-TTL token has typically expired by replica launch.
-    3. ``BIOENGINE_ARTIFACT_DOWNLOAD_URL`` (+ optional ``_TOKEN``) — direct
-       Hypha pull, used by the introspect Ray task.
+    2. ``BIOENGINE_ARTIFACT_FILES_URL`` (+ optional ``_DOWNLOAD_TOKEN``) —
+       per-file incremental Hypha sync (:func:`_sync_source_from_hypha`).
 
-    Single ``fcntl`` lock per node serialises concurrent same-node starts;
-    the second caller sees the up-to-date ``.version`` marker and skips.
+    A single ``fcntl`` lock per node serialises concurrent same-node starts.
     """
     source = app_dir / "source"
     version_marker = app_dir / ".version"
+    snapshot_path = app_dir / ".source_snapshot.json"
     app_dir.mkdir(parents=True, exist_ok=True)
 
     # Dev override: ``BIOENGINE_LOCAL_ARTIFACT_PATH`` points at a directory
     # holding ``<artifact_alias>/`` subdirs with the raw app sources.
     local_root_env = os.environ.get("BIOENGINE_LOCAL_ARTIFACT_PATH")
     artifact_id = os.environ.get("BIOENGINE_ARTIFACT_ID", "")
-    # Cache identity keys on the artifact too, not just the version string:
-    # two different artifacts (or a reused application_id) can share a version
-    # string, and a bare-version marker would serve the first one's stale
-    # source. Same content ⇒ same identity in both the introspect and replica
-    # branches, so the flock skip still short-circuits correctly.
+    # Identity keys on the artifact too, not just the version string, so a
+    # reused application_id across artifacts can't serve stale source.
     identity = f"{artifact_id}@{version}"
     if local_root_env and artifact_id:
         alias = artifact_id.split("/")[-1]
@@ -278,69 +255,18 @@ def _ensure_source(app_dir: Path, version: str, logger: logging.Logger) -> Path:
     with open(lock_path, "w") as lock_fh:
         fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
         try:
-            current = (
-                version_marker.read_text().strip()
-                if version_marker.exists()
-                else None
-            )
-
-            gcs_uri = os.environ.get("BIOENGINE_APP_SOURCE_URI")
-            if gcs_uri:
-                # Replica/build path. The introspect for this deploy always
-                # re-materialises the source (below), so a matching identity
-                # marker means the current content is already on disk — on a
-                # shared FS the build/replicas reuse it (and the flock
-                # serialises concurrent same-node replicas). Only pull from the
-                # content-addressed GCS package when the source is absent.
-                if current == identity and source.is_dir():
-                    logger.info(
-                        f"BioEngine: source already at {identity} — skip download"
-                    )
-                    return source
-                _download_from_ray_gcs(gcs_uri, source, logger)
-                version_marker.write_text(identity)
-                return source
-
-            url = os.environ.get("BIOENGINE_ARTIFACT_DOWNLOAD_URL")
-            if not url:
-                raise RuntimeError(
-                    "Neither BIOENGINE_APP_SOURCE_URI nor "
-                    "BIOENGINE_ARTIFACT_DOWNLOAD_URL is set; cannot "
-                    "materialise the app source. The worker is expected to "
-                    "populate one of these env_vars when constructing the "
-                    "runtime_env for the task or deployment."
-                )
-            # Introspect path: the authoritative per-deploy fetch from Hypha.
-            # A version string is NOT a content identity (a version can be
-            # re-staged / re-uploaded with new code, an artifact_id recreated),
-            # so we cannot skip on it. Instead gate the (potentially heavy)
-            # re-download on a content signature over the artifact's file
-            # listing — path + size + last_modified of the files that land in
-            # source/. Unchanged ⇒ skip the download and keep the cached
-            # source; changed / unavailable ⇒ re-download and re-extract (which
-            # also drops files deleted from the artifact).
-            token = os.environ.get("BIOENGINE_ARTIFACT_DOWNLOAD_TOKEN") or None
             files_url = os.environ.get("BIOENGINE_ARTIFACT_FILES_URL")
-            signature = (
-                _artifact_source_signature(files_url, version, token, logger)
-                if files_url
-                else None
-            )
-            sig_marker = app_dir / ".source_signature"
-            if signature is not None and source.is_dir():
-                prev = (
-                    sig_marker.read_text().strip() if sig_marker.exists() else None
+            if not files_url:
+                raise RuntimeError(
+                    "BIOENGINE_ARTIFACT_FILES_URL is not set; cannot materialise "
+                    "the app source. The worker is expected to populate it (and "
+                    "optionally BIOENGINE_ARTIFACT_DOWNLOAD_TOKEN) when "
+                    "constructing the runtime_env for the task or deployment."
                 )
-                if prev == signature:
-                    logger.info(
-                        "BioEngine: artifact source signature unchanged — "
-                        "skip download"
-                    )
-                    version_marker.write_text(identity)
-                    return source
-            _download_and_extract(url, token, source, logger)
-            if signature is not None:
-                sig_marker.write_text(signature)
+            token = os.environ.get("BIOENGINE_ARTIFACT_DOWNLOAD_TOKEN") or None
+            _sync_source_from_hypha(
+                files_url, version, token, source, snapshot_path, logger
+            )
             version_marker.write_text(identity)
             return source
         finally:

--- a/bioengine/_version.py
+++ b/bioengine/_version.py
@@ -13,4 +13,4 @@ see the same string that ``pip`` sees.
 Must stay in lock-step with ``pyproject.toml``'s ``version`` field.
 The ``version-check.yml`` CI workflow enforces the match.
 """
-__version__ = "0.11.30"
+__version__ = "0.12.0"

--- a/bioengine/apps/builder.py
+++ b/bioengine/apps/builder.py
@@ -5,19 +5,19 @@ the filesystem. The worker only handles:
 
 * manifest loading + ``format_version`` / ``authorized_users`` gate
 * runtime_env composition (base pip + env_vars for the introspect task)
-* mint short-TTL Hypha download token
+* mint a read-only Hypha download token (30-day; public artifacts need none)
 * submit :func:`bioengine._app.bootstrap.introspect_app_in_ray_task` —
-  that Ray task downloads source, walks the type-hint composition graph,
-  packages source to Ray's internal GCS, returns ``{spec, app_source_uri}``
+  that Ray task syncs source from Hypha and walks the type-hint composition
+  graph, returning ``{spec}``
 * kwargs validation against the returned spec
 * resource accounting + ``_check_resources`` (the SLURM-aware gate)
 * authorisation-rule resolution + ``ProxyDeployment`` argument assembly
 * submit :func:`bioengine._app.bootstrap.build_and_run_application` — that
   Ray task does ``cls.bind(...)`` + ``serve.run(blocking=False)``
 
-Every replica receives ``BIOENGINE_APP_SOURCE_URI`` in its ``env_vars``
-and uses Ray-internal GCS to materialise source — no Hypha auth on the
-replica side, so the short-TTL token never matters after step 4.
+Every replica syncs its own source **per file from Hypha** (durable) using
+the ``BIOENGINE_ARTIFACT_FILES_URL`` (+ optional token) in its ``env_vars`` —
+no Ray-GCS package for the app source.
 """
 
 from __future__ import annotations
@@ -56,11 +56,14 @@ from bioengine.utils import (
     validate_manifest,
 )
 
-#: TTL of the short-lived read-only token the worker mints per deploy and
-#: hands the replica setup hook for its create-zip-file download. Bounded
-#: well above the time it takes a typical Ray Serve replica to pull the
-#: ~MB-scale artifact and well under any plausible session-reuse window.
-_DOWNLOAD_TOKEN_TTL_SECONDS = 600
+#: TTL of the read-only token the worker mints per deploy and hands replicas
+#: for their per-file Hypha source sync. Unlike the old ~10 min introspect-only
+#: token, replicas now pull source at *every* start (autoscale, crash-restart,
+#: head-restart re-submit), so it must span the deployment lifetime; 30 days
+#: matches the proxy service token. Refreshed on every redeploy, with
+#: auto_redeploy as the backstop for the 30-day edge. Public artifacts need no
+#: token (anonymous read).
+_DOWNLOAD_TOKEN_TTL_SECONDS = 3600 * 24 * 30
 
 
 class AppBuilder:
@@ -159,7 +162,7 @@ class AppBuilder:
         """Compose the env_vars dict the replica's runtime_env will receive.
 
         The replica setup hook (``bioengine._app.replica_init``) reads
-        ``BIOENGINE_APP_DIR`` + ``BIOENGINE_ARTIFACT_DOWNLOAD_URL`` +
+        ``BIOENGINE_APP_DIR`` + ``BIOENGINE_ARTIFACT_FILES_URL`` +
         ``BIOENGINE_ARTIFACT_VERSION`` + ``BIOENGINE_ARTIFACT_DOWNLOAD_TOKEN``
         from this dict to materialise the user source. HOME and TMPDIR are
         deliberately *not* set here — the setup hook computes them under
@@ -193,13 +196,9 @@ class AppBuilder:
             env_vars["HYPHA_ARTIFACT_VERSION"] = version
             env_vars["BIOENGINE_ARTIFACT_VERSION"] = version
             artifact_workspace, alias = artifact_id.split("/", 1)
-            env_vars["BIOENGINE_ARTIFACT_DOWNLOAD_URL"] = (
-                f"{self.server_url.rstrip('/')}/{artifact_workspace}"
-                f"/artifacts/{alias}/create-zip-file?version={version}"
-            )
-            # Files-listing endpoint (metadata only) — the introspect uses it
-            # to compute a content signature and skip the full re-download when
-            # the artifact is unchanged.
+            # Files endpoint: lists files (name/type/size/last_modified) for the
+            # per-file incremental sync, and serves each file at
+            # ``{files_url}/{relpath}?version=&token=``. See replica_init.py.
             env_vars["BIOENGINE_ARTIFACT_FILES_URL"] = (
                 f"{self.server_url.rstrip('/')}/{artifact_workspace}"
                 f"/artifacts/{alias}/files"
@@ -291,11 +290,9 @@ class AppBuilder:
     ) -> Dict[str, Any]:
         """Submit :func:`introspect_app_in_ray_task` as a Ray task.
 
-        The task downloads the user package (Hypha, short-TTL token in
-        ``env_vars``), walks the type-hint composition graph, packages
-        the source to Ray's internal GCS, and returns the
-        ``{spec, app_source_uri}`` payload. We never touch the worker's
-        filesystem.
+        The task syncs the user package from Hypha (token in ``env_vars``),
+        walks the type-hint composition graph, and returns the ``{spec}``
+        payload. We never touch the worker's filesystem.
 
         Strips the ``_BIOENGINE_SECRET_*`` keys from ``env_vars`` before
         passing into the task to keep secrets out of Ray's logs; the
@@ -487,11 +484,11 @@ class AppBuilder:
         application_kwargs = dict(application_kwargs or {})
         application_env_vars = dict(application_env_vars or {})
 
-        # 1. Mint a short-TTL read-only token the introspect Ray task will
-        # attach to its single Hypha create-zip-file download. The token
-        # never crosses to Ray Serve replicas — they pull source from Ray's
-        # internal GCS via ``BIOENGINE_APP_SOURCE_URI`` (uploaded inside the
-        # introspect task), so its TTL only matters for the next ~10 s.
+        # 1. Mint a read-only token for the introspect task AND every replica's
+        # per-file Hypha source sync (it rides in replica_env_vars). 30-day TTL
+        # so replicas starting later (autoscale, crash-restart) can still pull;
+        # refreshed on each redeploy. On a public artifact the mint raises a
+        # permission error and we fall through to anonymous read (below).
         download_token: Optional[str] = None
         artifact_workspace = artifact_id.split("/", 1)[0]
         try:
@@ -540,18 +537,14 @@ class AppBuilder:
         )
         runtime_env = self._build_submit_runtime_env(env_vars)
 
-        # 3. Introspect the user package via a Ray task — the task
-        # downloads from Hypha, walks @bioengine.app composition, and
-        # packages the source to Ray-internal GCS. Returns spec + URI.
+        # 3. Introspect the user package via a Ray task — the task syncs the
+        # source from Hypha and walks the @bioengine.app composition. Returns
+        # spec only; replicas sync their own source per file from Hypha.
         introspect_result = await self._introspect_via_ray_task(
             entry_id, env_vars, runtime_env
         )
         spec = introspect_result["spec"]
-        app_source_uri = introspect_result["app_source_uri"]
-        self.logger.info(
-            f"Introspect task returned for '{application_id}' — "
-            f"app_source_uri={app_source_uri}"
-        )
+        self.logger.info(f"Introspect task returned for '{application_id}'")
 
         # Sanity check: format_version round-trip.
         if spec.get("format_version") != SPEC_FORMAT_VERSION:
@@ -718,7 +711,6 @@ class AppBuilder:
             proxy_args=proxy_args,
             runtime_env=runtime_env,
             bioengine_uri=self._bioengine_gcs_uri(),
-            app_source_uri=app_source_uri,
             proxy_pip=proxy_pip,
             user_replica_framework_pip=user_replica_framework_pip,
             replica_env_vars=replica_env_vars,
@@ -736,8 +728,7 @@ class AppBuilder:
         not after — and preserves the SLURM-scaling fallback.
 
         No worker-side cleanup needed: the worker never wrote anything to
-        its own filesystem. Source bytes live in Ray's GCS package store
-        (uploaded by the introspect task); replicas fetch from there.
+        its own filesystem. Replicas sync source per file from Hypha.
         """
         # The Ray Client server unpickles ``.remote(...)`` args in a
         # per-client runtime_env that ships bioengine via ``py_modules``
@@ -762,7 +753,6 @@ class AppBuilder:
                     application_id,
                     f"/{application_id}",
                     built_app.bioengine_uri,
-                    built_app.app_source_uri,
                     built_app.proxy_pip,
                     built_app.user_replica_framework_pip,
                     _ensure_jsonable(built_app.replica_env_vars),
@@ -789,10 +779,10 @@ class BuiltApp:
     the manager can do ``build → check_resources → submit`` and keep the
     resource check on the right side of the actual claim.
 
-    ``app_source_uri`` is the ``gcs://_ray_pkg_<hash>.zip`` URI returned
-    by the introspect Ray task — the build task plus every replica use
-    it to materialise source via Ray's internal package store, no Hypha
-    auth needed.
+    ``bioengine_uri`` is the content-hashed ``gcs://_ray_pkg_<hash>.zip`` URI
+    for the framework package (re-derived from the worker's ``ray.init``
+    upload). The user app source is NOT carried here — replicas sync it per
+    file from Hypha via the coords in ``replica_env_vars``.
     """
 
     __slots__ = (
@@ -802,7 +792,6 @@ class BuiltApp:
         "proxy_args",
         "runtime_env",
         "bioengine_uri",
-        "app_source_uri",
         "proxy_pip",
         "user_replica_framework_pip",
         "replica_env_vars",
@@ -818,7 +807,6 @@ class BuiltApp:
         proxy_args: Dict[str, Any],
         runtime_env: Dict[str, Any],
         bioengine_uri: str,
-        app_source_uri: str,
         proxy_pip: List[str],
         user_replica_framework_pip: List[str],
         replica_env_vars: Dict[str, str],
@@ -831,7 +819,6 @@ class BuiltApp:
         self.proxy_args = proxy_args
         self.runtime_env = runtime_env
         self.bioengine_uri = bioengine_uri
-        self.app_source_uri = app_source_uri
         self.proxy_pip = proxy_pip
         self.user_replica_framework_pip = user_replica_framework_pip
         self.replica_env_vars = replica_env_vars

--- a/bioengine/apps/manager.py
+++ b/bioengine/apps/manager.py
@@ -28,6 +28,23 @@ from bioengine.utils import (
 )
 
 
+def _is_serve_controller_gone(exc: BaseException) -> bool:
+    """Whether a ``serve.*`` call failed because the Serve controller is gone.
+
+    A Ray head restart wipes the Serve controller actor: ``serve.status``
+    then reports "There is no Serve instance running on this Ray cluster",
+    or — when a cached client handle outlives the controller — "doesn't have
+    a handle for <actor>". Both mean the controller must be re-bootstrapped
+    by a fresh ``serve.run`` rather than merely reconnected.
+    """
+    msg = str(exc).lower()
+    return (
+        "no serve instance running" in msg
+        or "there is no serve instance" in msg
+        or "doesn't have a handle for" in msg
+    )
+
+
 def _belongs_to_worker_workspace(
     application_id: str,
     app_data: Dict[str, Any],
@@ -91,6 +108,12 @@ from bioengine.apps._cache_fs_tasks import (
 # Schedule: 10, 20, 40, 80, 160, 320, 600, 600 … s.
 _REDEPLOY_BACKOFF_INITIAL_SECONDS = 10.0
 _REDEPLOY_BACKOFF_MAX_SECONDS = 600.0
+
+# Minimum gap between in-place Serve-controller-loss recovery sweeps. Long
+# enough for a redeploy's serve.run to bootstrap the controller before we'd
+# consider re-firing, short enough for a couple of attempts before the
+# monitor's degraded backstop cycles the pod (~62 s to 5 consecutive errors).
+_CONTROLLER_RECOVERY_COOLDOWN_SECONDS = 25.0
 
 
 class AppsManager:
@@ -223,6 +246,11 @@ class AppsManager:
         # entry holds {consecutive_failures, next_attempt_at}. Cleared the
         # moment an app is observed healthy again. See monitor_applications.
         self._redeploy_backoff: Dict[str, Dict[str, Any]] = {}
+
+        # Timestamp of the last in-place Serve-controller-loss recovery sweep,
+        # used to rate-limit re-firing while a redeploy's serve.run is still
+        # bootstrapping the controller. See _recover_from_controller_loss.
+        self._last_controller_recovery = 0.0
 
         # Cache the result of the one-time FS-topology probe across Ray
         # nodes. None until the first list/clear-cache call from the
@@ -602,6 +630,14 @@ class AppsManager:
             f"User '{user_id}' is starting undeployment of application '{application_id}'..."
         )
         await self._cancel_deployment_process(application_id=application_id)
+
+        # Drop the tracking entry BEFORE serve.delete. The monitor loop iterates
+        # _deployed_applications and fires auto-redeploy for anything unhealthy;
+        # if the entry survived the serve.delete window, a monitor tick could
+        # re-adopt the app mid-stop and re-deploy it, racing the stop. Popping
+        # first makes the app invisible to the monitor for the rest of teardown.
+        self._deployed_applications.pop(application_id, None)
+        self._redeploy_backoff.pop(application_id, None)
 
         try:
             await self.ray_cluster.call_with_reconnect(
@@ -1255,7 +1291,20 @@ class AppsManager:
 
         # Get status of actively running deployments
         await self.ray_cluster.check_connection()
-        serve_status = await self.ray_cluster.call_with_reconnect(serve.status)
+        try:
+            serve_status = await self.ray_cluster.call_with_reconnect(serve.status)
+        except Exception as exc:
+            if _is_serve_controller_gone(exc):
+                # A Ray head restart wiped the Serve controller. The client
+                # reconnects (handles refreshed, cached Serve client dropped)
+                # but there is no controller until an app is (re)deployed, so
+                # redeploy the tracked apps in-place: serve.run bootstraps a
+                # fresh controller and recreates the replicas without cycling
+                # the pod. Re-raise so, if recovery can't take within a few
+                # ticks, the monitor's degraded counter still trips the
+                # liveness backstop.
+                await self._recover_from_controller_loss(apps_to_redeploy)
+            raise
 
         now = time.time()
 
@@ -1332,6 +1381,35 @@ class AppsManager:
             )
             backoff_state["consecutive_failures"] = attempt
             backoff_state["next_attempt_at"] = now + delay
+
+    async def _recover_from_controller_loss(
+        self, application_ids: List[str]
+    ) -> None:
+        """Re-establish Ray Serve in-place after the controller was lost.
+
+        A Ray head restart destroys the Serve controller; ``reconnect`` has
+        already dropped the cached Serve client, so re-firing each tracked
+        app's deploy task lets ``serve.run`` bootstrap a fresh controller and
+        recreate the replicas without cycling the worker pod. A deployed app's
+        deploy task blocks alive on an event, so we can't gate on it being
+        idle; instead a cooldown rate-limits sweeps so an in-flight serve.run
+        isn't stomped every tick. Apps recovered from a previous worker carry
+        no cached ``built_app``; they can't be rebuilt from here and are left
+        for the liveness backstop to recover via a pod cycle.
+        """
+        now = time.time()
+        if now - self._last_controller_recovery < _CONTROLLER_RECOVERY_COOLDOWN_SECONDS:
+            return
+        self._last_controller_recovery = now
+        for application_id in application_ids:
+            info = self._deployed_applications.get(application_id)
+            if not info or info.get("built_app") is None:
+                continue
+            self.logger.error(
+                f"Ray Serve controller lost (Ray head restart?); "
+                f"re-establishing application '{application_id}' in-place."
+            )
+            self._fire_redeploy(application_id, info, attempt=1)
 
     def _fire_redeploy(
         self,

--- a/bioengine/cluster/ray_cluster.py
+++ b/bioengine/cluster/ray_cluster.py
@@ -933,6 +933,20 @@ class RayCluster:
             # callers racing against the reconnect could hold and use it.
             self.proxy_actor_handle = None
             await self._connect_to_cluster()
+            # Ray Serve caches a module-global client bound to the previous
+            # session's controller actor; ray.shutdown()/reconnect does not
+            # reset it, so the next serve.* call keeps hitting the dead
+            # controller ("doesn't have a handle for"). Drop it so serve.*
+            # re-resolves the live controller, or cleanly reports that no
+            # instance is running (which triggers in-place app recovery).
+            try:
+                from ray import serve as _serve
+
+                _serve.context._set_global_client(None)
+            except Exception as e:
+                self.logger.debug(
+                    f"Could not reset Ray Serve global client during reconnect: {e}"
+                )
             self.logger.info("Ray Client reconnected; handles refreshed.")
 
     async def call_with_reconnect(self, fn, *args, **kwargs):

--- a/bioengine/worker/worker.py
+++ b/bioengine/worker/worker.py
@@ -276,6 +276,17 @@ class BioEngineWorker:
         self.start_time = None
         self._last_monitoring = 0
 
+        # Backstop for the in-place Serve recovery in
+        # ``AppsManager.monitor_applications``: after this many consecutive
+        # monitoring-loop failures the worker reports not-ready (get_status)
+        # so the k8s liveness probe cycles the pod. In-place recovery handles
+        # the common Ray-head-restart case (redeploy bootstraps a fresh Serve
+        # controller); this covers the residue it can't — e.g. an app with no
+        # cached built_app, or a redeploy that keeps failing — where a fresh
+        # pod is the only way out.
+        self._monitor_consecutive_errors = 0
+        self._monitor_degraded_threshold = 5
+
         self.is_ready = asyncio.Event()
         self._shutdown_event = asyncio.Event()
         self._shutdown_event.set()
@@ -830,7 +841,7 @@ class BioEngineWorker:
                 "Starting monitoring task with interval "
                 f"{self.monitoring_interval_seconds} seconds..."
             )
-            consecutive_errors = 0
+            self._monitor_consecutive_errors = 0
             while self.is_ready.is_set():
                 try:
                     # Sleep for 1 second before next iteration
@@ -860,7 +871,8 @@ class BioEngineWorker:
                         except Exception as step_exc:
                             step_errors.append((name, step_exc))
                             self.logger.warning(
-                                f"Monitoring step '{name}' failed: {step_exc}"
+                                f"Monitoring step '{name}' failed: {step_exc}",
+                                exc_info=True,
                             )
 
                     # ===== 0. Geo location =====
@@ -900,31 +912,47 @@ class BioEngineWorker:
                     # await self.dataset_manager.monitor_datasets()
 
                     # Log recovery after a streak of failures
-                    if consecutive_errors > 0:
+                    if self._monitor_consecutive_errors > 0:
                         self.logger.info(
                             f"Monitoring loop recovered after "
-                            f"{consecutive_errors} consecutive error(s)"
+                            f"{self._monitor_consecutive_errors} consecutive error(s)"
                         )
-                    consecutive_errors = 0
+                    self._monitor_consecutive_errors = 0
 
                 except asyncio.CancelledError:
                     # Propagate so the outer handler performs clean shutdown.
                     raise
                 except Exception as e:
-                    consecutive_errors += 1
+                    self._monitor_consecutive_errors += 1
                     # Exponential backoff capped at backoff_max_seconds.
                     backoff = min(
                         backoff_max_seconds,
-                        backoff_initial_seconds * (2 ** (consecutive_errors - 1)),
+                        backoff_initial_seconds
+                        * (2 ** (self._monitor_consecutive_errors - 1)),
                     )
-                    # Escalate severity once the streak indicates a sustained
-                    # outage so dashboards / alerts still notice, without
-                    # ever killing the worker.
-                    log = self.logger.warning if consecutive_errors <= 5 else self.logger.error
+                    log = (
+                        self.logger.warning
+                        if self._monitor_consecutive_errors <= 5
+                        else self.logger.error
+                    )
                     log(
-                        f"Error in monitoring task (#{consecutive_errors} consecutive, "
+                        f"Error in monitoring task "
+                        f"(#{self._monitor_consecutive_errors} consecutive, "
                         f"sleeping {backoff:.0f}s before retry): {e}"
                     )
+                    # At the degraded threshold, get_status flips to not-ready
+                    # so the k8s liveness probe cycles the pod — the backstop
+                    # for when in-place Serve recovery can't clear the wedge.
+                    if (
+                        self._monitor_consecutive_errors
+                        == self._monitor_degraded_threshold
+                    ):
+                        self.logger.error(
+                            f"Monitoring wedged for "
+                            f"{self._monitor_consecutive_errors} consecutive ticks — "
+                            f"reporting worker not-ready so the liveness probe "
+                            f"restarts the pod."
+                        )
                     await asyncio.sleep(backoff)
 
         except asyncio.CancelledError:
@@ -1207,7 +1235,11 @@ class BioEngineWorker:
             "ray_cluster": self.ray_cluster.status,
             "admin_users": self.admin_users,
             "geo_location": self.geo_location,
-            "is_ready": self.is_ready.is_set(),
+            "is_ready": (
+                self.is_ready.is_set()
+                and self._monitor_consecutive_errors
+                < self._monitor_degraded_threshold
+            ),
         }
 
         # SLURM jobs — refresh from squeue at read time so the dashboard

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.11.30"
+version = "0.12.0"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [

--- a/tests/_app/test_env_vars_propagation.py
+++ b/tests/_app/test_env_vars_propagation.py
@@ -39,7 +39,6 @@ def _merge_via_with_pkg(
     replica_env_vars: Dict[str, str],
     user_replica_framework_pip: list[str] | None = None,
     bioengine_uri: str = "gcs://_ray_pkg_aaaaaaaaaaaaaaaa.zip",
-    app_source_uri: str = "gcs://_ray_pkg_bbbbbbbbbbbbbbbb.zip",
 ) -> Dict[str, Any]:
     """Drive ``_with_pkg`` from bootstrap against a fake class and return
     the assembled ``runtime_env`` dict that bootstrap would hand to Ray
@@ -59,7 +58,6 @@ def _merge_via_with_pkg(
     )
     rt["env_vars"] = {
         **replica_env_vars,
-        "BIOENGINE_APP_SOURCE_URI": app_source_uri,
         **(rt.get("env_vars") or {}),
     }
     return rt
@@ -135,8 +133,6 @@ def test_empty_framework_env_vars_keeps_author_env_vars_intact() -> None:
         {"runtime_env": {"env_vars": {"AUTHOR_FLAG": "1"}}},
         replica_env_vars={},
     )
-    # BIOENGINE_APP_SOURCE_URI is always injected by _with_pkg so the
-    # replica's _ensure_source can pull source from Ray-GCS; the author's
-    # env vars sit alongside it.
+    # The author's env vars survive the merge (the app source is synced from
+    # Hypha at replica init, not carried in env_vars).
     assert rt["env_vars"]["AUTHOR_FLAG"] == "1"
-    assert rt["env_vars"]["BIOENGINE_APP_SOURCE_URI"].startswith("gcs://")

--- a/tests/_app/test_replica_init.py
+++ b/tests/_app/test_replica_init.py
@@ -1,18 +1,19 @@
 """Unit tests for :mod:`bioengine._app.replica_init` — the replica-side
-artifact materialisation that v0.11.4 substitutes for the worker's old
-zip-and-ship-via-file:// path.
+artifact materialisation (per-file incremental sync from Hypha).
 
-These tests exercise the pure-Python branches (exclude filtering, version
-marker reuse, atomic source/ rename, HOME/TMPDIR/sys.path setup) without
-needing a live Hypha server. The HTTP download path is monkey-patched so
-the tests don't reach the network.
+These tests exercise the pure-Python branches (exclude filtering, snapshot
+diffing, deletion of removed files, HOME/TMPDIR/sys.path setup) without a live
+Hypha server. The network-facing helpers are either monkey-patched at the
+``_list_source_files`` / ``_download_file`` seam (sync-logic tests) or driven
+through a fake ``urlopen`` (listing/download tests).
 """
 from __future__ import annotations
 
 import io
+import json
+import logging
 import os
 import sys
-import zipfile
 from pathlib import Path
 from typing import Tuple
 
@@ -20,64 +21,37 @@ import pytest
 
 from bioengine._app import replica_init
 
-
-def _make_artifact_zip(files: dict[str, bytes]) -> bytes:
-    buf = io.BytesIO()
-    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
-        for name, content in files.items():
-            zf.writestr(name, content)
-    return buf.getvalue()
-
-
-@pytest.fixture
-def fake_artifact_files() -> dict[str, bytes]:
-    return {
-        "entry.py": b"def main(): return 42\n",
-        "subpkg/__init__.py": b"",
-        "subpkg/util.py": b"X = 1\n",
-        "config/settings.yaml": b"key: value\n",
-        "manifest.yaml": b"name: My App\n",  # excluded
-        "README.md": b"# excluded\n",  # excluded
-        "tutorial.ipynb": b"{}",  # excluded
-        "frontend/index.html": b"<html/>",  # excluded
-        ".env": b"SECRET=1",  # excluded (hidden)
-        "__pycache__/x.pyc": b"\x00",  # excluded
-    }
+#: Canned artifact: ``{relpath: (content, last_modified)}``.
+_ARTIFACT = {
+    "entry.py": (b"def main(): return 42\n", "2026-01-01T00:00:00"),
+    "subpkg/__init__.py": (b"", "2026-01-01T00:00:00"),
+    "subpkg/util.py": (b"X = 1\n", "2026-01-01T00:00:00"),
+    "config/settings.yaml": (b"key: value\n", "2026-01-01T00:00:00"),
+}
 
 
 @pytest.fixture
-def patched_download(monkeypatch, fake_artifact_files):
-    """Replace ``_download_and_extract`` so the test never touches the network.
+def fake_hypha(monkeypatch):
+    """Fake ``_list_source_files`` + ``_download_file``.
 
-    The fake writes a zip with the canned artifact bytes into the dest dir
-    using the real extract+filter logic, so exclude semantics still get
-    exercised.
+    Returns a controller with a mutable ``remote`` map (``{rel: (content, lm)}``)
+    and a ``downloads`` list recording every relpath fetched, so tests can
+    mutate the remote between syncs and assert exactly what got re-downloaded.
     """
-    captured: dict = {}
+    remote = dict(_ARTIFACT)
+    downloads: list = []
 
-    def fake(url, token, dest, logger):
-        captured["url"] = url
-        captured["token"] = token
-        zip_bytes = _make_artifact_zip(fake_artifact_files)
-        tmp = dest.parent / f".source.new.{os.getpid()}"
-        if tmp.exists():
-            import shutil
-            shutil.rmtree(tmp)
-        tmp.mkdir(parents=True)
-        with zipfile.ZipFile(io.BytesIO(zip_bytes), "r") as zf:
-            for info in zf.infolist():
-                if info.is_dir():
-                    continue
-                if replica_init._is_excluded(info.filename):
-                    continue
-                zf.extract(info, tmp)
-        if dest.exists():
-            import shutil
-            shutil.rmtree(dest)
-        os.replace(tmp, dest)
+    def fake_list(files_url, version, token, logger):
+        return {rel: lm for rel, (_content, lm) in remote.items()}
 
-    monkeypatch.setattr(replica_init, "_download_and_extract", fake)
-    return captured
+    def fake_download(files_url, relpath, version, token, dest, logger):
+        downloads.append(relpath)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(remote[relpath][0])
+
+    monkeypatch.setattr(replica_init, "_list_source_files", fake_list)
+    monkeypatch.setattr(replica_init, "_download_file", fake_download)
+    return {"remote": remote, "downloads": downloads}
 
 
 @pytest.fixture
@@ -87,9 +61,8 @@ def replica_env(monkeypatch, tmp_path) -> Tuple[Path, dict]:
         "BIOENGINE_APP_DIR": str(app_dir),
         "BIOENGINE_ARTIFACT_ID": "bioimage-io/model-runner",
         "BIOENGINE_ARTIFACT_VERSION": "1.2.0",
-        "BIOENGINE_ARTIFACT_DOWNLOAD_URL": (
-            "https://hypha.aicell.io/bioimage-io/artifacts/model-runner"
-            "/create-zip-file?version=1.2.0"
+        "BIOENGINE_ARTIFACT_FILES_URL": (
+            "https://hypha.aicell.io/bioimage-io/artifacts/model-runner/files"
         ),
     }
     for k, v in env.items():
@@ -97,6 +70,9 @@ def replica_env(monkeypatch, tmp_path) -> Tuple[Path, dict]:
     monkeypatch.delenv("BIOENGINE_ARTIFACT_DOWNLOAD_TOKEN", raising=False)
     monkeypatch.delenv("BIOENGINE_LOCAL_ARTIFACT_PATH", raising=False)
     return app_dir, env
+
+
+# ───────────────────────────── exclude filter ─────────────────────────────
 
 
 def test_is_excluded_drops_docs_frontend_and_dotfiles() -> None:
@@ -116,20 +92,18 @@ def test_is_excluded_keeps_python_and_config() -> None:
     assert not replica_init._is_excluded("model.json")
 
 
-def test_setup_creates_dirs_and_extends_sys_path(replica_env, patched_download) -> None:
-    app_dir, env = replica_env
+# ───────────────────────────── setup + sync ───────────────────────────────
+
+
+def test_setup_creates_dirs_and_extends_sys_path(replica_env, fake_hypha) -> None:
+    app_dir, _env = replica_env
 
     replica_init.setup_replica_environment()
 
     source = app_dir / "source"
-    assert source.is_dir()
     assert (source / "entry.py").is_file()
     assert (source / "subpkg" / "util.py").is_file()
     assert (source / "config" / "settings.yaml").is_file()
-    assert not (source / "manifest.yaml").exists()
-    assert not (source / "README.md").exists()
-    assert not (source / "frontend").exists()
-    assert not (source / "__pycache__").exists()
 
     assert (app_dir / "home").is_dir()
     assert (app_dir / "tmp").is_dir()
@@ -137,55 +111,66 @@ def test_setup_creates_dirs_and_extends_sys_path(replica_env, patched_download) 
     assert os.environ["TMPDIR"] == str(app_dir / "tmp")
     assert str(source) in sys.path
 
-    marker = (app_dir / ".version").read_text().strip()
-    assert marker == "1.2.0"
+    snapshot = json.loads((app_dir / ".source_snapshot.json").read_text())
+    assert set(snapshot) == set(_ARTIFACT)
+    assert (
+        app_dir / ".version"
+    ).read_text().strip() == "bioimage-io/model-runner@1.2.0"
 
 
-def test_second_setup_at_same_version_skips_download(
-    replica_env, patched_download, monkeypatch
+def test_initial_sync_downloads_all(replica_env, fake_hypha) -> None:
+    replica_init.setup_replica_environment()
+    assert sorted(fake_hypha["downloads"]) == sorted(_ARTIFACT)
+
+
+def test_unchanged_timestamps_skip_download(replica_env, fake_hypha) -> None:
+    replica_init.setup_replica_environment()
+    fake_hypha["downloads"].clear()
+
+    replica_init.setup_replica_environment()  # nothing changed remotely
+    assert fake_hypha["downloads"] == []
+
+
+def test_changed_timestamp_redownloads_only_that_file(
+    replica_env, fake_hypha
 ) -> None:
-    app_dir, env = replica_env
+    app_dir, _env = replica_env
     replica_init.setup_replica_environment()
-    patched_download.clear()
+    fake_hypha["downloads"].clear()
 
-    sentinel = app_dir / "source" / "marker.txt"
-    sentinel.write_text("preserve me")
-
-    download_calls = {"count": 0}
-    original = replica_init._download_and_extract
-
-    def counting(url, token, dest, logger):
-        download_calls["count"] += 1
-        return original(url, token, dest, logger)
-
-    monkeypatch.setattr(replica_init, "_download_and_extract", counting)
-    replica_init.setup_replica_environment()
-
-    assert download_calls["count"] == 0
-    assert sentinel.read_text() == "preserve me"
-
-
-def test_version_change_triggers_redownload(
-    replica_env, patched_download, monkeypatch
-) -> None:
-    app_dir, env = replica_env
-    replica_init.setup_replica_environment()
-
-    sentinel = app_dir / "source" / "sentinel.txt"
-    sentinel.write_text("v1")
-
-    monkeypatch.setenv("BIOENGINE_ARTIFACT_VERSION", "1.3.0")
-    monkeypatch.setenv(
-        "BIOENGINE_ARTIFACT_DOWNLOAD_URL",
-        "https://hypha.aicell.io/bioimage-io/artifacts/model-runner"
-        "/create-zip-file?version=1.3.0",
+    fake_hypha["remote"]["entry.py"] = (
+        b"def main(): return 99\n",
+        "2026-02-02T00:00:00",
     )
-
     replica_init.setup_replica_environment()
 
-    assert not sentinel.exists()
+    assert fake_hypha["downloads"] == ["entry.py"]
+    assert (app_dir / "source" / "entry.py").read_bytes() == b"def main(): return 99\n"
+
+
+def test_removed_file_deleted_locally(replica_env, fake_hypha) -> None:
+    app_dir, _env = replica_env
+    replica_init.setup_replica_environment()
+    assert (app_dir / "source" / "subpkg" / "util.py").is_file()
+
+    del fake_hypha["remote"]["subpkg/util.py"]
+    replica_init.setup_replica_environment()
+
+    assert not (app_dir / "source" / "subpkg" / "util.py").exists()
     assert (app_dir / "source" / "entry.py").is_file()
-    assert (app_dir / ".version").read_text().strip() == "1.3.0"
+
+
+def test_missing_local_file_redownloaded(replica_env, fake_hypha) -> None:
+    """A file the snapshot claims is current is re-fetched if gone from disk."""
+    app_dir, _env = replica_env
+    replica_init.setup_replica_environment()
+    fake_hypha["downloads"].clear()
+
+    (app_dir / "source" / "entry.py").unlink()
+    replica_init.setup_replica_environment()
+
+    assert "entry.py" in fake_hypha["downloads"]
+    assert (app_dir / "source" / "entry.py").is_file()
 
 
 def test_setup_is_noop_without_app_dir(monkeypatch) -> None:
@@ -200,14 +185,25 @@ def test_setup_raises_when_version_missing(monkeypatch, tmp_path) -> None:
         replica_init.setup_replica_environment()
 
 
-def test_local_artifact_path_shortcircuits_download(
-    replica_env, monkeypatch, tmp_path, fake_artifact_files
+def test_missing_files_url_raises(monkeypatch, tmp_path) -> None:
+    app_dir = tmp_path / "app"
+    monkeypatch.setenv("BIOENGINE_APP_DIR", str(app_dir))
+    monkeypatch.setenv("BIOENGINE_ARTIFACT_VERSION", "1.2.0")
+    monkeypatch.delenv("BIOENGINE_ARTIFACT_FILES_URL", raising=False)
+    monkeypatch.delenv("BIOENGINE_LOCAL_ARTIFACT_PATH", raising=False)
+    monkeypatch.delenv("BIOENGINE_ARTIFACT_ID", raising=False)
+    with pytest.raises(RuntimeError, match="BIOENGINE_ARTIFACT_FILES_URL"):
+        replica_init.setup_replica_environment()
+
+
+def test_local_artifact_path_shortcircuits_sync(
+    replica_env, monkeypatch, tmp_path
 ) -> None:
-    app_dir, env = replica_env
+    app_dir, _env = replica_env
     local_root = tmp_path / "local-dev"
     artifact_subdir = local_root / "model-runner"
     artifact_subdir.mkdir(parents=True)
-    for rel, content in fake_artifact_files.items():
+    for rel, (content, _lm) in _ARTIFACT.items():
         out = artifact_subdir / rel
         out.parent.mkdir(parents=True, exist_ok=True)
         out.write_bytes(content)
@@ -215,82 +211,91 @@ def test_local_artifact_path_shortcircuits_download(
     monkeypatch.setenv("BIOENGINE_LOCAL_ARTIFACT_PATH", str(local_root))
 
     def boom(*a, **kw):
-        raise AssertionError("download must not be called when local path exists")
+        raise AssertionError("Hypha sync must not run when local path exists")
 
-    monkeypatch.setattr(replica_init, "_download_and_extract", boom)
-
-    replica_init.setup_replica_environment()
-    assert (app_dir / "source" / "entry.py").is_file()
-    assert (app_dir / ".version").read_text().strip() == "1.2.0"
-
-
-def test_authed_url_appends_token_via_query_string() -> None:
-    base = "https://hypha.aicell.io/ws/artifacts/x/create-zip-file?version=1"
-    assert replica_init._authed_url(base, "abc 123").endswith(
-        "&token=abc%20123"
-    )
-    no_query = "https://hypha.aicell.io/ws/artifacts/x/create-zip-file"
-    assert replica_init._authed_url(no_query, "abc").endswith("?token=abc")
-
-
-def test_authed_url_returns_base_when_no_token() -> None:
-    base = "https://hypha.aicell.io/ws/artifacts/x/create-zip-file?version=1"
-    assert replica_init._authed_url(base, None) == base
-    assert replica_init._authed_url(base, "") == base
-
-
-def test_ray_gcs_uri_branch_skips_hypha(
-    replica_env, monkeypatch, tmp_path, fake_artifact_files
-) -> None:
-    """When BIOENGINE_APP_SOURCE_URI is set, _ensure_source pulls from
-    Ray-internal GCS and never touches Hypha — even if a Hypha URL is
-    also in the env."""
-    app_dir, env = replica_env
-
-    monkeypatch.setenv(
-        "BIOENGINE_APP_SOURCE_URI",
-        "gcs://_ray_pkg_deadbeefdeadbeef.zip",
-    )
-
-    def fake_ray_gcs(uri, dest, logger):
-        # Materialise the artifact bytes the same way Hypha would, so the
-        # downstream version-marker write / sys.path lookup paths still
-        # work identically.
-        assert uri == "gcs://_ray_pkg_deadbeefdeadbeef.zip"
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        if dest.exists():
-            import shutil
-            shutil.rmtree(dest)
-        dest.mkdir(parents=True)
-        for rel, content in fake_artifact_files.items():
-            if replica_init._is_excluded(rel):
-                continue
-            out = dest / rel
-            out.parent.mkdir(parents=True, exist_ok=True)
-            out.write_bytes(content)
-
-    def boom(*a, **kw):
-        raise AssertionError(
-            "Hypha _download_and_extract must not be called when "
-            "BIOENGINE_APP_SOURCE_URI is set"
-        )
-
-    monkeypatch.setattr(replica_init, "_download_from_ray_gcs", fake_ray_gcs)
-    monkeypatch.setattr(replica_init, "_download_and_extract", boom)
+    monkeypatch.setattr(replica_init, "_sync_source_from_hypha", boom)
 
     replica_init.setup_replica_environment()
     assert (app_dir / "source" / "entry.py").is_file()
-    assert (app_dir / ".version").read_text().strip() == "1.2.0"
+    assert (
+        app_dir / ".version"
+    ).read_text().strip() == "bioimage-io/model-runner@1.2.0"
 
 
-def test_neither_uri_set_raises_clear_error(monkeypatch, tmp_path) -> None:
-    app_dir = tmp_path / "app"
-    monkeypatch.setenv("BIOENGINE_APP_DIR", str(app_dir))
-    monkeypatch.setenv("BIOENGINE_ARTIFACT_VERSION", "1.2.0")
-    monkeypatch.delenv("BIOENGINE_APP_SOURCE_URI", raising=False)
-    monkeypatch.delenv("BIOENGINE_ARTIFACT_DOWNLOAD_URL", raising=False)
-    monkeypatch.delenv("BIOENGINE_LOCAL_ARTIFACT_PATH", raising=False)
-    monkeypatch.delenv("BIOENGINE_ARTIFACT_ID", raising=False)
+# ───────────────────────── network-facing helpers ─────────────────────────
 
-    with pytest.raises(RuntimeError, match="BIOENGINE_APP_SOURCE_URI"):
-        replica_init.setup_replica_environment()
+
+class _FakeResp:
+    def __init__(self, data: bytes) -> None:
+        self._buf = io.BytesIO(data)
+
+    def read(self, n: int = -1) -> bytes:
+        return self._buf.read(n)
+
+    def __enter__(self) -> "_FakeResp":
+        return self
+
+    def __exit__(self, *a) -> bool:
+        return False
+
+
+def test_list_source_files_walks_and_excludes(monkeypatch) -> None:
+    tree = {
+        "": [
+            {"name": "entry.py", "type": "file", "size": 10, "last_modified": "t1"},
+            {"name": "manifest.yaml", "type": "file", "size": 5, "last_modified": "t1"},
+            {"name": "subpkg", "type": "directory"},
+            {"name": "frontend", "type": "directory"},
+        ],
+        "subpkg/": [
+            {"name": "util.py", "type": "file", "size": 3, "last_modified": "t2"},
+        ],
+    }
+
+    def fake_urlopen(url, timeout=None):
+        after = url.split("?")[0].split("/files", 1)[1].lstrip("/")
+        return _FakeResp(json.dumps(tree.get(after, [])).encode())
+
+    monkeypatch.setattr(replica_init.urllib.request, "urlopen", fake_urlopen)
+    files = replica_init._list_source_files(
+        "https://h/ws/artifacts/x/files", "1.0", None, logging.getLogger("t")
+    )
+    # manifest.yaml + frontend/ excluded; subpkg walked recursively.
+    assert files == {"entry.py": "t1", "subpkg/util.py": "t2"}
+
+
+def test_download_file_writes_content_and_builds_url(monkeypatch, tmp_path) -> None:
+    seen = {}
+
+    def fake_urlopen(url, timeout=None):
+        seen["url"] = url
+        return _FakeResp(b"hello world")
+
+    monkeypatch.setattr(replica_init.urllib.request, "urlopen", fake_urlopen)
+    dest = tmp_path / "a" / "b" / "f.py"
+    replica_init._download_file(
+        "https://h/ws/artifacts/x/files",
+        "a/b/f.py",
+        "1.0",
+        "tok",
+        dest,
+        logging.getLogger("t"),
+    )
+    assert dest.read_bytes() == b"hello world"
+    assert seen["url"].startswith("https://h/ws/artifacts/x/files/a/b/f.py?")
+    assert "version=1.0" in seen["url"] and "token=tok" in seen["url"]
+
+
+def test_artifact_url_appends_version_and_token() -> None:
+    files = "https://h/ws/artifacts/x/files"
+    url = replica_init._artifact_url(files, "entry.py", "1.2.0", "abc 123")
+    assert url.startswith("https://h/ws/artifacts/x/files/entry.py?")
+    assert "version=1.2.0" in url
+    assert "token=abc%20123" in url
+
+
+def test_artifact_url_public_no_token() -> None:
+    files = "https://h/ws/artifacts/x/files"
+    url = replica_init._artifact_url(files, "entry.py", "1.2.0", None)
+    assert url == "https://h/ws/artifacts/x/files/entry.py?version=1.2.0"
+    assert "token" not in url


### PR DESCRIPTION
## Summary

Move BioEngine app-source transport off the **ephemeral Ray GCS** onto **durable Hypha per-file download** with remote-timestamp incremental sync. Replicas now materialise `<app_dir>/source/` by syncing files directly from the Hypha artifact (keyed on each file's `last_modified`), instead of pulling a `gcs://_ray_pkg_<hash>.zip` package the introspect task uploaded.

## Why

The in-memory Ray GCS intermediary was the root of three problems, all hit in production on 2026-07-22:

- **Head-restart outage** — a Ray head restart wipes the GCS, so the cached `built_app.app_source_uri` package dangles (`package prematurely deleted from GCS`) and redeploys wedge (both prod apps were down until a manual pod kill).
- **Head-node OOM** — a package accumulates per app×version in the head's memory-backed store (a likely driver of the biweekly head restarts).
- **Redeploy stale-code footgun** — a redeploy reusing a cached/stale package served old code.

Hypha is already a hard dependency (a BioEngine app can't register its service without it), so pulling source from Hypha at replica start adds **no new availability surface** — if Hypha is unreachable the deployment fails and `auto_redeploy` retries.

## What changed

- **`bioengine/_app/replica_init.py`** — per-file incremental sync: `_list_source_files` (recursive `/files` listing with `last_modified`), `_download_file` (streamed per-file GET), `_sync_source_from_hypha` (snapshot diff via `.source_snapshot.json` → download changed/new, delete removed, reconcile the whole tree so migrated app_dirs shed GCS-era orphans). The `sys.meta_path` finder is now the **sole** source path — the app source is no longer shipped as a Ray py_module.
- **`bioengine/_app/bootstrap.py` / `bioengine/apps/builder.py`** — deleted `_package_source_to_ray_gcs`; introspect returns `{spec}` only; removed all `app_source_uri` / `BIOENGINE_APP_SOURCE_URI` plumbing. Read token TTL → **30 days** (replicas pull for their lifetime; public artifacts stay anonymous). The **bioengine framework package stays on Ray py_modules** — it's the bootstrap that runs the sync (chicken-egg), is re-uploaded on every reconnect, and is content-hash-dedup'd (not the OOM driver).
- **`bioengine/apps/manager.py` / `cluster/ray_cluster.py` / `worker/worker.py`** — kept the head-restart in-place recovery this uncovered: Serve-client reset on reconnect, controller-loss detect+redeploy with cooldown, `is_ready` liveness backstop, `exc_info` diagnostics, and the `stop_app` pop-before-`serve.delete` race fix. (An earlier rebuild-on-redeploy approach was reverted — durable Hypha source makes the cached `built_app` re-submittable, so it's unnecessary.)

## Validation

83 unit tests pass. End-to-end on a persistent standalone Ray head (dev image `0.11.31-dev6`), **both** external-cluster and single-machine modes:

| Check | Result |
|---|---|
| Monolithic entry (sibling import before `import bioengine`), py_modules channel removed | ✅ RUNNING, serves sibling code — finder is sole path |
| Composed app (EntryApp↔RuntimeApp) + child-deployment sibling import | ✅ works |
| Per-file Hypha sync on introspect+build+replica+proxy; no app-source `_ray_pkg` on head | ✅ |
| Redeploy 0.1.0→0.2.0 picks up changed code | ✅ new code served |
| **Head-restart recovery** | ✅ in-place ~74s, correct code, **zero "prematurely deleted from GCS"** |
| Single-machine mode | ✅ RUNNING + serves |

## Known limitation / follow-ups

- **Cross-version incremental** isn't there yet: `upload_app` re-uploads every file, so all get fresh `last_modified` on a commit → a version bump re-downloads all files. **Same-version** re-syncs (replica restart / autoscale / head-restart) *are* incremental (0 downloads). Full "big weights not re-fetched on a small change" needs an upload-side change (skip unchanged files) — tracked as a follow-up. Moot for model-runner (weights come from HF, not the artifact).
- Reconsider the biweekly Ray-head restarts now that GCS no longer accumulates app packages.

## Rollout

Draft until **model-runner is validated on a dev image** (worker change; even-clam drives the redeploy-cutover check on an isolated dev worker). `pyproject.toml`/`_version.py` version bump lands as the final commit before `gh pr ready`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
