### PR TITLE
fix(app): cold-replica pickle-by-value + reused-process module purge (0.12.0 transport hardening)

### DIFF
--- a/bioengine/_app/bootstrap.py
+++ b/bioengine/_app/bootstrap.py
@@ -433,6 +433,7 @@ def build_and_run_application(
     import os
     from pathlib import Path
 
+    from ray import cloudpickle as ray_cloudpickle
     from ray import serve
 
     from bioengine._app.replica_init import _ensure_source
@@ -544,6 +545,25 @@ def build_and_run_application(
         return handles[cid]
 
     entry_handle = bind(spec["entry_id"])
+
+    # Ray Serve pickles each deployment's class with ``ray.cloudpickle`` on this
+    # head. A @bioengine.app class that touches module-level symbols of its own
+    # source module (helper funcs/classes — any monolith like cellpose has many)
+    # otherwise pickles those references BY NAME, so a cold replica has to
+    # ``import main``/``import entry`` inside ``cloudpickle.loads`` — before any
+    # bioengine code runs, hence before the meta_path finder is installed →
+    # ``ModuleNotFoundError``. (worker_process_setup_hook is NOT honoured before
+    # a Serve replica's unpickle, so it can't bridge this.) Registering every
+    # materialised app-source module for pickle-by-value makes the deployment
+    # carry the code, so the replica reconstructs it without importing user
+    # modules. Lazy in-method imports still resolve via the finder, which is
+    # installed when the reconstructed class's @bioengine wrappers import
+    # bioengine on load.
+    src_prefix = os.path.realpath(src_str) + os.sep
+    for module in list(sys.modules.values()):
+        module_file = getattr(module, "__file__", None)
+        if module_file and os.path.realpath(module_file).startswith(src_prefix):
+            ray_cloudpickle.register_pickle_by_value(module)
 
     # Override the proxy's ray_actor_options.memory at deployment time.
     # ``num_cpus=0`` is set on the decorator (see proxy_deployment.py); a

--- a/bioengine/_app/mixin.py
+++ b/bioengine/_app/mixin.py
@@ -45,6 +45,7 @@ def _setup_replica(instance: Any) -> None:
 
     _register_with_proxy_actor(logger)
     _ensure_working_directory(logger)
+    _purge_stale_app_modules(logger)
     _unmask_secret_env_vars()
 
     instance._bioengine_replica_initialized = False
@@ -98,6 +99,45 @@ def _register_with_proxy_actor(logger: logging.Logger) -> None:
         logger.error(
             f"❌ Unable to register replica with BioEngineProxyActor: {e}",
             exc_info=True,
+        )
+
+
+def _purge_stale_app_modules(logger: logging.Logger) -> None:
+    """Drop cached app-source modules from ``sys.modules`` so a redeploy that
+    reuses this Ray worker process re-imports the freshly-synced source.
+
+    A redeploy can land a fresh replica on a *reused* worker process — forced
+    when the deployment holds a single-slot resource (``num_gpus=1`` on a
+    one-GPU node), or when the runtime_env is unchanged. The per-file Hypha
+    sync already refreshed ``<app_dir>/source`` on disk, but the reused
+    interpreter still has the *previous* deploy's app modules in
+    ``sys.modules``, so ``import entry`` returns stale code. Purging every
+    module whose file lives under ``<app_dir>/source`` (framework and
+    site-packages untouched) forces a fresh import of the new source. Runs
+    per replica instance via :func:`_setup_replica`, before user ``__init__``.
+    """
+    import sys
+
+    app_dir = os.environ.get("BIOENGINE_APP_DIR")
+    if not app_dir:
+        return
+    source_root = str(Path(app_dir).resolve() / "source")
+    prefix = source_root + os.sep
+    purged = []
+    for name, module in list(sys.modules.items()):
+        path = getattr(module, "__file__", None)
+        if path and path.startswith(prefix):
+            del sys.modules[name]
+            purged.append(name)
+    if source_root not in sys.path:
+        sys.path.insert(0, source_root)
+    if purged:
+        import importlib
+
+        importlib.invalidate_caches()
+        logger.info(
+            f"BioEngine: purged {len(purged)} stale app module(s) from "
+            f"sys.modules for a fresh import: {sorted(purged)}"
         )
 
 

--- a/bioengine/_version.py
+++ b/bioengine/_version.py
@@ -13,4 +13,4 @@ see the same string that ``pip`` sees.
 Must stay in lock-step with ``pyproject.toml``'s ``version`` field.
 The ``version-check.yml`` CI workflow enforces the match.
 """
-__version__ = "0.12.0"
+__version__ = "0.12.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.12.0"
+version = "0.12.1"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [

--- a/tests/_app/test_pickle_by_value_cold_replica.py
+++ b/tests/_app/test_pickle_by_value_cold_replica.py
@@ -1,0 +1,98 @@
+"""Regression test for the cold-replica pickle-by-reference bug.
+
+Since 0.12.0 stopped shipping app source on Ray ``py_modules`` (it syncs per
+file from Hypha instead), a Serve replica no longer has ``<app_dir>/source`` on
+``sys.path`` when Ray runs ``cloudpickle.loads(serialized_deployment_def)`` in
+``ServeReplica.__init__``. If the entry class's methods reference a module-level
+symbol of their own source module (a helper function / class — any monolith like
+cellpose has many), ``cloudpickle`` pickles that reference BY NAME, so the cold
+replica must ``import main`` inside the unpickle — before any bioengine code runs
+(so before the meta_path finder exists) — and dies with ``ModuleNotFoundError``.
+
+``build_and_run_application`` fixes this by registering every materialised
+app-source module for pickle-by-value before ``serve.run`` serializes, so the
+deployment carries the code and the replica reconstructs it without importing
+user modules. This test reproduces the exact failure and the fix at the
+``ray.cloudpickle`` layer, loading in a CLEAN subprocess that mimics the cold
+replica (source dir absent from ``sys.path``).
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+pytest.importorskip("ray")
+
+_ENTRY = textwrap.dedent(
+    """
+    # Module-level helper referenced by a method — the by-name pickle trigger.
+    def compute():
+        return 42
+
+    class Entry:
+        def marker(self):
+            return compute()
+    """
+)
+
+
+def _dump_script(src_dir: str, register: bool) -> str:
+    return textwrap.dedent(
+        f"""
+        import sys
+        sys.path.insert(0, {src_dir!r})
+        import entry
+        from ray import cloudpickle as cp
+        if {register!r}:
+            cp.register_pickle_by_value(sys.modules["entry"])
+        sys.stdout.buffer.write(cp.dumps(entry.Entry))
+        """
+    )
+
+
+def _load_script(blob_path: str) -> str:
+    # A cold replica: the source dir is NOT on sys.path, no bioengine finder.
+    return textwrap.dedent(
+        f"""
+        from ray import cloudpickle as cp
+        cls = cp.loads(open({blob_path!r}, "rb").read())
+        print("OK", cls().marker())
+        """
+    )
+
+
+def _dump(code: str, blob):
+    with open(blob, "wb") as fh:
+        return subprocess.run(
+            [sys.executable, "-c", code], stdout=fh, stderr=subprocess.PIPE
+        )
+
+
+def _load(code: str, cwd: str):
+    return subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, cwd=cwd
+    )
+
+
+def test_by_reference_pickle_fails_cold_but_by_value_loads(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "entry.py").write_text(_ENTRY)
+
+    byref = tmp_path / "byref.pkl"
+    byval = tmp_path / "byval.pkl"
+    assert _dump(_dump_script(str(src), register=False), byref).returncode == 0
+    assert _dump(_dump_script(str(src), register=True), byval).returncode == 0
+
+    # Cold replica: run from tmp_path so the source dir is not importable and
+    # is absent from sys.path.
+    ref = _load(_load_script(str(byref)), cwd=str(tmp_path))
+    assert ref.returncode != 0
+    assert b"No module named 'entry'" in ref.stderr, ref.stderr
+
+    val = _load(_load_script(str(byval)), cwd=str(tmp_path))
+    assert val.returncode == 0, val.stderr
+    assert val.stdout.strip() == b"OK 42", (val.stdout, val.stderr)

--- a/tests/_app/test_replica_module_purge.py
+++ b/tests/_app/test_replica_module_purge.py
@@ -1,0 +1,76 @@
+"""Unit test for ``_purge_stale_app_modules`` — the per-replica sys.modules
+purge that lets a redeploy on a REUSED Ray worker process pick up freshly
+synced source instead of a prior deploy's cached modules.
+
+The end-to-end trigger (a fresh replica landing on a warm worker process) only
+occurs when the runtime_env is stable across deploys — e.g. a public artifact
+that mints no download token, on a single-slot GPU that Ray keeps warm. That is
+hard to reproduce off a real GPU cluster, so we test the purge's contract
+directly: given a stale app-source module in ``sys.modules`` and fresh source on
+disk, the purge drops exactly the app-source modules so the next import reads
+the new code, and leaves framework / stdlib modules untouched.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import sys
+
+from bioengine._app import mixin
+
+
+def test_purge_drops_app_source_modules_and_reimports_fresh(tmp_path, monkeypatch):
+    app_dir = tmp_path / "app"
+    source = app_dir / "source"
+    source.mkdir(parents=True)
+    (source / "probemod.py").write_text("VALUE = 'v1'\n")
+
+    monkeypatch.setenv("BIOENGINE_APP_DIR", str(app_dir))
+    monkeypatch.syspath_prepend(str(source))
+    try:
+        m = importlib.import_module("probemod")
+        assert m.VALUE == "v1"
+        assert "probemod" in sys.modules
+
+        # Source changes on disk (as the per-file Hypha sync would do). Advance
+        # the mtime so the cached .pyc is invalidated — the real sync writes the
+        # changed file with a fresh (later) mtime; without this the sub-second
+        # rewrite in the test would keep the v1 bytecode.
+        import os
+        import time
+
+        probe = source / "probemod.py"
+        probe.write_text("VALUE = 'v2'\n")
+        future = time.time() + 10
+        os.utime(probe, (future, future))
+
+        mixin._purge_stale_app_modules(logging.getLogger("test"))
+
+        # The stale app module is gone; a stdlib module is untouched.
+        assert "probemod" not in sys.modules
+        assert "os" in sys.modules
+
+        # Re-import now reads the new source.
+        m2 = importlib.import_module("probemod")
+        assert m2.VALUE == "v2"
+    finally:
+        sys.modules.pop("probemod", None)
+
+
+def test_purge_noop_without_app_dir(monkeypatch):
+    monkeypatch.delenv("BIOENGINE_APP_DIR", raising=False)
+    # Must not raise and must not touch sys.modules.
+    before = set(sys.modules)
+    mixin._purge_stale_app_modules(logging.getLogger("test"))
+    assert set(sys.modules) == before
+
+
+def test_purge_leaves_non_source_modules(tmp_path, monkeypatch):
+    """A module whose file is outside <app_dir>/source is never purged."""
+    app_dir = tmp_path / "app"
+    (app_dir / "source").mkdir(parents=True)
+    monkeypatch.setenv("BIOENGINE_APP_DIR", str(app_dir))
+    # bioengine.* modules live in site-packages, not app_dir/source.
+    assert "bioengine._app.mixin" in sys.modules
+    mixin._purge_stale_app_modules(logging.getLogger("test"))
+    assert "bioengine._app.mixin" in sys.modules


### PR DESCRIPTION
Two replica-side follow-ups to 0.12.0's move of app source off Ray-GCS onto per-file **Hypha sync** (#148). Both are gated on that transport and were surfaced by it. Ships as **0.12.1**.

---

## Fix 1 — cold replica must not `import` app source during `cloudpickle.loads` (the KTH cellpose outage)

**Symptom.** A *cold* Serve replica of a real app (cellpose; composed model-runner) dies in `ServeReplica.__init__`:

```
replica.py:2671  deployment_def = cloudpickle.loads(serialized_deployment_def)
ModuleNotFoundError: No module named 'main'
```

**Cause.** 0.12.0 stopped shipping app source on Ray `py_modules`, so `<app_dir>/source` is not on the replica's `sys.path` when Ray runs `cloudpickle.loads`. Ray Serve pickles a deployment's class **by name** (`ray.cloudpickle`) whenever that class's methods reference a **module-level symbol of their own source module** — a helper function/class, of which any monolith like cellpose has many. Unpickling such a reference does `import main`/`import entry` **before any bioengine code runs**, so before the `sys.meta_path` finder that would materialise the source is installed → `ModuleNotFoundError`. The `worker_process_setup_hook` (the intended pre-import bridge) is **not** honoured before a Serve replica's unpickle, confirmed on KTH: the runtime_env carried the hook, yet it produced no output before the crash. Both prod apps only survived 0.12.0 as **warm-adopted** replicas (never re-pickle-loaded); the first genuine cold pickle-load failed. A trivial `@bioengine.app` class with no module-level self-references pickles fully by value and loads cold fine — which is why simple apps and the pre-merge risk-A test never surfaced it.

**Fix** (`bioengine/_app/bootstrap.py`, `build_and_run_application`). After binding, walk `sys.modules` and `ray.cloudpickle.register_pickle_by_value` every module whose `__file__` is under `<app_dir>/source` (covers subpackages like model-runner's `model_cache/`). The deployment then serializes **by value** and the replica reconstructs it without importing user modules. Lazy in-method imports still resolve via the finder — installed when the reconstructed class's `@bioengine` wrappers import bioengine on load.

## Fix 2 — reused warm worker process serves the previous deploy's code

**Symptom.** A redeploy that lands a fresh replica on a **reused** Ray worker process serves the *previous* deploy's code even though `<app_dir>/source` on disk is fresh (model-runner's tagging fix looked deployed but ran old logic on KTH).

**Cause.** Per-file Hypha sync refreshes the source on disk, but the reused interpreter still has the old app modules in `sys.modules`, so a lazy `import entry` returns stale code. Ray reuses a warm process when the `runtime_env` is byte-identical across deploys — true for **public artifacts** (no per-deploy download token → identical env → warm GPU process reused). Private apps mint a fresh token each deploy, so they dodge it. Env-var changes (e.g. `BIOENGINE_ARTIFACT_VERSION`) do **not** force Ray to recycle a warm process, so this must be fixed replica-side. The old content-hashed GCS py_module incidentally forced a fresh process on any source change, masking this until 0.12.0 removed it.

**Fix** (`bioengine/_app/mixin.py`, `_purge_stale_app_modules`). Run per replica instance in `_setup_replica`, before the user's `__init__`: drop every `sys.modules` entry whose file lives under `<app_dir>/source`, so the next import re-reads the freshly-synced source. No-op on a genuinely fresh process; framework/stdlib untouched. Pairs with the sync's fresh mtimes (forces a real recompile).

---

## Validation

- **Unit tests** (both green; full `tests/_app/` = 87):
  - `tests/_app/test_pickle_by_value_cold_replica.py` — a source module whose entry class references a module-level symbol, loaded in a **clean subprocess** (cold replica): by-reference → `No module named 'entry'`; after `register_pickle_by_value` → loads + constructs.
  - `tests/_app/test_replica_module_purge.py` — stale app module + fresh source on disk → purge drops it → re-import reads new code; framework modules untouched.
- **cloudpickle-layer proof** — clean-interpreter load of a real `@bioengine.app` deployment reproduces the exact `ModuleNotFoundError: No module named 'main'` by-reference, and the by-value pickle loads.
- **Isolated KTH cold gate** (`0.12.1-dev2` on a separate test worker in a non-prod workspace, adoption-isolated from prod; prod stayed on 0.11.29 throughout):
  - **Monolith** cold deploy (module-level ref + lazy in-method import) → RUNNING; `marker()` returns the computed + lazily-imported values (layers 1 & 2).
  - **Composed model-runner** cold `import entry` → RUNNING, lazy `model_cache` subpackage resolved at call time (layers 1 & 2 on the composed shape).
  - **In-process cutover** (Fix 2): same `application_id` redeploy `v1.15.24 → v1.15.26`, **no stop / no restart**, on the warm-public-process condition → serves the new tagging code. The exact prod failure mode, proven fixed without a restart.

## Rollout
`bioengine/**` → PR + dev-image workflow. Version bumped to **0.12.1** on this branch. After merge + canonical publish, KTH is upgraded 0.11.29 → 0.12.1 (restoring the Hypha transport) and the model-runner 1.15.26 in-process cutover proceeds. Never merge — left to the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
