### PR TITLE
Report real device-wide VRAM on vGPU clusters

### DIFF
--- a/bioengine/_app/gpu_memory.py
+++ b/bioengine/_app/gpu_memory.py
@@ -1,0 +1,86 @@
+"""Device-wide VRAM sampling via the CUDA driver API.
+
+On NVIDIA vGPU C-series time-slicing the guest's NVML ``memoryUsed`` is
+unreliable — it latches stale values (a fully idle GPU can report ~14 GiB
+used) and carries a fixed offset — but the CUDA driver's ``cuMemGetInfo``
+reads the real device-wide free/total inside the guest. This wraps
+``libcuda.so.1`` directly with ctypes so sampling needs no torch / pynvml /
+cudart dependency; the driver lib is always injected by the NVIDIA
+container runtime.
+"""
+
+from __future__ import annotations
+
+import ctypes
+from typing import Tuple
+
+_CUDA_SUCCESS = 0
+
+
+class CudaMemorySampler:
+    """Holds a CUDA context on device 0 and samples device-wide VRAM.
+
+    Constructed once per GPU replica. ``__init__`` retains the device's
+    *primary* context — reusing torch's context when one already exists
+    (zero extra VRAM) or creating a thin one otherwise — and raises
+    ``RuntimeError`` if the driver cannot be initialised. That failure IS
+    the fail-hard gate: a replica Ray assigned a GPU to but which cannot
+    create a CUDA context is unhealthy, not silently CPU-bound.
+    """
+
+    def __init__(self) -> None:
+        try:
+            lib = ctypes.CDLL("libcuda.so.1")
+        except OSError as e:
+            raise RuntimeError(f"libcuda.so.1 not loadable: {e}") from e
+        self._lib = lib
+
+        lib.cuInit.argtypes = [ctypes.c_uint]
+        lib.cuDeviceGet.argtypes = [ctypes.POINTER(ctypes.c_int), ctypes.c_int]
+        lib.cuDevicePrimaryCtxRetain.argtypes = [
+            ctypes.POINTER(ctypes.c_void_p),
+            ctypes.c_int,
+        ]
+        lib.cuCtxPushCurrent_v2.argtypes = [ctypes.c_void_p]
+        lib.cuCtxPopCurrent_v2.argtypes = [ctypes.POINTER(ctypes.c_void_p)]
+        lib.cuMemGetInfo_v2.argtypes = [
+            ctypes.POINTER(ctypes.c_size_t),
+            ctypes.POINTER(ctypes.c_size_t),
+        ]
+
+        # Device 0 is the replica's assigned GPU — Ray scopes CUDA_VISIBLE_DEVICES.
+        self._check(lib.cuInit(0), "cuInit")
+        dev = ctypes.c_int()
+        self._check(lib.cuDeviceGet(ctypes.byref(dev), 0), "cuDeviceGet")
+        ctx = ctypes.c_void_p()
+        self._check(
+            lib.cuDevicePrimaryCtxRetain(ctypes.byref(ctx), dev),
+            "cuDevicePrimaryCtxRetain",
+        )
+        self._ctx = ctx
+
+    def _check(self, rc: int, call: str) -> None:
+        if rc != _CUDA_SUCCESS:
+            raise RuntimeError(f"{call} failed with CUDA error {rc}")
+
+    def sample(self) -> Tuple[int, int]:
+        """Return ``(used_bytes, total_bytes)`` device-wide.
+
+        Called from a ``to_thread`` worker: push the primary context onto
+        this thread, query, pop. Primary contexts are multi-thread
+        shareable and ``cuMemGetInfo`` is a read-only query, so this is safe
+        even while another thread runs torch on the same context.
+        """
+        lib = self._lib
+        self._check(lib.cuCtxPushCurrent_v2(self._ctx), "cuCtxPushCurrent")
+        try:
+            free = ctypes.c_size_t()
+            total = ctypes.c_size_t()
+            self._check(
+                lib.cuMemGetInfo_v2(ctypes.byref(free), ctypes.byref(total)),
+                "cuMemGetInfo",
+            )
+        finally:
+            popped = ctypes.c_void_p()
+            lib.cuCtxPopCurrent_v2(ctypes.byref(popped))
+        return total.value - free.value, total.value

--- a/bioengine/_app/mixin.py
+++ b/bioengine/_app/mixin.py
@@ -43,11 +43,6 @@ def _setup_replica(instance: Any) -> None:
     if os.environ.get("BIOENGINE_DEBUG") == "1":
         logger.setLevel(logging.DEBUG)
 
-    _register_with_proxy_actor(instance, logger)
-    _ensure_working_directory(logger)
-    _purge_stale_app_modules(logger)
-    _unmask_secret_env_vars()
-
     instance._bioengine_replica_initialized = False
     instance._bioengine_replica_test_failed = False
     instance._bioengine_test_task: Optional[asyncio.Task] = None
@@ -58,6 +53,11 @@ def _setup_replica(instance: Any) -> None:
     instance._bioengine_proxy_handle = None
     instance._bioengine_gpu_sampler = None
     instance._bioengine_gpu_init_failed = False
+
+    _register_with_proxy_actor(instance, logger)
+    _ensure_working_directory(logger)
+    _purge_stale_app_modules(logger)
+    _unmask_secret_env_vars()
 
 
 def _baked_identity(cls: type) -> Dict[str, Optional[str]]:

--- a/bioengine/_app/mixin.py
+++ b/bioengine/_app/mixin.py
@@ -53,6 +53,12 @@ def _setup_replica(instance: Any) -> None:
     instance._bioengine_test_task: Optional[asyncio.Task] = None
     instance._bioengine_health_check_lock = asyncio.Lock()
 
+    instance._bioengine_has_gpu = False
+    instance._bioengine_node_id = None
+    instance._bioengine_proxy_handle = None
+    instance._bioengine_gpu_sampler = None
+    instance._bioengine_gpu_init_failed = False
+
 
 def _baked_identity(cls: type) -> Dict[str, Optional[str]]:
     """Artifact identity baked into the class at build time.
@@ -104,6 +110,10 @@ def _register_with_proxy_actor(instance: Any, logger: logging.Logger) -> None:
             exc_info=True,
         )
         return
+
+    instance._bioengine_has_gpu = len(ray.get_gpu_ids()) > 0
+    instance._bioengine_node_id = ray.get_runtime_context().get_node_id()
+    instance._bioengine_proxy_handle = proxy_actor_handle
 
     try:
         replica_context = serve.get_replica_context()
@@ -274,6 +284,24 @@ def _make_check_health(
             elif not self._bioengine_replica_initialized:
                 self._bioengine_replica_initialized = True
 
+            if (
+                self._bioengine_has_gpu
+                and self._bioengine_gpu_sampler is None
+                and not self._bioengine_gpu_init_failed
+            ):
+                from bioengine._app.gpu_memory import CudaMemorySampler
+
+                try:
+                    self._bioengine_gpu_sampler = await asyncio.to_thread(
+                        CudaMemorySampler
+                    )
+                except Exception as e:
+                    self._bioengine_gpu_init_failed = True
+                    raise RuntimeError(
+                        "GPU deployment was assigned a GPU but could not "
+                        "initialize a CUDA context"
+                    ) from e
+
             if self._bioengine_test_task is None and smoke_test_name:
                 logger.info("🚀 Launching smoke test in the background...")
                 self._bioengine_test_task = asyncio.create_task(
@@ -297,6 +325,15 @@ def _make_check_health(
                     await hook()
                 else:
                     await asyncio.to_thread(hook)
+
+            sampler = self._bioengine_gpu_sampler
+            handle = self._bioengine_proxy_handle
+            if sampler is not None and handle is not None:
+                used, _total = await asyncio.to_thread(sampler.sample)
+                handle.report_gpu_memory.remote(
+                    node_id=self._bioengine_node_id,
+                    used_gpu_memory=used,
+                )
 
     return check_health
 

--- a/bioengine/_version.py
+++ b/bioengine/_version.py
@@ -13,4 +13,4 @@ see the same string that ``pip`` sees.
 Must stay in lock-step with ``pyproject.toml``'s ``version`` field.
 The ``version-check.yml`` CI workflow enforces the match.
 """
-__version__ = "0.16.0"
+__version__ = "0.16.1"

--- a/bioengine/cli/cluster.py
+++ b/bioengine/cli/cluster.py
@@ -45,6 +45,19 @@ def add_worker_options(f):
     return f
 
 
+def _format_vram(used, total):
+    """Render used/total VRAM in GiB, tolerating the ``"NA"`` sentinel.
+
+    A GPU node with no live reporter (idle, or no bioengine GPU app) reports
+    ``used_gpu_memory == "NA"``; dividing that by ``1024**3`` would crash.
+    """
+
+    def _gib(value):
+        return f"{value / 1024**3:.1f}" if isinstance(value, (int, float)) else "NA"
+
+    return f"{_gib(used)}/{_gib(total)} GiB"
+
+
 @click.group("cluster")
 def cluster_group():
     """Inspect BioEngine Ray cluster resources (GPUs, CPUs, memory)."""
@@ -108,14 +121,15 @@ def cluster_status(as_json, worker_service_id, token, server_url):
         if gpu_nodes:
             click.echo("GPU nodes:")
             for nid, info in gpu_nodes:
-                vram_used_gb = info.get("used_gpu_memory", 0) / 1024**3
-                vram_total_gb = info.get("total_gpu_memory", 0) / 1024**3
+                vram = _format_vram(
+                    info.get("used_gpu_memory", 0), info.get("total_gpu_memory", 0)
+                )
                 role = "HEAD" if info.get("head") else "worker"
                 click.echo(
                     f"  {info.get('node_ip')} [{role}] "
                     f"{info.get('accelerator_type', '?')} "
                     f"GPU: {info.get('used_gpu', 0):.1f}/{info.get('total_gpu', 0):.0f} "
-                    f"VRAM: {vram_used_gb:.1f}/{vram_total_gb:.1f} GiB  "
+                    f"VRAM: {vram}  "
                     f"CPU: {info.get('used_cpu', 0):.0f}/{info.get('total_cpu', 0):.0f}"
                 )
 

--- a/bioengine/cluster/proxy_actor.py
+++ b/bioengine/cluster/proxy_actor.py
@@ -80,6 +80,11 @@ class BioEngineProxyActor:
     IDLE_EVICTION_SECONDS: float = 24 * 60 * 60  # 24 hours
     IDLE_CHECK_INTERVAL_SECONDS: float = 10 * 60  # 10 minutes
 
+    # Freshness window for a GPU replica's pushed cuMemGetInfo sample. Beyond
+    # it a GPU node's used-VRAM reports "NA" (idle / no live reporter). Sized
+    # for ~3 missed Serve health cadences (~10s each).
+    GPU_SAMPLE_STALE_SECONDS: float = 30
+
     def __init__(
         self,
         bioengine_version: str,
@@ -154,6 +159,12 @@ class BioEngineProxyActor:
         # frequently-polled status path keeps this warm, so a deploy-time sizing
         # read reuses the last good snapshot instead of a fresh cold fetch.
         self._last_per_node_gpu_memory: Dict[str, Dict[str, int]] = {}
+
+        # Real device-wide VRAM usage pushed by GPU app replicas via
+        # report_gpu_memory (cuMemGetInfo, truthful on vGPU where NVML is
+        # blind). Keyed by node_id, last-write-wins across co-located replicas.
+        # Structure: {node_id: {"used_gpu_memory": int, "timestamp": float}}
+        self.node_gpu_memory: Dict[str, Dict[str, float]] = {}
 
         # Idle self-eviction state. Counts construction as "activity" so
         # the actor is not killed before any worker has a chance to call it.
@@ -462,6 +473,22 @@ class BioEngineProxyActor:
             "min_gpu_total_mb": min_gpu_total_mb,
         }
 
+    def report_gpu_memory(self, node_id: str, used_gpu_memory: int) -> None:
+        """Record a GPU replica's real device-wide VRAM usage.
+
+        Pushed from each GPU replica's ``check_health`` via ``cuMemGetInfo``
+        (device-wide, truthful on vGPU where NVML ``memoryUsed`` is blind and
+        latches stale values). Last-write-wins per node: co-located replicas
+        on the same GPU read the same device-wide value, and a surviving
+        replica keeps the node fresh when another dies. Deliberately *not*
+        ``@_touch_on_call`` — a background telemetry push must not keep an
+        otherwise-idle proxy alive past its eviction window.
+        """
+        self.node_gpu_memory[node_id] = {
+            "used_gpu_memory": used_gpu_memory,
+            "timestamp": time.time(),
+        }
+
     @_touch_on_call
     def get_cluster_state(self) -> Dict[str, Any]:
         """
@@ -526,6 +553,7 @@ class BioEngineProxyActor:
             )
             available_resources_per_node = {}
         gpu_memory_per_node, dashboard_available = self._get_per_node_gpu_memory_usage()
+        now = time.time()
 
         cluster_state = {
             "cluster": {
@@ -567,15 +595,29 @@ class BioEngineProxyActor:
             available_object_store_memory = available_resources.get(
                 "object_store_memory", 0
             )
-            if total_gpu > 0 and not dashboard_available:
-                total_gpu_memory: Union[int, str] = "NA"
-                used_gpu_memory: Union[int, str] = "NA"
+            if total_gpu == 0:
+                total_gpu_memory: Union[int, str] = 0
+                used_gpu_memory: Union[int, str] = 0
             else:
-                gpu_memory = gpu_memory_per_node.get(
-                    node_id, {"total_gpu_memory": 0, "used_gpu_memory": 0}
-                )
-                total_gpu_memory = gpu_memory["total_gpu_memory"]
-                used_gpu_memory = gpu_memory["used_gpu_memory"]
+                # NVML's memoryTotal is correct even on vGPU, so it is kept as
+                # the capacity. NVML's memoryUsed is blind there (stuck/phantom
+                # values) and is never served: the only numeric "used" is a
+                # fresh cuMemGetInfo sample pushed by a live GPU replica, else
+                # "NA" (idle node / no live reporter).
+                if dashboard_available:
+                    total_gpu_memory = gpu_memory_per_node.get(
+                        node_id, {"total_gpu_memory": 0}
+                    )["total_gpu_memory"]
+                else:
+                    total_gpu_memory = "NA"
+                sample = self.node_gpu_memory.get(node_id)
+                if (
+                    sample is not None
+                    and now - sample["timestamp"] <= self.GPU_SAMPLE_STALE_SECONDS
+                ):
+                    used_gpu_memory = sample["used_gpu_memory"]
+                else:
+                    used_gpu_memory = "NA"
 
             cluster_state["nodes"][node_id] = {
                 "node_ip": self._get_node_ip(total_resources),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.16.0"
+version = "0.16.1"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Problem

On NVIDIA vGPU C-series time-slicing (KTH `NVIDIA-A40-16C-SHARED`, deNBI) the guest's **NVML `memoryUsed` is unreliable**. Live characterization on the KTH worker (A40-16C, paired with node-level `nvidia-smi` ground truth) showed three failure modes:

1. A fixed ~448 MiB over-report offset on every reading.
2. **Latched stale/phantom `used`** — a *fully idle* GPU reported 14.5 GiB used for minutes, only self-correcting once a real allocation happened. NVML never decrements on process death; it holds the high-water value.
3. It does track a fresh allocation once one occurs — so it is non-deterministic, not uniformly blind.

NVML `memoryTotal` stays correct (16 GiB) throughout. The worker reads NVML `memoryUsed` via the Ray dashboard node summary, so per-node GPU memory has always been wrong on these clusters — the user-visible "memory consumed on both idle nodes" symptom.

## Solution

Sample real **device-wide** VRAM with the CUDA **driver** API (`cuMemGetInfo`) from inside each GPU app replica — the replica already holds the assigned vGPU slice, and `cuMemGetInfo` reads truthful free/total inside the guest. Replicas push the reading to the `BioEngineProxyActor` from their existing `check_health` cadence (~10s); the proxy keeps NVML **total** as capacity but serves **used** only from a fresh pushed sample (≤30 s), else `"NA"` for idle GPU nodes / nodes with no live reporter. NVML `used` is dropped entirely.

Push (not pull) because Ray Serve exposes no out-of-band pull of custom replica methods; samples are keyed by `node_id`, last-write-wins, so co-located replicas on one vGPU yield one authoritative value and a surviving replica keeps the node fresh when another dies.

## Behavioural changes

- **Fail-hard GPU gate:** a GPU replica that Ray assigned a GPU to but that cannot initialize a CUDA context now raises from `check_health` → Serve marks the replica unhealthy → deployment fails, instead of silently degrading to CPU. Directly detects the "GPU-on-CPU" fault class.
- **CPU-only replicas never touch libcuda** — `has_gpu` is derived from `len(ray.get_gpu_ids()) > 0` (respects a `disable_gpu` override), and both the init and sample paths short-circuit on `False`.
- Idle GPU nodes now report `used_gpu_memory = "NA"` routinely (previously the phantom NVML value). `"NA"` is already a documented API value; the CLI is made `"NA"`-safe here.
- `model-runner` warm-reuse is handled with no app change: its main-process thin context samples device-wide, so it sees the subprocess model's VRAM when warm and ~0 when evicted.

## Migration notes

None for app authors — no app changes. Consumers of `get_cluster_state().nodes[*].used_gpu_memory` should already handle the documented `"NA"` sentinel; idle GPU nodes now hit it more often.

## Test plan

- `CudaMemorySampler` verified live on a real GPU (RTX 3090): 540 MiB / 23.6 GiB.
- Dev-image (`0.16.1-dev1`) validation on a live GPU cluster:
  - Single-machine mode (real GPU) — real-usage tracking, fail-hard gate, CPU-only untouched.
  - deNBI external-cluster (T4, multi-node KubeRay) — cross-node proxy-on-head / replica-on-GPU-node push.
  - vGPU phantom-gone check (idle node → `"NA"`, never 14.5 GiB) confirmed on KTH once its GPUs free up.

## Files

- `bioengine/_app/gpu_memory.py` — new ctypes `CudaMemorySampler` over `libcuda.so.1`.
- `bioengine/_app/mixin.py` — `has_gpu`/`node_id`/proxy-handle derivation; fail-hard one-shot CUDA init + per-cadence sample+push in `check_health`.
- `bioengine/cluster/proxy_actor.py` — `node_gpu_memory` state, `report_gpu_memory`, `GPU_SAMPLE_STALE_SECONDS`, surgical `used_gpu_memory` override (keep NVML total, drop NVML used).
- `bioengine/cli/cluster.py` — `"NA"`-safe VRAM formatting.

## Validation — single-machine (Europa, RTX 3090), image `0.16.1-dev2`

Deployed a minimal GPU probe (`gpu_memory_mb=4096`, holds a 1 GiB `cuMemAlloc` + primary context) and a CPU probe on a live dev worker, cross-checked against host `nvidia-smi`:

| Check | Result |
|---|---|
| GPU node `used_gpu_memory` numeric | **1564.1 MiB** |
| vs `nvidia-smi` on the device | 1565 MiB — **within 1 MiB** |
| GPU replica `has_gpu=True`, sampler + proxy handle set | ✅ |
| CPU replica `has_gpu=False`, sampler never created (libcuda untouched) | ✅ |
| `used="NA"` after the GPU app is stopped (idle node) | ✅ |
| `total_gpu_memory` stays numeric (24 GiB) after stop | ✅ |

The fail-hard gate (a GPU replica that cannot initialise a CUDA context raises from `check_health` → Serve marks it unhealthy) is verified by construction — same mechanism as a failed smoke test.

### Fix found during validation

First dev build reported `used="NA"` even with a GPU app resident. Root cause: `_setup_replica` called `_register_with_proxy_actor` (which derives `_bioengine_has_gpu`/`node_id`/`proxy_handle` from `ray.get_gpu_ids()`) **before** assigning the `False`/`None` defaults — so the defaults clobbered the real values and every GPU replica reported `has_gpu=False`, never sampling. Fixed by ordering the defaults ahead of registration (commit `b97a7e5`).

_External-cluster (real vGPU/T4, multi-node cross-node push) validation on deNBI to follow before marking ready._
