### PR TITLE
feat(docker): worker image variant with model-runner deps preinstalled

### DIFF
--- a/bioengine/_version.py
+++ b/bioengine/_version.py
@@ -13,4 +13,4 @@ see the same string that ``pip`` sees.
 Must stay in lock-step with ``pyproject.toml``'s ``version`` field.
 The ``version-check.yml`` CI workflow enforces the match.
 """
-__version__ = "0.16.1"
+__version__ = "0.16.2"

--- a/docker/worker-model-runner.Dockerfile
+++ b/docker/worker-model-runner.Dockerfile
@@ -1,0 +1,74 @@
+# BioEngine worker image with the model-runner app's pinned dependencies
+# preinstalled. Ray's runtime_env venv inherits the image's site-packages,
+# so at deploy time every pin resolves as already satisfied and the app
+# skips the multi-GB download/install that otherwise runs on first startup.
+#
+# Mirrors docker/worker.Dockerfile, but installs the model-runner
+# requirements FIRST: they are by far the largest layer and change the
+# least, so worker-requirement bumps and bioengine code updates rebuild
+# only the cheap layers on top. Keep the two files in sync when the
+# worker build changes.
+#
+# Build (from the repo root):
+#   docker build \
+#       -f docker/worker-model-runner.Dockerfile \
+#       -t bioengine-worker-model-runner:<bioengine-version> .
+#
+# Rebuild whenever apps/model-runner/requirements-*.txt change — the
+# preinstall only short-circuits the deploy-time install while the pins
+# match the deployed app version.
+
+# Rolling tag — each build picks up current Debian-slim security patches.
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    build-essential \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+
+WORKDIR /app
+
+# Model-runner app dependencies — installed before everything else so
+# this multi-GB layer survives worker-requirement and bioengine updates.
+# requirements-worker.txt is installed after and wins on any conflict.
+COPY apps/model-runner/requirements-entry.txt \
+     apps/model-runner/requirements-runtime.txt \
+     /app/model-runner/
+RUN pip install -U pip && \
+    pip install -r model-runner/requirements-entry.txt \
+                -r model-runner/requirements-runtime.txt
+
+# Worker requirements — intentionally does NOT pin Ray. Ray is installed
+# as the very last step, controlled by the RAY_VERSION build arg, so
+# changing the Ray version doesn't invalidate this layer (or any of the
+# layers between here and the final Ray install) on rebuild.
+COPY requirements-worker.txt /app/
+RUN pip install -r requirements-worker.txt
+
+COPY bioengine/ /app/bioengine/
+COPY pyproject.toml README.md LICENSE /app/
+
+# Install the bioengine package without dependencies — all runtime deps
+# (including ray's transitive deps that survive a version bump) are
+# already in requirements-worker.txt.
+RUN pip install --no-deps .
+
+# Ray install — kept as the final step so RAY_VERSION can be overridden
+# at build time without invalidating any prior layer cache. protobuf is
+# re-constrained here: tensorflow (model-runner) needs <5, and without
+# the pin Ray's opentelemetry deps upgrade protobuf to 7, which breaks
+# both tensorflow and Ray Serve 2.55.
+ARG RAY_VERSION=2.55.1
+RUN pip install "ray[client,serve]==${RAY_VERSION}" "protobuf>=4,<5"
+
+# Surface the active Ray version inside the image for diagnostics
+ENV BIOENGINE_RAY_VERSION=${RAY_VERSION}
+
+CMD [ "/bin/bash" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioengine"
-version = "0.16.1"
+version = "0.16.2"
 description = "BioEngine — CLI and SDK for deploying and calling AI model services on BioEngine workers"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Problem

Deploying the model-runner app on a fresh worker installs its pinned dependencies (torch, tensorflow, cellpose, stardist, careamics, …) into the Ray runtime env on first startup — a multi-GB download and install that runs every time a cluster is brought up from a plain worker image.

## Solution

Add `docker/worker-model-runner.Dockerfile`: a standalone worker image build that preinstalls the pins from `apps/model-runner/requirements-entry.txt` and `requirements-runtime.txt` into the image's site-packages. Ray's runtime_env venv inherits site-packages, so at deploy time every pin resolves as already satisfied and the install is a no-op — a worker started from this image can run the model-runner as a startup app with no per-launch package installation.

The file mirrors `docker/worker.Dockerfile` but installs the model-runner requirements first: they are the largest layer and change the least, so worker-requirement bumps and bioengine code changes rebuild only the cheap layers on top. Ray stays the final step, driven by `RAY_VERSION`.

The Ray install step additionally re-constrains `protobuf>=4,<5`: tensorflow 2.16.1 requires protobuf <5, and without the pin Ray's opentelemetry dependencies upgrade protobuf to 7.x, which breaks both tensorflow and Ray Serve 2.55.

The image is not published by CI; it is built ad hoc like `worker-ray-overlay.Dockerfile` (build command documented in the file header).

## Test plan

- Built the image from the repo root (`bioengine-worker-model-runner:test`, 9.34 GB).
- Verified imports inside the image: protobuf 4.25.9, ray 2.55.1, tensorflow 2.16.1, torch 2.5.1+cu124, bioimageio.core 0.10.4, cellpose, stardist.
- Re-ran `pip install` of both requirement files inside the image: every pin already satisfied, nothing installed.
- `pip check`: no broken requirements.

## Files

- `docker/worker-model-runner.Dockerfile` — new

🤖 Generated with [Claude Code](https://claude.com/claude-code)
