### PR TITLE
fix(proxy): tolerate entry-saturation timeout, deregister only on a raised health error

### DIFF
--- a/bioengine/_version.py
+++ b/bioengine/_version.py
@@ -13,4 +13,4 @@ see the same string that ``pip`` sees.
 Must stay in lock-step with ``pyproject.toml``'s ``version`` field.
 The ``version-check.yml`` CI workflow enforces the match.
 """
-__version__ = "0.12.3"
+__version__ = "0.12.4"

--- a/bioengine/apps/proxy_deployment.py
+++ b/bioengine/apps/proxy_deployment.py
@@ -1133,8 +1133,14 @@ class ProxyDeployment:
         """
         # Check entry deployment health.
         # First call: wait without timeout (entry may be slow to initialise).
-        # Subsequent calls: short timeout so a stuck entry is detected quickly,
-        # the service is deregistered, and the health check fails fast.
+        # Subsequent calls: short timeout so a genuinely unhealthy entry is
+        # detected quickly, the service is deregistered, and the health check
+        # fails fast. A timeout is NOT a health failure: the probe is routed
+        # through the entry's router and counts against its
+        # ``max_ongoing_requests``, so a saturated-but-healthy entry
+        # head-of-line-blocks it. Treat a timeout as "busy, still registered";
+        # only a raised health error (entry crashed, or a depends_on
+        # dependency is down and its health_check raised) deregisters.
         if not self.entry_deployment_ready:
             logger.info(
                 f"⏳ Waiting for entry deployment (app '{self.application_id}') to complete initial health check."
@@ -1149,6 +1155,11 @@ class ProxyDeployment:
                 await asyncio.wait_for(
                     self.entry_deployment_handle.check_health.remote(),
                     timeout=3.0,
+                )
+            except asyncio.TimeoutError:
+                logger.debug(
+                    f"⏳ Entry deployment health probe for '{self.application_id}' "
+                    f"timed out (entry saturated). Leaving Hypha service registered."
                 )
             except Exception as e:
                 logger.error(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.12.3"
+version = "0.12.4"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [

--- a/tests/apps/test_proxy_entry_saturation_tolerance.py
+++ b/tests/apps/test_proxy_entry_saturation_tolerance.py
@@ -1,0 +1,59 @@
+"""Pin that ProxyDeployment's entry health check tolerates saturation.
+
+The proxy probes the entry in-band via ``check_health.remote()``. That call
+is routed through the entry's router and counts against its
+``max_ongoing_requests`` (default 10), so a saturated-but-healthy entry
+head-of-line-blocks the probe and the 3s ``wait_for`` fires. Treating that
+timeout as a health failure spuriously deregisters the Hypha service while
+the entry is merely busy.
+
+The fix classifies the two outcomes distinctly: an ``asyncio.TimeoutError``
+is tolerated (entry busy, service stays registered), while any other raised
+exception — the entry crashed, or a ``depends_on`` dependency is down and
+its ``health_check`` raised — deregisters. Reading the entry's RUNNING
+count from ``serve.status()`` instead does NOT work here: Ray Serve keeps a
+health-check-failing replica at ``RUNNING`` (it is not evicted on a raised
+check_health within the health window), so an out-of-band count is blind to
+a ``depends_on`` outage. These tests pin the shape (check_health is
+Ray-Serve glue that is impractical to exercise standalone).
+"""
+from __future__ import annotations
+
+import inspect
+
+from bioengine.apps import proxy_deployment as pd_module
+
+
+def _check_health_src() -> str:
+    return inspect.getsource(pd_module.ProxyDeployment.func_or_class.check_health)
+
+
+def test_timeout_is_tolerated_not_deregistered() -> None:
+    """A saturation timeout must be caught separately and NOT deregister."""
+    src = _check_health_src()
+    assert "except asyncio.TimeoutError" in src, (
+        "check_health must catch asyncio.TimeoutError separately so a "
+        "saturated entry is not mistaken for an unhealthy one."
+    )
+    timeout_block = src.split("except asyncio.TimeoutError", 1)[1].split(
+        "except Exception", 1
+    )[0]
+    assert "_deregister_services" not in timeout_block, (
+        "a saturation timeout must leave the Hypha service registered."
+    )
+
+
+def test_raised_health_error_deregisters() -> None:
+    """A genuine health failure (crash / depends_on down) deregisters."""
+    src = _check_health_src()
+    error_block = src.split("except Exception", 1)[1]
+    assert "_deregister_services" in error_block
+    assert "raise RuntimeError" in error_block
+
+
+def test_probe_stays_in_band() -> None:
+    """The in-band probe is what propagates the entry's raised health error
+    (incl. the depends_on gate) — an out-of-band serve.status() RUNNING count
+    is blind to it, so the probe must stay in-band."""
+    src = _check_health_src()
+    assert "entry_deployment_handle.check_health.remote" in src


### PR DESCRIPTION
## Problem

`ProxyDeployment.check_health` probes the entry deployment in-band and, on **every** subsequent tick, kept the Hypha service registration gated on:

```python
await asyncio.wait_for(self.entry_deployment_handle.check_health.remote(), timeout=3.0)
```

A `DeploymentHandle` call is routed through the entry deployment's router and **counts against its `max_ongoing_requests`**. So when the entry is merely *saturated* — not unhealthy — the probe head-of-line-blocks behind queued user requests and the 3s `wait_for` fires. The old code treated **any** exception (the timeout included) as a health failure and called `_deregister_services()`, tearing down the live Hypha endpoint under load. Deployments would then spuriously drop out of Hypha whenever they got busy.

## Why not read readiness out-of-band from `serve.status()`

The first cut of this PR (commit `c5bec53`) replaced the in-band probe with an out-of-band `serve.status()` RUNNING-replica count. That was abandoned: the RUNNING count is **blind to a `depends_on` outage**. When a dependency goes down, Ray Serve keeps the entry's health-check-*failing* replica in `RUNNING` within the health-check window, so the count never drops and the proxy would **never deregister on a genuine dep-down** — regressing the deregistration behavior PR #151 established. The in-band probe is the only signal that carries the entry's *raised* health error (including the `depends_on` gate), so we keep it and instead **classify the failure**.

## Fix

Keep the in-band probe; split the failure by type (`bioengine/apps/proxy_deployment.py`):

- **`except asyncio.TimeoutError`** → entry is saturated-but-healthy. Tolerate it: log at debug, leave the Hypha service registered. (First-ever call still awaits without a timeout, since initial init can be legitimately slow.)
- **`except Exception`** → the entry's `check_health` *raised* (it crashed, or a `depends_on` dependency is down and its health check raised `RuntimeError`). Deregister the Hypha service and re-raise, exactly as before.

A raised `RuntimeError` propagates through `wait_for` as itself — not as a `TimeoutError` — so the classification is clean: saturation takes the timeout branch (stay registered), a real fault takes the exception branch (deregister). This fixes the spurious-deregister-under-load bug **and** preserves #151's dep-down deregistration.

## Tests

- New `tests/apps/test_proxy_entry_saturation_tolerance.py` — 3 source-level assertions: a timeout is tolerated (no `_deregister_services`), a raised health error deregisters + re-raises, and the probe stays in-band (still calls `entry_deployment_handle.check_health.remote()`).
- Existing proxy suites unchanged and green.

## Validation

Dev image `0.12.4-dev2` (canonical `0.12.3` + this fix). A purpose-built 2-deployment app (`EntryDeployment` `max_ongoing_requests=2` with `@bioengine.health_check(depends_on=["RuntimeDeployment"])`; `RuntimeDeployment` with an env/flag-gated ctor raise to force a *durable* dependency-down, not a transient blip).

- [x] Unit tests (`tests/apps/`) green.
- [x] **Single-machine** — saturation-tolerant (stays registered under sustained load); durable dep-down deregisters and recovers.
- [x] **External-cluster (KTH), cross-node KubeRay** —
  - *Saturation harness*: entry hammered past `max_ongoing_requests`; proxy probe times out every tick but the service **stayed registered** the whole window (single proxy replica, no re-registration ⇒ timeout branch executed).
  - *Durable dep-down harness*: from a clean latched baseline, forcing `RuntimeDeployment`→0 deregistered the service at **t+8s** (`except Exception` branch) and re-registered at **t+34s** once the entry replica cycled — expected `_bioengine_dep_seen_ready` latch behavior.
- [x] **App-side cross-check** on `model-runner-dev` 1.15.36 (joint ship): `RuntimeDeployment`→0 deregistered at t+3.3s, re-registered at t+12.7s, full self-heal.

Both dev-image modes green per the maintainer dev-image workflow. Version bumped to `0.12.4` as the final commit before marking ready.
