### PR TITLE
feat(app): @bioengine.health_check(depends_on=[...]) cross-deployment readiness gate

### DIFF
--- a/bioengine/_app/bootstrap.py
+++ b/bioengine/_app/bootstrap.py
@@ -90,23 +90,24 @@ def introspect_app(entry_id: str) -> Dict[str, Any]:
 
         {
           "format_version": "0.6.0",
-          "entry_id": "demo_app.deployment:DemoApp",
-          "classes": {
-            "demo_app.deployment:DemoApp": {
-              "module": "demo_app.deployment",
-              "qualname": "DemoApp",
-              "deployment_name": "DemoApp",
+          "entry_id": "entry:EntryApp",
+          "classes": {                         // one entry per deployment in the graph
+            "entry:EntryApp": {                // key is "module:ClassName"; the
+              "module": "entry",               // class IS the Ray Serve deployment,
+              "qualname": "EntryApp",          // so deployment_name == the class name
+              "deployment_name": "EntryApp",
               "ray_actor_options": {...},
               "max_ongoing_requests": 20,
               "method_schemas": [...],
               "lifecycle_methods": {...},
               "init_params": [
                 {"name": "runtime_a", "kind": "deployment_handle",
-                 "target": "demo_app.runtime:RuntimeA", "required": true},
+                 "target": "runtimes.a:RuntimeA", "required": true},
                 {"name": "batch_size", "kind": "value",
                  "annotation": "int", "default": 32, "required": false},
               ]
-            }
+            },
+            "runtimes.a:RuntimeA": {...}        // the composed dependency, same shape
           }
         }
 

--- a/bioengine/_app/bootstrap.py
+++ b/bioengine/_app/bootstrap.py
@@ -90,12 +90,12 @@ def introspect_app(entry_id: str) -> Dict[str, Any]:
 
         {
           "format_version": "0.6.0",
-          "entry_id": "entry:EntryApp",
+          "entry_id": "entry:EntryDeployment",
           "classes": {                         // one entry per deployment in the graph
-            "entry:EntryApp": {                // key is "module:ClassName"; the
+            "entry:EntryDeployment": {         // key is "module:ClassName"; the
               "module": "entry",               // class IS the Ray Serve deployment,
-              "qualname": "EntryApp",          // so deployment_name == the class name
-              "deployment_name": "EntryApp",
+              "qualname": "EntryDeployment",   // so deployment_name == the class name
+              "deployment_name": "EntryDeployment",
               "ray_actor_options": {...},
               "max_ongoing_requests": 20,
               "method_schemas": [...],

--- a/bioengine/_app/bootstrap.py
+++ b/bioengine/_app/bootstrap.py
@@ -26,6 +26,7 @@ from typing import Any, Dict, List, Optional
 from bioengine._app.errors import (
     BioEngineUserError,
     CompositionCycleError,
+    UnknownDependencyError,
 )
 
 #: Manifest format the worker and bootstrap agree on. Bumped together
@@ -94,6 +95,7 @@ def introspect_app(entry_id: str) -> Dict[str, Any]:
             "demo_app.deployment:DemoApp": {
               "module": "demo_app.deployment",
               "qualname": "DemoApp",
+              "deployment_name": "DemoApp",
               "ray_actor_options": {...},
               "max_ongoing_requests": 20,
               "method_schemas": [...],
@@ -123,12 +125,28 @@ def introspect_app(entry_id: str) -> Dict[str, Any]:
     classes: Dict[str, Dict[str, Any]] = {}
     # DFS with a visiting set so cycles surface as a clear error.
     _walk(entry_id, user_cls, entry_cls, classes, visiting=[])
+    _validate_dependencies(classes)
 
     return {
         "format_version": SPEC_FORMAT_VERSION,
         "entry_id": entry_id,
         "classes": classes,
     }
+
+
+def _validate_dependencies(classes: Dict[str, Dict[str, Any]]) -> None:
+    """Every ``@bioengine.health_check(depends_on=[...])`` name must be a
+    deployment in this app's composition graph — a typo would otherwise read as
+    permanently "unknown" and silently never gate, so we reject it at deploy."""
+    deployment_names = {c["deployment_name"] for c in classes.values()}
+    for cid, c in classes.items():
+        for dep in c["lifecycle_methods"].get("health_check_depends_on") or []:
+            if dep not in deployment_names:
+                raise UnknownDependencyError(
+                    f"{cid}: @bioengine.health_check(depends_on=...) names "
+                    f"'{dep}', which is not a deployment in this app. Known "
+                    f"deployments: {sorted(deployment_names)}."
+                )
 
 
 def introspect_app_in_ray_task(
@@ -198,6 +216,7 @@ def _walk(
         classes[cid] = {
             "module": module_name,
             "qualname": qualname,
+            "deployment_name": getattr(deployment, "name", qualname),
             "ray_actor_options": _ensure_jsonable(deployment.ray_actor_options),
             "max_ongoing_requests": getattr(deployment, "max_ongoing_requests", 10),
             "method_schemas": _sanitise_schemas(

--- a/bioengine/_app/decorators.py
+++ b/bioengine/_app/decorators.py
@@ -53,6 +53,10 @@ _KIND_ATTR = "_bioengine_kind"
 # forward the Hypha caller's context as a kwarg.
 _WANTS_CONTEXT_ATTR = "_bioengine_wants_context"
 
+# Sibling-deployment names attached by ``@bioengine.health_check(depends_on=...)``;
+# read into the lifecycle dict by ``_scan_class`` and gated in ``_make_check_health``.
+_DEPENDS_ON_ATTR = "_bioengine_health_depends_on"
+
 
 # ─────────────────────────── method markers ──────────────────────────────
 
@@ -173,14 +177,42 @@ def smoke_test(fn: Callable[..., Any]) -> Callable[..., Any]:
     return fn
 
 
-def health_check(fn: Callable[..., Any]) -> Callable[..., Any]:
+def health_check(
+    fn: Optional[Callable[..., Any]] = None,
+    *,
+    depends_on: Optional[List[str]] = None,
+) -> Callable[..., Any]:
     """Mark a method as the periodic health check.
 
     Invoked on every ``check_health`` call after one-shot init has
     completed. Raise to signal unhealthy.
+
+    ``depends_on`` names sibling deployments in the same app. After the marked
+    method runs, the framework additionally fails the check once a named
+    deployment — having first been seen RUNNING — later drops to zero running
+    replicas, so the service is deregistered rather than advertised while a
+    core dependency is dead. Readiness is read out-of-band from the Serve
+    controller (never an in-band request), so a merely-busy dependency is not
+    misread as down. Each name must exactly match a deployment (the
+    ``@bioengine.app`` class name) in this app's composition graph — a name
+    that matches none raises at deploy time.
+
+    Usable bare (``@bioengine.health_check``) or parameterised
+    (``@bioengine.health_check(depends_on=["RuntimeDeployment"])``).
     """
-    setattr(fn, _KIND_ATTR, "health_check")
-    return fn
+    deps = list(depends_on) if depends_on is not None else []
+    if not all(isinstance(d, str) for d in deps):
+        raise TypeError(
+            "@bioengine.health_check(depends_on=...) must be a list of "
+            "deployment-name strings."
+        )
+
+    def _apply(f: Callable[..., Any]) -> Callable[..., Any]:
+        setattr(f, _KIND_ATTR, "health_check")
+        setattr(f, _DEPENDS_ON_ATTR, deps)
+        return f
+
+    return _apply(fn) if fn is not None else _apply
 
 
 # ───────────────────────────── @bioengine.app ────────────────────────────
@@ -310,6 +342,10 @@ def _scan_class(cls: type) -> tuple[Dict[str, Any], List[Dict[str, Any]]]:
                     f"'{lifecycle[kind]}' and '{attr_name}'. Only one is allowed."
                 )
             lifecycle[kind] = attr_name
+            if kind == "health_check":
+                lifecycle["health_check_depends_on"] = list(
+                    getattr(member, _DEPENDS_ON_ATTR, [])
+                )
 
     return lifecycle, method_schemas
 

--- a/bioengine/_app/errors.py
+++ b/bioengine/_app/errors.py
@@ -27,6 +27,11 @@ class CompositionCycleError(BioEngineUserError):
     """The type-hint composition graph contains a cycle."""
 
 
+class UnknownDependencyError(BioEngineUserError):
+    """``@bioengine.health_check(depends_on=[...])`` names a deployment that
+    isn't part of this app's composition graph."""
+
+
 class MissingDataServerError(BioEngineUserError):
     """``bioengine.datasets`` accessed before BIOENGINE_DATA_SERVER_URL was set.
 

--- a/bioengine/_app/mixin.py
+++ b/bioengine/_app/mixin.py
@@ -53,6 +53,19 @@ def _setup_replica(instance: Any) -> None:
     instance._bioengine_test_task: Optional[asyncio.Task] = None
     instance._bioengine_health_check_lock = asyncio.Lock()
 
+    # Per-dependency "seen RUNNING at least once" latch for
+    # @bioengine.health_check(depends_on=...); a dependency only fails the
+    # check after first coming up, so a slow initial start doesn't fail deploy.
+    instance._bioengine_dep_seen_ready: Dict[str, bool] = {}
+    # This replica's own Serve application name, used to read sibling
+    # deployment status out-of-band. None outside a Serve replica (unit tests).
+    try:
+        from ray import serve as _serve
+
+        instance._bioengine_app_name = _serve.get_replica_context().app_name
+    except Exception:
+        instance._bioengine_app_name = None
+
 
 def _register_with_proxy_actor(logger: logging.Logger) -> None:
     """Register this replica with the worker's ``BioEngineProxyActor``.
@@ -241,6 +254,7 @@ def _make_check_health(
     async_init_name: Optional[str] = lifecycle.get("async_init")
     smoke_test_name: Optional[str] = lifecycle.get("smoke_test")
     health_check_name: Optional[str] = lifecycle.get("health_check")
+    depends_on: list = list(lifecycle.get("health_check_depends_on") or [])
 
     async def check_health(self: Any) -> None:
         logger = logging.getLogger("ray.serve")
@@ -275,7 +289,68 @@ def _make_check_health(
                 else:
                     await asyncio.to_thread(hook)
 
+            for dep in depends_on:
+                running = await _read_running_replicas(
+                    self._bioengine_app_name, dep, logger
+                )
+                if running and running > 0:
+                    self._bioengine_dep_seen_ready[dep] = True
+                elif running == 0 and self._bioengine_dep_seen_ready.get(dep):
+                    raise RuntimeError(
+                        f"Dependency deployment '{dep}' has no running replica "
+                        f"— this app cannot serve."
+                    )
+
     return check_health
+
+
+async def _read_running_replicas(
+    app_name: Optional[str], deployment_name: str, logger: logging.Logger
+) -> Optional[int]:
+    """RUNNING replica count of a sibling deployment, read out-of-band from the
+    Serve controller.
+
+    The controller already health-checks every replica; this reads that
+    collected state and never issues an in-band request to the dependency, so
+    its load can't affect the reading. Returns ``None`` when the count can't be
+    determined (no app name, controller mid-restart, app/deployment not yet in
+    the status view) — callers treat ``None`` as "unknown" and must not
+    deregister on it; only a definite ``0`` means the dependency is down.
+    """
+    if not app_name:
+        return None
+
+    from ray import serve as _serve
+
+    def _query() -> Optional[int]:
+        application = _serve.status().applications.get(app_name)
+        if application is None:
+            return None
+        deployment = application.deployments.get(deployment_name)
+        if deployment is None:
+            return None
+        return sum(
+            count
+            for state, count in deployment.replica_states.items()
+            if str(getattr(state, "value", state)) == "RUNNING"
+        )
+
+    def _read() -> Optional[int]:
+        try:
+            return _query()
+        except Exception:
+            # A restarted Serve controller leaves serve.status() wedged on a
+            # dead cached client handle (status() never re-checks controller
+            # liveness); drop it so the retry reconnects to the live one.
+            _serve.context._set_global_client(None)
+            return _query()
+
+    try:
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(None, _read)
+    except Exception as e:
+        logger.debug(f"Could not read '{deployment_name}' status: {e}")
+        return None
 
 
 def _make_runtime_version(user_cls: type) -> Callable[..., Any]:

--- a/bioengine/_version.py
+++ b/bioengine/_version.py
@@ -13,4 +13,4 @@ see the same string that ``pip`` sees.
 Must stay in lock-step with ``pyproject.toml``'s ``version`` field.
 The ``version-check.yml`` CI workflow enforces the match.
 """
-__version__ = "0.12.2"
+__version__ = "0.12.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.12.2"
+version = "0.12.3"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [

--- a/tests/_app/test_health_check_depends_on.py
+++ b/tests/_app/test_health_check_depends_on.py
@@ -1,0 +1,173 @@
+"""Unit tests for ``@bioengine.health_check(depends_on=[...])``.
+
+Three layers, none needing a live Ray cluster:
+
+* decorator — ``depends_on`` is captured into the lifecycle dict, and the bare
+  form keeps working;
+* build-time — ``introspect_app`` rejects a ``depends_on`` name that isn't a
+  deployment in the app's composition graph;
+* runtime — the gate ``_make_check_health`` installs latches on first-ready and
+  fails only on a definite post-latch zero, tolerating "unknown".
+"""
+
+import asyncio
+import textwrap
+
+import pytest
+
+import bioengine
+from bioengine._app import mixin
+from bioengine._app.bootstrap import introspect_app
+from bioengine._app.errors import UnknownDependencyError
+from bioengine._app.mixin import _make_check_health
+
+
+# ─────────────────────────── decorator capture ───────────────────────────
+
+
+def test_bare_health_check_has_empty_depends_on():
+    @bioengine.app()
+    class App:
+        @bioengine.health_check
+        async def liveness(self):
+            pass
+
+    lc = App.func_or_class._bioengine_lifecycle
+    assert lc["health_check"] == "liveness"
+    assert lc["health_check_depends_on"] == []
+
+
+def test_depends_on_captured_into_lifecycle():
+    @bioengine.app()
+    class App:
+        @bioengine.health_check(depends_on=["RuntimeDeployment"])
+        async def liveness(self):
+            pass
+
+    lc = App.func_or_class._bioengine_lifecycle
+    assert lc["health_check"] == "liveness"
+    assert lc["health_check_depends_on"] == ["RuntimeDeployment"]
+
+
+def test_depends_on_must_be_strings():
+    with pytest.raises(TypeError, match="list of deployment-name strings"):
+
+        @bioengine.app()
+        class App:
+            @bioengine.health_check(depends_on=[object()])
+            async def liveness(self):
+                pass
+
+
+# ───────────────────────── build-time validation ─────────────────────────
+
+
+def _build_depends_pkg(tmp_path, monkeypatch, depends_on: str) -> str:
+    """Write a two-deployment app whose entry depends_on ``depends_on`` and
+    return its ``module:Class`` entry id."""
+    pkg = tmp_path / "dep_pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "runtime.py").write_text(
+        textwrap.dedent(
+            """
+            import bioengine
+            @bioengine.app(num_cpus=0)
+            class Runtime:
+                pass
+            """
+        )
+    )
+    (pkg / "entry.py").write_text(
+        textwrap.dedent(
+            f"""
+            import bioengine
+            from .runtime import Runtime
+            @bioengine.app(num_cpus=0)
+            class Entry:
+                def __init__(self, runtime: Runtime):
+                    self.runtime = runtime
+
+                @bioengine.health_check(depends_on={depends_on!r})
+                async def liveness(self):
+                    pass
+            """
+        )
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    import sys
+
+    for name in ("dep_pkg", "dep_pkg.runtime", "dep_pkg.entry"):
+        sys.modules.pop(name, None)
+    return "dep_pkg.entry:Entry"
+
+
+def test_depends_on_matching_deployment_is_accepted(tmp_path, monkeypatch):
+    entry_id = _build_depends_pkg(tmp_path, monkeypatch, ["Runtime"])
+    spec = introspect_app(entry_id)
+    entry = spec["classes"][entry_id]
+    assert entry["deployment_name"] == "Entry"
+    assert entry["lifecycle_methods"]["health_check_depends_on"] == ["Runtime"]
+
+
+def test_depends_on_unknown_deployment_rejected(tmp_path, monkeypatch):
+    entry_id = _build_depends_pkg(tmp_path, monkeypatch, ["Runtimee"])
+    with pytest.raises(UnknownDependencyError, match="Runtimee"):
+        introspect_app(entry_id)
+
+
+# ──────────────────────────── runtime gate ───────────────────────────────
+
+
+class _FakeReplica:
+    """Minimal stand-in carrying the ``_bioengine_*`` state the gate reads."""
+
+    def __init__(self):
+        self._bioengine_health_check_lock = asyncio.Lock()
+        self._bioengine_replica_initialized = True
+        self._bioengine_replica_test_failed = False
+        self._bioengine_test_task = None
+        self._bioengine_dep_seen_ready = {}
+        self._bioengine_app_name = "app"
+
+
+def _gate(monkeypatch, readings):
+    """Install a ``_make_check_health`` gating on one dependency, backed by a
+    fake replica-count reader yielding ``readings`` in order."""
+    seq = iter(readings)
+
+    async def fake_read(app_name, deployment_name, logger):
+        return next(seq)
+
+    monkeypatch.setattr(mixin, "_read_running_replicas", fake_read)
+    lifecycle = {
+        "async_init": None,
+        "smoke_test": None,
+        "health_check": None,
+        "health_check_depends_on": ["Dep"],
+    }
+    return _make_check_health(_FakeReplica, lifecycle), _FakeReplica()
+
+
+def test_unknown_reading_is_tolerated(monkeypatch):
+    check_health, replica = _gate(monkeypatch, [None])
+    asyncio.run(check_health(replica))
+    assert replica._bioengine_dep_seen_ready.get("Dep") is None
+
+
+def test_zero_before_ever_ready_is_tolerated(monkeypatch):
+    check_health, replica = _gate(monkeypatch, [0])
+    asyncio.run(check_health(replica))  # not latched → no raise
+    assert not replica._bioengine_dep_seen_ready.get("Dep")
+
+
+def test_zero_after_ready_raises(monkeypatch):
+    check_health, replica = _gate(monkeypatch, [2, 0])
+
+    async def drive():
+        await check_health(replica)  # sees 2 → latches ready
+        assert replica._bioengine_dep_seen_ready["Dep"] is True
+        await check_health(replica)  # sees 0 after latch → unhealthy
+
+    with pytest.raises(RuntimeError, match="no running replica"):
+        asyncio.run(drive())


### PR DESCRIPTION
## What

Generalizes the runtime-readiness gate that `apps/model-runner` carries locally (shipped app-side in model-runner 1.15.34) into the `@bioengine.health_check` framework decorator, so any composed app can deregister itself when a sibling deployment it depends on goes down.

```python
@bioengine.health_check(depends_on=["RuntimeDeployment"])
async def _health_check(self):
    ...  # user body runs first; the depends_on gate runs after
```

## Behaviour

- **Out-of-band readiness.** Dependency health is read from the Serve controller's collected `replica_states` (`serve.status()`), never via an in-band `DeploymentHandle` call — a merely-*busy* dependency can't be misread as down. This is exactly the fix for the deNBI HOL-blocking incident (in-band 2s `runtime.ping()` stalled behind a saturated queue), now expressed once in the framework.
- **First-ready latch.** A dependency only fails the check *after* it has been seen RUNNING at least once, so a slow initial start never fails the deploy. Only a definite drop-to-zero after that deregisters.
- **Unknown is tolerated.** A controller mid-restart / not-yet-in-status view returns "unknown" and does not deregister; the restarted-controller case self-heals by dropping the stale cached Serve client and retrying.
- **Exact-match validation.** Each `depends_on` name must match a deployment (the `@bioengine.app` class name) in the app's composition graph. `introspect_app` raises `UnknownDependencyError` at deploy time on a typo, so a misspelled dependency fails loudly instead of silently never gating.

## Scope

Framework-only. `apps/model-runner` is **not** migrated in this PR — it already carries the equivalent app-local logic; migrating it to the decorator is a follow-up once this lands.

## Tests

`tests/_app/test_health_check_depends_on.py` — decorator capture (bare form still works, `depends_on` captured, `TypeError` on non-strings); build-time validation (matching name passes, unknown raises `UnknownDependencyError`); runtime gate semantics (unknown tolerated, zero-before-ready tolerated, zero-after-ready raises). Full `tests/_app/` suite green.

## Dev-image validation (both modes, `0.12.3-dev1`)

A throwaway 2-deployment app (`EntryDeployment` composing `RuntimeDeployment`, entry gated on `depends_on=["RuntimeDeployment"]`):

- **Single-machine** (local docker worker): app reached RUNNING, composition served (`runtime: pong`), and the gated health check kept ticking (`health_checks` 4 -> 8 over 20 s) with no spurious failure. A typo'd `depends_on` was rejected at deploy.
- **External-cluster** (standalone Ray head + `ray://` client worker on an isolated docker network — same topology used for the transport PR, avoids touching prod KubeRay): same RUNNING + gate-ticks result, and the typo'd deploy was rejected with the exact `UnknownDependencyError` naming the bad dependency and listing the known deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)