### PR TITLE
feat(app): size GPUs by VRAM (gpu_memory_mb) instead of num_gpus

### DIFF
--- a/bioengine/_app/bootstrap.py
+++ b/bioengine/_app/bootstrap.py
@@ -209,6 +209,7 @@ def _walk(
             "lifecycle_methods": dict(
                 getattr(user_cls, "_bioengine_lifecycle", {})
             ),
+            "gpu_memory_mb": getattr(user_cls, "_bioengine_gpu_memory_mb", None),
             "init_params": init_params,
         }
         for child_id, child_user_cls, child_deployment in child_ids:
@@ -528,7 +529,7 @@ def build_and_run_application(
         # the override is silently lost — e.g. disable_gpu on a type-hint-
         # composed GPU deployment would keep requesting a GPU and never
         # schedule on a CPU-only target.
-        for _rk in ("num_cpus", "num_gpus", "memory"):
+        for _rk in ("num_cpus", "num_gpus", "memory", "resources"):
             if _rk in (spec_ray_opts or {}):
                 opts[_rk] = spec_ray_opts[_rk]
         runtime_env = dict(opts.get("runtime_env") or {})

--- a/bioengine/_app/decorators.py
+++ b/bioengine/_app/decorators.py
@@ -24,7 +24,7 @@ import inspect
 from functools import wraps
 from typing import Any, Callable, Dict, List, Optional
 
-from bioengine._app.errors import ReservedMethodNameError
+from bioengine._app.errors import BioEngineUserError, ReservedMethodNameError
 from bioengine._app.mixin import _make_check_health, _make_runtime_version, wrap_init
 
 # Top-level imports of hypha_rpc and ray.serve were moved inside the
@@ -196,7 +196,7 @@ def health_check(fn: Optional[Callable[..., Any]] = None) -> Callable[..., Any]:
 def app(
     *,
     num_cpus: float = 1,
-    num_gpus: float = 0,
+    gpu_memory_mb: Optional[int] = None,
     memory_mb: Optional[int] = None,
     pip: Optional[List[str]] = None,
     container_image: Optional[str] = None,
@@ -209,8 +209,14 @@ def app(
 
     Args:
         num_cpus: CPU cores per replica.
-        num_gpus: GPU devices per replica (the worker may force this to 0
-            when ``disable_gpu`` is set at deploy time).
+        gpu_memory_mb: VRAM the replica needs, in megabytes. This is
+            cluster-independent: the worker translates it into a Ray GPU
+            reservation at deploy time against the actual GPUs it lands on
+            (a fraction of a GPU, so several replicas can share one card).
+            Omit for CPU-only apps. Replaces the old ``num_gpus`` knob,
+            which was non-portable (a fraction meant different amounts of
+            VRAM on different GPUs). ``disable_gpu`` at deploy time still
+            forces the reservation to zero.
         memory_mb: Soft memory cap in megabytes. Converted to Ray's bytes
             convention internally.
         pip: Additional pip requirements for the replica's runtime_env on
@@ -233,6 +239,15 @@ def app(
         **serve_deployment_kwargs: Forwarded to ``serve.deployment(...)``
             (e.g. ``num_replicas``, ``autoscaling_config``).
     """
+
+    if "num_gpus" in serve_deployment_kwargs or (
+        ray_actor_options is not None and "num_gpus" in ray_actor_options
+    ):
+        raise BioEngineUserError(
+            "@bioengine.app no longer accepts 'num_gpus' — GPUs are now sized "
+            "by VRAM. Declare 'gpu_memory_mb=<MB>' instead (e.g. "
+            "gpu_memory_mb=8192 for an 8 GB model)."
+        )
 
     def decorator(cls: type) -> Any:
         from ray import serve
@@ -258,6 +273,7 @@ def app(
         cls._bioengine_method_schemas = method_schemas
         cls._bioengine_lifecycle = lifecycle
         cls._bioengine_composition_params = composition_params
+        cls._bioengine_gpu_memory_mb = gpu_memory_mb
 
         orig_init = cls.__init__
         cls.__init__ = wrap_init(cls, orig_init)
@@ -266,7 +282,6 @@ def app(
 
         opts = _build_ray_actor_options(
             num_cpus=num_cpus,
-            num_gpus=num_gpus,
             memory_mb=memory_mb,
             pip=pip,
             container_image=container_image,
@@ -395,15 +410,19 @@ def _resolve_app_user_class(annotation: Any) -> Optional[type]:
 def _build_ray_actor_options(
     *,
     num_cpus: float,
-    num_gpus: float,
     memory_mb: Optional[int],
     pip: Optional[List[str]],
     container_image: Optional[str],
     env_vars: Optional[Dict[str, str]],
     extra: Optional[Dict[str, Any]],
 ) -> Dict[str, Any]:
-    """Translate the flat decorator args into Ray Serve's nested options shape."""
-    opts: Dict[str, Any] = {"num_cpus": num_cpus, "num_gpus": num_gpus}
+    """Translate the flat decorator args into Ray Serve's nested options shape.
+
+    ``num_gpus`` is deliberately absent: GPU sizing is derived from
+    ``gpu_memory_mb`` by the worker at deploy time, once the target cluster's
+    GPUs are known. See ``bioengine/apps/builder.py``.
+    """
+    opts: Dict[str, Any] = {"num_cpus": num_cpus}
     if memory_mb is not None:
         opts["memory"] = int(memory_mb) * 1024 * 1024
 

--- a/bioengine/_app/decorators.py
+++ b/bioengine/_app/decorators.py
@@ -213,10 +213,12 @@ def app(
             cluster-independent: the worker translates it into a Ray GPU
             reservation at deploy time against the actual GPUs it lands on
             (a fraction of a GPU, so several replicas can share one card).
-            Omit for CPU-only apps. Replaces the old ``num_gpus`` knob,
-            which was non-portable (a fraction meant different amounts of
-            VRAM on different GPUs). ``disable_gpu`` at deploy time still
-            forces the reservation to zero.
+            Pass ``-1`` to reserve a whole GPU on whatever node it lands on,
+            regardless of that GPU's size. Omit for CPU-only apps. Replaces
+            the old ``num_gpus`` knob, which was non-portable (a fraction
+            meant different amounts of VRAM on different GPUs).
+            ``disable_gpu`` at deploy time still forces the reservation to
+            zero.
         memory_mb: Soft memory cap in megabytes. Converted to Ray's bytes
             convention internally.
         pip: Additional pip requirements for the replica's runtime_env on
@@ -247,6 +249,17 @@ def app(
             "@bioengine.app no longer accepts 'num_gpus' — GPUs are now sized "
             "by VRAM. Declare 'gpu_memory_mb=<MB>' instead (e.g. "
             "gpu_memory_mb=8192 for an 8 GB model)."
+        )
+
+    if gpu_memory_mb is not None and (
+        not isinstance(gpu_memory_mb, int)
+        or isinstance(gpu_memory_mb, bool)
+        or (gpu_memory_mb <= 0 and gpu_memory_mb != -1)
+    ):
+        raise BioEngineUserError(
+            "gpu_memory_mb must be a positive integer (VRAM in MB), -1 to "
+            "reserve a whole GPU regardless of its size, or None for a "
+            f"CPU-only app; got {gpu_memory_mb!r}."
         )
 
     def decorator(cls: type) -> Any:

--- a/bioengine/_version.py
+++ b/bioengine/_version.py
@@ -13,4 +13,4 @@ see the same string that ``pip`` sees.
 Must stay in lock-step with ``pyproject.toml``'s ``version`` field.
 The ``version-check.yml`` CI workflow enforces the match.
 """
-__version__ = "0.14.0"
+__version__ = "0.15.0"

--- a/bioengine/apps/builder.py
+++ b/bioengine/apps/builder.py
@@ -465,6 +465,12 @@ class AppBuilder:
                 opts["num_gpus"] = 0
                 continue
 
+            # -1 is the portable "whole GPU": book the entire device on any
+            # node regardless of its VRAM, so it never joins VRAM_MB packing.
+            if gmb == -1:
+                opts["num_gpus"] = 1.0
+                continue
+
             if vram_advertised:
                 opts["num_gpus"] = _GPU_HANDLE_EPSILON
                 opts.setdefault("resources", {})["VRAM_MB"] = int(gmb)

--- a/bioengine/apps/builder.py
+++ b/bioengine/apps/builder.py
@@ -71,6 +71,14 @@ _DOWNLOAD_TOKEN_TTL_SECONDS = 3600 * 24 * 30
 #: replicas share one GPU on a cluster that advertises real per-node VRAM.
 _GPU_HANDLE_EPSILON = 0.01
 
+#: Fraction-fallback sizing (no ``VRAM_MB`` advertised): round the derived
+#: ``num_gpus`` to this many decimals for clean, predictable packing, and clamp
+#: a request up to ``_GPU_FRACTION_GRACE`` over a whole GPU to 1.0 rather than
+#: rejecting it — a "16 GB" card typically reports ~15360 MB, so a literal
+#: ``gpu_memory_mb=16384`` would otherwise fail to deploy.
+_GPU_FRACTION_DECIMALS = 2
+_GPU_FRACTION_GRACE = 0.1
+
 
 class AppBuilder:
     """Build BioEngine apps from artifact storage for Ray Serve.
@@ -461,7 +469,14 @@ class AppBuilder:
                 opts["num_gpus"] = _GPU_HANDLE_EPSILON
                 opts.setdefault("resources", {})["VRAM_MB"] = int(gmb)
             elif min_gpu_mb:
-                opts["num_gpus"] = min(1.0, int(gmb) / min_gpu_mb)
+                fraction = round(int(gmb) / min_gpu_mb, _GPU_FRACTION_DECIMALS)
+                if fraction > 1.0 + _GPU_FRACTION_GRACE:
+                    raise BioEngineUserError(
+                        f"gpu_memory_mb={gmb} does not fit the smallest GPU on "
+                        f"the cluster ({min_gpu_mb} MB). Reduce gpu_memory_mb or "
+                        f"deploy on a cluster with a larger GPU."
+                    )
+                opts["num_gpus"] = min(1.0, fraction)
             else:
                 opts["num_gpus"] = 1.0
                 logger.warning(

--- a/bioengine/apps/builder.py
+++ b/bioengine/apps/builder.py
@@ -65,6 +65,12 @@ from bioengine.utils import (
 #: token (anonymous read).
 _DOWNLOAD_TOKEN_TTL_SECONDS = 3600 * 24 * 30
 
+#: Tiny GPU reservation used only to bind a physical device (and populate
+#: ``CUDA_VISIBLE_DEVICES``) when packing is driven by the ``VRAM_MB`` custom
+#: resource. The ``VRAM_MB`` reservation — not this fraction — bounds how many
+#: replicas share one GPU on a cluster that advertises real per-node VRAM.
+_GPU_HANDLE_EPSILON = 0.01
+
 
 class AppBuilder:
     """Build BioEngine apps from artifact storage for Ray Serve.
@@ -369,12 +375,20 @@ class AppBuilder:
     def _sum_resources(
         spec: Dict[str, Any], proxy_memory_in_gb: float
     ) -> Dict[str, int]:
-        totals: Dict[str, Union[int, float]] = {"num_cpus": 0, "num_gpus": 0, "memory": 0}
+        totals: Dict[str, Union[int, float]] = {
+            "num_cpus": 0,
+            "num_gpus": 0,
+            "memory": 0,
+            "VRAM_MB": 0,
+        }
         for meta in spec["classes"].values():
             opts = meta.get("ray_actor_options", {})
             totals["num_cpus"] += opts.get("num_cpus", 0)
             totals["num_gpus"] += opts.get("num_gpus", 0)
             totals["memory"] += opts.get("memory", 0)
+            # VRAM-based packing carries GPU demand as a custom resource with a
+            # near-zero num_gpus, so sum it separately for the SLURM autoscaler.
+            totals["VRAM_MB"] += (opts.get("resources") or {}).get("VRAM_MB", 0)
         # ProxyDeployment overhead — CPU/GPU come from the decorator;
         # memory reservation is the deploy-time ``proxy_memory_in_gb``.
         proxy_opts = getattr(ProxyDeployment, "ray_actor_options", {}) or {}
@@ -382,6 +396,79 @@ class AppBuilder:
         totals["num_gpus"] += proxy_opts.get("num_gpus", 0)
         totals["memory"] += int(proxy_memory_in_gb * (1024**3))
         return {k: int(v) if isinstance(v, (int, float)) else v for k, v in totals.items()}
+
+    async def _get_cluster_gpu_sizing(self) -> Dict[str, Any]:
+        """Ask the proxy actor how to size GPU reservations on this cluster.
+
+        Returns ``{"vram_resource_advertised": bool, "min_gpu_total_mb":
+        Optional[int]}``. Falls back to a "nothing known" answer (whole-GPU
+        reservation downstream) if the proxy is unreachable or has no GPU view
+        yet — safer than guessing a fraction from stale data.
+        """
+        default = {"vram_resource_advertised": False, "min_gpu_total_mb": None}
+        if not self.proxy_actor_name:
+            return default
+        try:
+            proxy = ray.get_actor(name=self.proxy_actor_name, namespace="bioengine")
+            return await asyncio.to_thread(
+                ray.get, proxy.get_gpu_memory_sizing.remote()
+            )
+        except Exception:
+            self.logger.warning(
+                "Could not query cluster GPU sizing from the proxy actor; "
+                "GPU apps will reserve a whole GPU each.",
+                exc_info=True,
+            )
+            return default
+
+    @staticmethod
+    def _apply_gpu_memory(
+        spec: Dict[str, Any],
+        disable_gpu: bool,
+        gpu_sizing: Dict[str, Any],
+        logger: logging.Logger,
+    ) -> None:
+        """Translate each class's ``gpu_memory_mb`` into a Ray GPU reservation.
+
+        The decorator records the VRAM requirement but leaves the reservation
+        to deploy time, where the target cluster's GPUs are known. Hybrid:
+        when the cluster advertises a ``VRAM_MB`` custom resource, request it
+        and let Ray pack by real memory (a tiny ``num_gpus`` only binds a
+        device); otherwise derive a safe fraction from the smallest GPU so the
+        replica fits on any node.
+        """
+        vram_advertised = bool(gpu_sizing.get("vram_resource_advertised"))
+        min_gpu_mb = gpu_sizing.get("min_gpu_total_mb")
+
+        for meta in spec["classes"].values():
+            opts = meta.setdefault("ray_actor_options", {})
+            gmb = meta.get("gpu_memory_mb")
+
+            # The worker is the sole authority on the GPU reservation; clear any
+            # residual so re-derivation is idempotent.
+            opts.pop("num_gpus", None)
+            resources = opts.get("resources")
+            if isinstance(resources, dict):
+                resources.pop("VRAM_MB", None)
+                if not resources:
+                    opts.pop("resources", None)
+
+            if disable_gpu or not gmb:
+                opts["num_gpus"] = 0
+                continue
+
+            if vram_advertised:
+                opts["num_gpus"] = _GPU_HANDLE_EPSILON
+                opts.setdefault("resources", {})["VRAM_MB"] = int(gmb)
+            elif min_gpu_mb:
+                opts["num_gpus"] = min(1.0, int(gmb) / min_gpu_mb)
+            else:
+                opts["num_gpus"] = 1.0
+                logger.warning(
+                    "No GPU VRAM visible on the cluster yet; app requesting "
+                    "%s MB will reserve a whole GPU until a GPU node reports in.",
+                    gmb,
+                )
 
     # ────────────────────────── auth resolution ──────────────────────────
 
@@ -558,12 +645,10 @@ class AppBuilder:
         translated_kwargs = self._translate_kwargs_keys(spec, application_kwargs)
         validate_kwargs_against_spec(spec, translated_kwargs)
 
-        # 5. Resource totals and disable_gpu override.
-        if disable_gpu:
-            for meta in spec["classes"].values():
-                opts = meta.get("ray_actor_options", {})
-                if opts.get("num_gpus"):
-                    opts["num_gpus"] = 0
+        # 5. Derive GPU reservations from each class's gpu_memory_mb (honouring
+        # disable_gpu), then sum resource totals.
+        gpu_sizing = await self._get_cluster_gpu_sizing()
+        self._apply_gpu_memory(spec, disable_gpu, gpu_sizing, self.logger)
         required_resources = self._sum_resources(spec, proxy_memory_in_gb)
 
         # 6. Generate the proxy service token.

--- a/bioengine/cluster/proxy_actor.py
+++ b/bioengine/cluster/proxy_actor.py
@@ -416,6 +416,43 @@ class BioEngineProxyActor:
 
         return per_node_gpu_memory, True
 
+    def get_gpu_memory_sizing(self) -> Dict[str, Any]:
+        """GPU sizing hints for VRAM-based deployment (used by AppBuilder).
+
+        Returns:
+            {
+                "vram_resource_advertised": bool,   # any node exposes VRAM_MB
+                "min_gpu_total_mb": Optional[int],  # smallest per-GPU VRAM (MB)
+            }
+
+        ``min_gpu_total_mb`` is the divisor for the fraction fallback, so it is
+        the smallest single-GPU capacity in the cluster — a replica sized for it
+        fits on any node. ``None`` when no GPU has reported memory yet.
+        """
+        vram_advertised = float(ray.cluster_resources().get("VRAM_MB", 0) or 0) > 0
+
+        per_node, dashboard_available = self._get_per_node_gpu_memory_usage()
+        min_gpu_total_mb: Optional[int] = None
+        if dashboard_available:
+            totals = self.global_state.total_resources_per_node()
+            for node_id, info in per_node.items():
+                gpu_count = int(totals.get(node_id, {}).get("GPU", 0) or 0)
+                total_bytes = info.get("total_gpu_memory", 0) or 0
+                if gpu_count <= 0 or total_bytes <= 0:
+                    continue
+                per_gpu_mb = int((total_bytes / (1024 * 1024)) / gpu_count)
+                if per_gpu_mb > 0:
+                    min_gpu_total_mb = (
+                        per_gpu_mb
+                        if min_gpu_total_mb is None
+                        else min(min_gpu_total_mb, per_gpu_mb)
+                    )
+
+        return {
+            "vram_resource_advertised": vram_advertised,
+            "min_gpu_total_mb": min_gpu_total_mb,
+        }
+
     @_touch_on_call
     def get_cluster_state(self) -> Dict[str, Any]:
         """

--- a/bioengine/cluster/proxy_actor.py
+++ b/bioengine/cluster/proxy_actor.py
@@ -147,6 +147,14 @@ class BioEngineProxyActor:
 
         self._cached_geo_location: Optional[Dict[str, Optional[Union[str, float]]]] = None
 
+        # Last successful per-node GPU memory read from the Ray dashboard. The
+        # dashboard sits behind a KubeRay auth proxy where a cold one-shot fetch
+        # can time out; a single miss must not erase the cluster's (static) GPU
+        # capacity, which get_gpu_memory_sizing() needs at deploy time. The
+        # frequently-polled status path keeps this warm, so a deploy-time sizing
+        # read reuses the last good snapshot instead of a fresh cold fetch.
+        self._last_per_node_gpu_memory: Dict[str, Dict[str, int]] = {}
+
         # Idle self-eviction state. Counts construction as "activity" so
         # the actor is not killed before any worker has a chance to call it.
         self._last_called_at: float = time.time()
@@ -369,7 +377,7 @@ class BioEngineProxyActor:
         """
         webui_url = self._get_dashboard_webui_url()
         if not webui_url:
-            return {}, False
+            return self._last_per_node_gpu_memory, bool(self._last_per_node_gpu_memory)
 
         url = f"{webui_url}/nodes?view=summary"
         # KubeRay (and some other managed Ray distributions) put the dashboard
@@ -391,10 +399,10 @@ class BioEngineProxyActor:
                 url,
                 exc_info=True,
             )
-            return {}, False
+            return self._last_per_node_gpu_memory, bool(self._last_per_node_gpu_memory)
 
         if not payload.get("result"):
-            return {}, False
+            return self._last_per_node_gpu_memory, bool(self._last_per_node_gpu_memory)
 
         summary = payload.get("data", {}).get("summary", [])
         per_node_gpu_memory: Dict[str, Dict[str, int]] = {}
@@ -414,6 +422,7 @@ class BioEngineProxyActor:
                 "used_gpu_memory": used_gpu_memory_mb * 1024 * 1024,
             }
 
+        self._last_per_node_gpu_memory = per_node_gpu_memory
         return per_node_gpu_memory, True
 
     def get_gpu_memory_sizing(self) -> Dict[str, Any]:

--- a/bioengine/cluster/ray_cluster.py
+++ b/bioengine/cluster/ray_cluster.py
@@ -690,34 +690,36 @@ class RayCluster:
         )
 
     def _detect_gpu_vram_mb(self) -> Optional[int]:
-        """Return total physical GPU VRAM in MB via nvidia-smi, or None.
+        """Return the managed GPU's VRAM in MB via nvidia-smi, or None.
 
-        Summed across all local GPUs; BioEngine-provisioned nodes are
-        one-GPU-per-node, so this is the per-node VRAM budget advertised as
-        the ``VRAM_MB`` custom resource. Returns None if nvidia-smi is absent
-        or fails, in which case the deploy-time fraction path is used instead.
+        Only meaningful for a single-GPU head, where node-level ``VRAM_MB``
+        equals the device's VRAM (the caller gates on that). Honours
+        ``CUDA_VISIBLE_DEVICES`` so a worker pinned to a subset sees only the
+        GPUs Ray manages. Returns None — deferring to the deploy-time fraction
+        path, which reads the real managed GPU from the Ray dashboard — when
+        nvidia-smi is unavailable or the visible GPUs differ in size (we can't
+        tell which one Ray picked, so advertising either is unsafe).
         """
+        query = [
+            "nvidia-smi",
+            "--query-gpu=memory.total",
+            "--format=csv,noheader,nounits",
+        ]
+        visible = os.environ.get("CUDA_VISIBLE_DEVICES")
+        if visible:
+            query.append(f"--id={visible}")
         try:
             result = subprocess.run(
-                [
-                    "nvidia-smi",
-                    "--query-gpu=memory.total",
-                    "--format=csv,noheader,nounits",
-                ],
-                capture_output=True,
-                text=True,
-                timeout=15,
+                query, capture_output=True, text=True, timeout=15
             )
         except (FileNotFoundError, subprocess.SubprocessError):
             return None
         if result.returncode != 0:
             return None
-        total_mb = 0
-        for line in result.stdout.splitlines():
-            line = line.strip()
-            if line:
-                total_mb += int(float(line))
-        return total_mb or None
+        mems = [int(float(l)) for l in result.stdout.splitlines() if l.strip()]
+        if not mems or len(set(mems)) != 1:
+            return None
+        return mems[0]
 
     async def _start_cluster(self) -> None:
         """Start Ray cluster head node with configured ports and resources.
@@ -782,8 +784,11 @@ class RayCluster:
                 args.append(f"--memory={memory_limit}")
 
             # Advertise real VRAM as a custom resource so apps declaring
-            # gpu_memory_mb pack by memory (single-machine head with GPUs).
-            if self.ray_cluster_config["head_num_gpus"] > 0:
+            # gpu_memory_mb pack by memory. Only for a single-GPU head, where
+            # the node-level VRAM_MB equals the device's VRAM; multi-GPU heads
+            # fall through to the deploy-time fraction path, which Ray's
+            # fractional GPU scheduler spreads across devices correctly.
+            if self.ray_cluster_config["head_num_gpus"] == 1:
                 vram_mb = await asyncio.to_thread(self._detect_gpu_vram_mb)
                 if vram_mb:
                     args.append(f"--resources={json.dumps({'VRAM_MB': vram_mb})}")

--- a/bioengine/cluster/ray_cluster.py
+++ b/bioengine/cluster/ray_cluster.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import logging
 import os
 import re
@@ -688,6 +689,36 @@ class RayCluster:
             f"container GPU LD_LIBRARY_PATH={ld_dir}"
         )
 
+    def _detect_gpu_vram_mb(self) -> Optional[int]:
+        """Return total physical GPU VRAM in MB via nvidia-smi, or None.
+
+        Summed across all local GPUs; BioEngine-provisioned nodes are
+        one-GPU-per-node, so this is the per-node VRAM budget advertised as
+        the ``VRAM_MB`` custom resource. Returns None if nvidia-smi is absent
+        or fails, in which case the deploy-time fraction path is used instead.
+        """
+        try:
+            result = subprocess.run(
+                [
+                    "nvidia-smi",
+                    "--query-gpu=memory.total",
+                    "--format=csv,noheader,nounits",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+        except (FileNotFoundError, subprocess.SubprocessError):
+            return None
+        if result.returncode != 0:
+            return None
+        total_mb = 0
+        for line in result.stdout.splitlines():
+            line = line.strip()
+            if line:
+                total_mb += int(float(line))
+        return total_mb or None
+
     async def _start_cluster(self) -> None:
         """Start Ray cluster head node with configured ports and resources.
 
@@ -749,6 +780,13 @@ class RayCluster:
             if self.ray_cluster_config["head_memory_in_gb"] is not None:
                 memory_limit = self.ray_cluster_config["head_memory_in_gb"] * 1024**3
                 args.append(f"--memory={memory_limit}")
+
+            # Advertise real VRAM as a custom resource so apps declaring
+            # gpu_memory_mb pack by memory (single-machine head with GPUs).
+            if self.ray_cluster_config["head_num_gpus"] > 0:
+                vram_mb = await asyncio.to_thread(self._detect_gpu_vram_mb)
+                if vram_mb:
+                    args.append(f"--resources={json.dumps({'VRAM_MB': vram_mb})}")
 
             # Prevent logging of Redis password in debug logs
             censored_args = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.14.0"
+version = "0.15.0"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## What

Replace the `num_gpus` knob on `@bioengine.app` with **`gpu_memory_mb`** — a cluster-independent VRAM requirement. The worker translates it into a Ray GPU reservation *at deploy time* against the actual GPUs it lands on, so several replicas can pack onto one card regardless of GPU size or cluster.

`num_gpus` was memory-blind and non-portable: `num_gpus=0.5` meant 8 GB on a 16 GB card but 40 GB on an 80 GB card, so authors couldn't write one manifest that behaved correctly across KTH / deNBI / Berzelius / external clusters — everyone defensively reserved a whole GPU.

## Mechanism (hybrid, auto-detected at deploy)

- **Clusters BioEngine provisions** advertise real per-node VRAM as a custom Ray resource `VRAM_MB` (single-machine head does this via `nvidia-smi` at `ray start`). Ray then packs by real memory; a tiny `num_gpus` (`_GPU_HANDLE_EPSILON`) only binds a device.
- **Clusters we don't control** (no `VRAM_MB` advertised) → fall back to a **safe fraction from the smallest GPU** (`min(1.0, gpu_memory_mb / min_gpu_mb)`) so a replica fits on any node and never OOMs.

The presence of the `VRAM_MB` cluster resource is itself the branch signal — self-configuring, no extra flag. The builder asks the proxy actor (`get_gpu_memory_sizing`) for both signals at deploy.

## Hard removal

Passing `num_gpus` (directly or via the `ray_actor_options` escape hatch) raises `BioEngineUserError` with the migration message. `disable_gpu` at deploy still forces the reservation to zero.

## Files

- `bioengine/_app/decorators.py` — API surface: drop `num_gpus`, add `gpu_memory_mb`, reject the old knob, stash `_bioengine_gpu_memory_mb` marker.
- `bioengine/_app/bootstrap.py` — carry `gpu_memory_mb` in the spec; copy a worker-derived `resources` dict at bind time.
- `bioengine/apps/builder.py` — deploy-time translation (`_apply_gpu_memory`, `_get_cluster_gpu_sizing`), VRAM-aware resource totals.
- `bioengine/cluster/proxy_actor.py` — `get_gpu_memory_sizing()` (advertised? + smallest per-GPU VRAM).
- `bioengine/cluster/ray_cluster.py` — advertise `VRAM_MB` on the single-machine head when it has GPUs.

## Follow-ups (not in this PR)

- **SLURM autoscaler VRAM-awareness** (`slurm_workers.py`): request GPUs from summed `VRAM_MB` demand when the epsilon path is active. Deferred — all current clusters are homogeneous, so the fraction path already covers them.
- **App migrations** to `gpu_memory_mb` (direct to `main`) must ship in the same coordinated helm bump as this worker version, since a migrated app on an old worker (or an old `num_gpus` app on the new worker) breaks.
- KubeRay clusters (KTH/deNBI) can advertise `VRAM_MB` via `rayStartParams` — optional, both are homogeneous today.

## Testing

Draft — pending dev-image validation on a live cluster (fraction packing, VRAM-resource path, hard-removal error, `disable_gpu`). Will mark ready + bump `pyproject.toml` after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)